### PR TITLE
cmakeとsetup.pyを切り離す、テストの追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -294,6 +294,8 @@ jobs:
       # Build
       - if: startsWith(matrix.os, 'windows')
         uses: ilammy/msvc-dev-cmd@v1
+        with: 
+          arch: ${{ matrix.python_architecture }}
 
       - if: startsWith(matrix.os, 'mac')
         uses: jwlawson/actions-setup-cmake@v1.9

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,6 +160,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [windows-2019, macos-10.15, ubuntu-18.04]
         python: [3.8]
         include:
           - os: windows-2019

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,6 +160,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        python: [3.8]
         include:
           - os: windows-2019
             device: gpu
@@ -228,6 +229,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
 
       - run: mkdir download
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,17 +163,19 @@ jobs:
         include:
           - os: windows-2019
             device: gpu
+            python_architecture: 'x64'
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-win-x64-gpu-1.9.0.zip
-            cmake_additional_options: -DENABLE_CUDA=ON
             artifact_name: windows-x64-gpu
 
           - os: windows-2019
             device: cpu-x64
+            python_architecture: 'x64'
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-win-x64-1.9.0.zip
             artifact_name: windows-x64-cpu
 
           - os: windows-2019
             device: cpu-x86
+            python_architecture: 'x86'
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-win-x86-1.9.0.zip
             cmake_additional_options: -DCMAKE_GENERATOR_PLATFORM=Win32
             artifact_name: windows-x86-cpu
@@ -192,19 +194,21 @@ jobs:
 
           - os: macos-10.15
             device: cpu-x64
+            python_architecture: 'x64'
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-osx-x64-1.9.0.tgz
             artifact_name: osx-x64-cpu
 
           - os: ubuntu-18.04
             device: gpu
+            python_architecture: 'x64'
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz
-            cmake_additional_options: -DENABLE_CUDA=ON
             artifact_name: linux-x64-gpu
             cc_version: '8'
             cxx_version: '8'
 
           - os: ubuntu-18.04
             device: cpu-x64
+            python_architecture: 'x64'
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-1.9.0.tgz
             artifact_name: linux-x64-cpu
             cc_version: '8'
@@ -229,10 +233,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python
+      - name: Setup Python
+        if: matrix.python_architecture != ''
+        id: setup-python
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
+          architecture: ${{ matrix.python_architecture }}
 
       - run: mkdir download
 
@@ -325,7 +332,8 @@ jobs:
           # copy lib to core/lib/* and set rpath (linux)
           cmake --install .
 
-      - name: Unit test
+      - name: Unit test ${{ matrix.python_architecture }}
+        if: matrix.python_architecture != ''
         shell: bash
         run: |
           pip install -r requirements.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,8 +160,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, macos-10.15, ubuntu-18.04]
-        python: [3.8]
         include:
           - os: windows-2019
             device: gpu
@@ -231,10 +229,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python ${{ matrix.python }}
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python }}
+          python-version: 3.8
 
       - run: mkdir download
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -320,6 +320,10 @@ jobs:
           # copy lib to core/lib/* and set rpath (linux)
           cmake --install .
 
+      - name: Unit test
+        shell: bash
+        run: python setup.py test
+
       - name: Organize artifact
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -322,7 +322,9 @@ jobs:
 
       - name: Unit test
         shell: bash
-        run: python setup.py test
+        run: |
+          pip install -r requirements.txt
+          python setup.py test
 
       - name: Organize artifact
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 project(VoiceVoxCore)
 
-# TODO: build options
-set(ENABLE_CUDA OFF CACHE BOOL "use CUDA")
-
 # TODO: download onnxruntime
 set(ONNXRUNTIME_DIR "${CMAKE_CURRENT_SOURCE_DIR}/onnxruntime" CACHE PATH "Path to ONNX Runtime")
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 ## 依存関係
 
 - ONNX Runtime v1.9.0/v1.9.1: https://github.com/microsoft/onnxruntime
+- CMake
 
 環境に対応した ONNX Runtime をダウンロードし、リポジトリに`onnxruntime`というディレクトリ名で展開します。
 
@@ -43,6 +44,20 @@ sudo apt install libgomp1
 #### ソースコードから実行
 
 ```bash
+# C++モジュールのビルド
+mkdir build
+cd build
+# もしダウンロードしたonnx runtimeが別のところにあるなら、以下のコマンドを
+# cmake .. -DONNXRUNTIME_DIR=(ダウンロードしたonnx runtimeのパス) に変更する。
+cmake ..
+cmake --build . --config Release
+cmake --install .
+cd ..
+
+# (省略可能) pythonモジュールのテスト
+python setup.py test
+
+# pythonモジュールのインストール
 pip install .
 
 cd example/python

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -39,11 +39,6 @@ target_link_libraries(core PUBLIC onnxruntime)
 # GCC 9.0以前ではstd::filesystemを使うためにリンクが必要 (https://gitlab.kitware.com/cmake/cmake/-/issues/17834)
 target_link_libraries(core PRIVATE $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs>)
 
-# core.cpp内にUSE_CUDAをdefineする
-if(ENABLE_CUDA)
-	target_compile_definitions(core PRIVATE USE_CUDA)
-endif(ENABLE_CUDA)
-
 # cmake --installを行うとcoreライブラリ、onnxruntimeライブラリ、core.hがインストール先のlibフォルダにコピーされる
 install(TARGETS core
 	ARCHIVE DESTINATION lib

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -17,6 +17,7 @@ else()
 	message(FATAL_ERROR "Unable to find ONNX Runtime. Use option -DONNXRUNTIME_DIR=...")
 endif()
 file(GLOB ONNXRUNTIME_LIBS
+	"${ONNXRUNTIME_DIR}/lib/*.dylib"
 	"${ONNXRUNTIME_DIR}/lib/*.dll"
 	"${ONNXRUNTIME_DIR}/lib/*.lib"
 	"${ONNXRUNTIME_DIR}/lib/*.so"

--- a/core/_core.pxd
+++ b/core/_core.pxd
@@ -10,6 +10,8 @@ cdef extern from "core.h":
 
     const char *c_metas "metas" ()
 
+    const char *c_supported_devices "supported_devices" ()
+
     bool c_yukarin_s_forward "yukarin_s_forward" (
         int length,
         long *phoneme_list,

--- a/core/_core.pyx
+++ b/core/_core.pyx
@@ -19,6 +19,9 @@ cpdef finalize():
 cpdef metas():
     return c_metas().decode()
 
+cpdef supported_devices():
+    return c_supported_devices().decode()
+
 cpdef numpy.ndarray[numpy.float32_t, ndim=1] yukarin_s_forward(
     int length,
     numpy.ndarray[numpy.int64_t, ndim=1] phoneme_list,

--- a/core/src/core.cpp
+++ b/core/src/core.cpp
@@ -70,18 +70,16 @@ bool open_metas(const fs::path &metas_path, nlohmann::json &metas) {
 }
 
 struct SupportedDevices {
-  bool cpu;
-  bool cuda;
+  bool cpu = true;
+  bool cuda = false;
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(SupportedDevices, cpu, cuda);
 
 SupportedDevices get_supported_devices() {
-  SupportedDevices devices{false, false};
+  SupportedDevices devices;
   const auto providers = Ort::GetAvailableProviders();
   for (const std::string &p : providers) {
-    if (p == "CPUExecutionProvider") {
-      devices.cpu = true;
-    } else if (p == "CUDAExecutionProvider") {
+    if (p == "CUDAExecutionProvider") {
       devices.cuda = true;
     }
   }

--- a/core/src/core.h
+++ b/core/src/core.h
@@ -43,6 +43,14 @@ extern "C" VOICEVOX_CORE_API const char *metas();
 
 /**
  * @fn
+ * 対応デバイス情報を取得する
+ * @brief cpu, cudaのうち、使用可能なデバイス情報を取得する
+ * @return 各デバイスが使用可能かどうかをboolで格納したjson形式の文字列
+ */
+extern "C" VOICEVOX_CORE_API const char *supported_devices();
+
+/**
+ * @fn
  * 音素ごとの長さを求める
  * @brief 音素列から、音素ごとの長さを求める
  * @param length 音素列の長さ

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Cython
+numpy

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup, Extension
-from subprocess import check_call, CalledProcessError
 import platform
 import os
 import sys
@@ -14,22 +13,11 @@ def get_version():
     with open(os.path.join(base_dir, 'VERSION.txt')) as f:
         return f.read().strip()
 
-def build_src():
-    """setupより前にC++モジュールのビルド"""
-    print('Building C++ modules...')
-
-    base_dir = os.path.dirname(os.path.abspath(__file__))
-    build_dir = os.path.join(base_dir, 'build')
-    os.makedirs(build_dir, exist_ok=True)
-    try:
-        check_call(['cmake', '..'], cwd=build_dir)
-        check_call(['cmake', '--build', '.', '--config', 'Release'], cwd=build_dir)
-        check_call(['cmake', '--install', '.'], cwd=build_dir)
-    except (CalledProcessError, KeyboardInterrupt) as e:
-        sys.exit(1)
-
 if __name__ == '__main__':
-    build_src()
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+
+    # C++モジュールがすでにビルドされ、core/libに入っているか確認
+    assert os.path.exists(os.path.join(base_dir, 'core', 'lib', 'core.h')), 'C++モジュールがビルドされていません'
 
     # 追加ライブラリ(pythonライブラリからの相対パスで./lib/*)を読み込めるように設定
     if platform.system() == "Windows":
@@ -51,7 +39,7 @@ if __name__ == '__main__':
         )
     ]
 
-    sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'tests'))
+    sys.path.append(os.path.join(base_dir, 'tests'))
 
     setup(
         name="core",

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from setuptools import setup, Extension
 import platform
 import os

--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,12 @@ if __name__ == '__main__':
     # 追加ライブラリ(pythonライブラリからの相対パスで./lib/*)を読み込めるように設定
     if platform.system() == "Windows":
         # Windowsでは別途__init__.pyで明示的に読み込む
-        runtime_library_dirs = []
+        extra_link_args = []
+    elif platform.system() == "Darwin":
+        extra_link_args = ["-Wl,-rpath,@loader_path/lib"]
     else:
         # $ORIGINはpythonライブラリの読み込み時に自動的に自身のパスに展開される
-        runtime_library_dirs = ["$ORIGIN/lib"]
+        extra_link_args = ["-Wl,-rpath,$ORIGIN/lib"]
 
     ext_modules = [
         Extension(
@@ -37,7 +39,7 @@ if __name__ == '__main__':
             libraries=["core"],
             include_dirs=["core/lib"],
             library_dirs=["core/lib"],
-            runtime_library_dirs=runtime_library_dirs,
+            extra_link_args=extra_link_args,
         )
     ]
 

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -39,5 +39,11 @@ class TestCore(unittest.TestCase):
         core.finalize()
         self.assertEqual(metas, core_metas)
 
+    def test_supported_devices(self):
+        devices = json.loads(core.supported_devices())
+        for expected_device in ["cpu", "cuda"]:
+            self.assertIn(expected_device, devices)
+        self.assertTrue(devices["cpu"])
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## 内容

* これまでpip install時に自動でcmakeが走っていたが、これを取りやめてcmake buildを手動でやるようにする
* cpu版/cuda版を統一し、ダウンロードしてきたonnx runtimeがcudaに対応しているかどうかを実行時に確認するように変更
* 単体テストをgithub actionに追加

## 関連 Issue

close #50 
ref #16 : cudaをサポートしているかどうかを確認する `supports_cuda` という関数を実装したので、良さそうならこれをAPIに追加しようと思います

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

