### PR TITLE
core.hの場所が変わったのでbuild.ymlを追従

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -411,7 +411,7 @@ jobs:
 
           mv -v artifacts/*-cpp-shared/* release/
 
-          cp core.h release/
+          cp core/src/core.h release/
 
           echo "${{ env.BUILD_IDENTIFIER }}" > release/VERSION
 


### PR DESCRIPTION
## 内容

Github Actionsが通らなくなっていたので修正
