### PR TITLE
ONNX版の自動ビルドを追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,14 +193,14 @@ jobs:
           mkdir release
 
           readarray -t MAPPINGS <<EOF
-          windows-x64-gpu   core.dll      core.dll
-          windows-x64-cpu   core.dll      core_cpu.dll
+          windows-x64-gpu   core.dll      core_gpu_x64_nvidia.dll
+          windows-x64-cpu   core.dll      core_cpu_x64.dll
           windows-x86-cpu   core.dll      core_cpu_x86.dll
           windows-arm64-cpu core.dll      core_cpu_arm64.dll
           windows-arm-cpu   core.dll      core_cpu_arm.dll
-          osx-x64-cpu       libcore.dylib libcore_cpu.dylib
-          linux-x64-gpu     libcore.so    libcore.so
-          linux-x64-cpu     libcore.so    libcore_cpu.so
+          osx-x64-cpu       libcore.dylib libcore_cpu_x64.dylib
+          linux-x64-gpu     libcore.so    libcore_gpu_x64_nvidia.so
+          linux-x64-cpu     libcore.so    libcore_cpu_x64.so
           EOF
 
           for line in "${MAPPINGS[@]}"; do


### PR DESCRIPTION
## 内容

ONNX COREのGitHub Actionsによる自動ビルドを追加します。

実行は3分くらいで終わります。

- [x] ビルド: https://github.com/aoirint/voicevox_core/actions/runs/1395462360
- [x] Artifactへのアップロード
    - OS・アーキテクチャ・CPU/GPU別にアップロード
    - ファイル名は`core.dll`、`libcore.dylib`、`libcore.so`
- [x] Releaseへのアップロード: https://github.com/aoirint/voicevox_core/releases/tag/0.7.4-aoirint-9
    - 0.7.4のcore.zipと同じ階層構造のcore.zipをアップロード
    - ファイル名は`core_cpu.dll`、`libcore_cpu.dylib`、`libcore_cpu.so`のようにリネーム
- macOS 自動ビルド実行時に出る警告 `Found 2 matching packages.`
    - ビルドにはmacOS 10.15を使っています
    - cmakeのReleaseで、macOS10.13+、10.10+向けの2つのRelease Assetがあるために起きています
    - 動作に問題はないので無視しています
    - https://github.com/jwlawson/actions-setup-cmake/issues/26

## 議論

- 共有ライブラリのファイル名フォーマット
    - もともとあったファイルは、そのままの名前
    - 新しく増えたx86、Arm向けビルドは`core_cpu_x86.dll`、`core_cpu_arm64.dll`、`core_cpu_arm.dll`
    - ONNX Runtimeの配布物は`win-x86`、`win-arm`、`win-x64-gpu`のようなフォーマット
        - GitHub Actions内ではONNX Runtimeのフォーマットをベースにした名付けにしている
- 暗号化された `*.bin` の読み込みに対応
<details>

https://github.com/Hiroshiba/voicevox_core/blob/f59c6fbe20f248a094afbe717a4c1127ed5ceb96/onnx/core.cpp#L29-L36

</details>

- `*.bin`、`metas.json`、`README.txt`の追加
- 依存関係のライセンス情報の追加 #29  

## 対応環境
- https://github.com/microsoft/onnxruntime/releases/tag/v1.9.0

ONNX RuntimeのReleaseに含まれていた以下の環境でビルドするようにしています。

- Windows x64 GPU
- Windows x64 CPU
- Windows x86 CPU
- Windows arm64 CPU
- Windows arm32 CPU
- macOS x64 CPU
- Linux x64 GPU
- Linux x64 CPU

## 関連 Issue

close #28 
ref #21
