### PR TITLE
int,longを全てint64_tへ変更して不要なキャストを削除

### DIFF
--- a/core/_core.pxd
+++ b/core/_core.pxd
@@ -1,4 +1,5 @@
 from libcpp cimport bool
+from libc.stdint cimport int64_t
 
 cdef extern from "core.h":
     bool c_initialize "initialize" (

--- a/core/_core.pxd
+++ b/core/_core.pxd
@@ -11,30 +11,30 @@ cdef extern from "core.h":
     const char *c_metas "metas" ()
 
     bool c_yukarin_s_forward "yukarin_s_forward" (
-        int length,
-        long *phoneme_list,
-        long *speaker_id,
+        int64_t length,
+        int64_t *phoneme_list,
+        int64_t *speaker_id,
         float *output
     )
 
     bool c_yukarin_sa_forward "yukarin_sa_forward" (
-        int length,
-        long *vowel_phoneme_list,
-        long *consonant_phoneme_list,
-        long *start_accent_list,
-        long *end_accent_list,
-        long *start_accent_phrase_list,
-        long *end_accent_phrase_list,
-        long *speaker_id,
+        int64_t length,
+        int64_t *vowel_phoneme_list,
+        int64_t *consonant_phoneme_list,
+        int64_t *start_accent_list,
+        int64_t *end_accent_list,
+        int64_t *start_accent_phrase_list,
+        int64_t *end_accent_phrase_list,
+        int64_t *speaker_id,
         float *output
     )
 
     bool c_decode_forward "decode_forward" (
-        int length,
-        int phoneme_size,
+        int64_t length,
+        int64_t phoneme_size,
         float *f0,
         float *phoneme,
-        long *speaker_id,
+        int64_t *speaker_id,
         float *output
     )
 

--- a/core/_core.pyx
+++ b/core/_core.pyx
@@ -2,6 +2,7 @@ cimport numpy
 import numpy
 
 from libcpp cimport bool
+from libc.stdint cimport int64_t
 
 cpdef initialize(
     str root_dir_path,

--- a/core/_core.pyx
+++ b/core/_core.pyx
@@ -20,15 +20,15 @@ cpdef metas():
     return c_metas().decode()
 
 cpdef numpy.ndarray[numpy.float32_t, ndim=1] yukarin_s_forward(
-    int length,
+    int64_t length,
     numpy.ndarray[numpy.int64_t, ndim=1] phoneme_list,
     numpy.ndarray[numpy.int64_t, ndim=1] speaker_id,
 ):
     cdef numpy.ndarray[numpy.float32_t, ndim=1] output = numpy.zeros((length,), dtype=numpy.float32)
     cdef bool success = c_yukarin_s_forward(
         length,
-        <long*> phoneme_list.data,
-        <long*> speaker_id.data,
+        <int64_t*> phoneme_list.data,
+        <int64_t*> speaker_id.data,
         <float*> output.data,
     )
     if not success: raise Exception(c_last_error_message().decode())
@@ -36,7 +36,7 @@ cpdef numpy.ndarray[numpy.float32_t, ndim=1] yukarin_s_forward(
 
 
 cpdef numpy.ndarray[numpy.float32_t, ndim=2] yukarin_sa_forward(
-    int length,
+    int64_t length,
     numpy.ndarray[numpy.int64_t, ndim=2] vowel_phoneme_list,
     numpy.ndarray[numpy.int64_t, ndim=2] consonant_phoneme_list,
     numpy.ndarray[numpy.int64_t, ndim=2] start_accent_list,
@@ -48,21 +48,21 @@ cpdef numpy.ndarray[numpy.float32_t, ndim=2] yukarin_sa_forward(
     cdef numpy.ndarray[numpy.float32_t, ndim=2] output = numpy.empty((len(speaker_id), length,), dtype=numpy.float32)
     cdef bool success = c_yukarin_sa_forward(
         length,
-        <long*> vowel_phoneme_list.data,
-        <long*> consonant_phoneme_list.data,
-        <long*> start_accent_list.data,
-        <long*> end_accent_list.data,
-        <long*> start_accent_phrase_list.data,
-        <long*> end_accent_phrase_list.data,
-        <long*> speaker_id.data,
+        <int64_t*> vowel_phoneme_list.data,
+        <int64_t*> consonant_phoneme_list.data,
+        <int64_t*> start_accent_list.data,
+        <int64_t*> end_accent_list.data,
+        <int64_t*> start_accent_phrase_list.data,
+        <int64_t*> end_accent_phrase_list.data,
+        <int64_t*> speaker_id.data,
         <float*> output.data,
     )
     if not success: raise Exception(c_last_error_message().decode())
     return output
 
 cpdef numpy.ndarray[numpy.float32_t, ndim=1] decode_forward(
-    int length,
-    int phoneme_size,
+    int64_t length,
+    int64_t phoneme_size,
     numpy.ndarray[numpy.float32_t, ndim=2] f0,
     numpy.ndarray[numpy.float32_t, ndim=2] phoneme,
     numpy.ndarray[numpy.int64_t, ndim=1] speaker_id,
@@ -73,7 +73,7 @@ cpdef numpy.ndarray[numpy.float32_t, ndim=1] decode_forward(
         phoneme_size,
         <float*> f0.data,
         <float*> phoneme.data,
-        <long*> speaker_id.data,
+        <int64_t*> speaker_id.data,
         <float*> output.data,
     )
     if not success: raise Exception(c_last_error_message().decode())

--- a/core/src/core.cpp
+++ b/core/src/core.cpp
@@ -88,7 +88,7 @@ struct Status {
     supported_styles.clear();
     for (const auto &meta : metas) {
       for (const auto &style : meta["styles"]) {
-        supported_styles.insert(style["id"].get<int>());
+        supported_styles.insert(style["id"].get<int64_t>());
       }
     }
 
@@ -118,7 +118,7 @@ struct Status {
 
   nlohmann::json metas;
   std::string metas_str;
-  std::unordered_set<int> supported_styles;
+  std::unordered_set<int64_t> supported_styles;
 };
 
 static std::unique_ptr<Status> status;
@@ -206,7 +206,7 @@ bool yukarin_s_forward(int64_t length, int64_t *phoneme_list, int64_t *speaker_i
     status->yukarin_s.Run(Ort::RunOptions{nullptr}, inputs, input_tensors.data(), input_tensors.size(), outputs,
                           &output_tensor, 1);
 
-    for (int i = 0; i < length; i++) {
+    for (int64_t i = 0; i < length; i++) {
       if (output[i] < PHONEME_LENGTH_MINIMAL) output[i] = PHONEME_LENGTH_MINIMAL;
     }
   } catch (const Ort::Exception &e) {

--- a/core/src/core.cpp
+++ b/core/src/core.cpp
@@ -132,7 +132,7 @@ Ort::Value to_tensor(T *data, const std::array<int64_t, Rank> &shape) {
   return Ort::Value::CreateTensor<T>(status->memory_info, data, count, shape.data(), shape.size());
 }
 
-bool validate_speaker_id(int speaker_id) {
+bool validate_speaker_id(int64_t speaker_id) {
   if (status->supported_styles.find(speaker_id) == status->supported_styles.end()) {
     error_message = UNKNOWN_STYLE + std::to_string(speaker_id);
     return false;
@@ -158,7 +158,7 @@ bool initialize(const char *root_dir_path, bool use_gpu) {
       int length = 500;
       int phoneme_size = 45;
       std::vector<float> phoneme(length * phoneme_size), f0(length);
-      long speaker_id = 0;
+      int64_t speaker_id = 0;
       std::vector<float> output(length * 256);
       decode_forward(length, phoneme_size, f0.data(), phoneme.data(), &speaker_id, output.data());
     }
@@ -186,7 +186,7 @@ void finalize() {
 
 const char *metas() { return status->metas_str.c_str(); }
 
-bool yukarin_s_forward(int length, long *phoneme_list, long *speaker_id, float *output) {
+bool yukarin_s_forward(int64_t length, int64_t *phoneme_list, int64_t *speaker_id, float *output) {
   if (!initialized) {
     error_message = NOT_INITIALIZED_ERR;
     return false;
@@ -198,10 +198,9 @@ bool yukarin_s_forward(int length, long *phoneme_list, long *speaker_id, float *
     const char *inputs[] = {"phoneme_list", "speaker_id"};
     const char *outputs[] = {"phoneme_length"};
     const std::array<int64_t, 1> phoneme_shape{length};
-    int64_t speaker_id_ll = static_cast<int64_t>(*speaker_id);
 
-    std::array<Ort::Value, 2> input_tensors = {to_tensor((int64_t *)phoneme_list, phoneme_shape),
-                                               to_tensor(&speaker_id_ll, speaker_shape)};
+    std::array<Ort::Value, 2> input_tensors = {to_tensor(phoneme_list, phoneme_shape),
+                                               to_tensor(&speaker_id, speaker_shape)};
     Ort::Value output_tensor = to_tensor(output, phoneme_shape);
 
     status->yukarin_s.Run(Ort::RunOptions{nullptr}, inputs, input_tensors.data(), input_tensors.size(), outputs,
@@ -219,9 +218,9 @@ bool yukarin_s_forward(int length, long *phoneme_list, long *speaker_id, float *
   return true;
 }
 
-bool yukarin_sa_forward(int length, long *vowel_phoneme_list, long *consonant_phoneme_list, long *start_accent_list,
-                        long *end_accent_list, long *start_accent_phrase_list, long *end_accent_phrase_list,
-                        long *speaker_id, float *output) {
+bool yukarin_sa_forward(int64_t length, int64_t *vowel_phoneme_list, int64_t *consonant_phoneme_list, int64_t *start_accent_list,
+                        int64_t *end_accent_list, int64_t *start_accent_phrase_list, int64_t *end_accent_phrase_list,
+                        int64_t *speaker_id, float *output) {
   if (!initialized) {
     error_message = NOT_INITIALIZED_ERR;
     return false;
@@ -235,17 +234,15 @@ bool yukarin_sa_forward(int length, long *vowel_phoneme_list, long *consonant_ph
         "end_accent_list", "start_accent_phrase_list", "end_accent_phrase_list", "speaker_id"};
     const char *outputs[] = {"f0_list"};
     const std::array<int64_t, 1> phoneme_shape{length};
-    int64_t length_ll = static_cast<int64_t>(length);
-    int64_t speaker_id_ll = static_cast<int64_t>(*speaker_id);
 
-    std::array<Ort::Value, 8> input_tensors = {to_tensor(&length_ll, scalar_shape),
-                                               to_tensor((int64_t *)vowel_phoneme_list, phoneme_shape),
-                                               to_tensor((int64_t *)consonant_phoneme_list, phoneme_shape),
-                                               to_tensor((int64_t *)start_accent_list, phoneme_shape),
-                                               to_tensor((int64_t *)end_accent_list, phoneme_shape),
-                                               to_tensor((int64_t *)start_accent_phrase_list, phoneme_shape),
-                                               to_tensor((int64_t *)end_accent_phrase_list, phoneme_shape),
-                                               to_tensor(&speaker_id_ll, speaker_shape)};
+    std::array<Ort::Value, 8> input_tensors = {to_tensor(&length, scalar_shape),
+                                               to_tensor(vowel_phoneme_list, phoneme_shape),
+                                               to_tensor(consonant_phoneme_list, phoneme_shape),
+                                               to_tensor(start_accent_list, phoneme_shape),
+                                               to_tensor(end_accent_list, phoneme_shape),
+                                               to_tensor(start_accent_phrase_list, phoneme_shape),
+                                               to_tensor(end_accent_phrase_list, phoneme_shape),
+                                               to_tensor(speaker_id, speaker_shape)};
     Ort::Value output_tensor = to_tensor(output, phoneme_shape);
 
     status->yukarin_sa.Run(Ort::RunOptions{nullptr}, inputs, input_tensors.data(), input_tensors.size(), outputs,
@@ -258,7 +255,7 @@ bool yukarin_sa_forward(int length, long *vowel_phoneme_list, long *consonant_ph
   return true;
 }
 
-bool decode_forward(int length, int phoneme_size, float *f0, float *phoneme, long *speaker_id, float *output) {
+bool decode_forward(int64_t length, int64_t phoneme_size, float *f0, float *phoneme, int64_t *speaker_id, float *output) {
   if (!initialized) {
     error_message = NOT_INITIALIZED_ERR;
     return false;
@@ -271,10 +268,9 @@ bool decode_forward(int length, int phoneme_size, float *f0, float *phoneme, lon
     const char *outputs[] = {"wave"};
     const std::array<int64_t, 1> wave_shape{length * 256};
     const std::array<int64_t, 2> f0_shape{length, 1}, phoneme_shape{length, phoneme_size};
-    int64_t speaker_id_ll = static_cast<int64_t>(*speaker_id);
 
     std::array<Ort::Value, 3> input_tensor = {to_tensor(f0, f0_shape), to_tensor(phoneme, phoneme_shape),
-                                              to_tensor(&speaker_id_ll, speaker_shape)};
+                                              to_tensor(speaker_id, speaker_shape)};
     Ort::Value output_tensor = to_tensor(output, wave_shape);
 
     status->decode.Run(Ort::RunOptions{nullptr}, inputs, input_tensor.data(), input_tensor.size(), outputs,

--- a/core/src/core.cpp
+++ b/core/src/core.cpp
@@ -200,7 +200,7 @@ bool yukarin_s_forward(int64_t length, int64_t *phoneme_list, int64_t *speaker_i
     const std::array<int64_t, 1> phoneme_shape{length};
 
     std::array<Ort::Value, 2> input_tensors = {to_tensor(phoneme_list, phoneme_shape),
-                                               to_tensor(&speaker_id, speaker_shape)};
+                                               to_tensor(speaker_id, speaker_shape)};
     Ort::Value output_tensor = to_tensor(output, phoneme_shape);
 
     status->yukarin_s.Run(Ort::RunOptions{nullptr}, inputs, input_tensors.data(), input_tensors.size(), outputs,

--- a/core/src/core.h
+++ b/core/src/core.h
@@ -50,7 +50,7 @@ extern "C" VOICEVOX_CORE_API const char *metas();
  * @param speaker_id 話者番号
  * @return 音素ごとの長さ
  */
-extern "C" VOICEVOX_CORE_API bool yukarin_s_forward(int length, long *phoneme_list, long *speaker_id, float *output);
+extern "C" VOICEVOX_CORE_API bool yukarin_s_forward(int64_t length, int64_t *phoneme_list, int64_t *speaker_id, float *output);
 
 /**
  * @fn
@@ -66,10 +66,10 @@ extern "C" VOICEVOX_CORE_API bool yukarin_s_forward(int length, long *phoneme_li
  * @param speaker_id 話者番号
  * @return モーラごとの音高
  */
-extern "C" VOICEVOX_CORE_API bool yukarin_sa_forward(int length, long *vowel_phoneme_list, long *consonant_phoneme_list,
-                                                     long *start_accent_list, long *end_accent_list,
-                                                     long *start_accent_phrase_list, long *end_accent_phrase_list,
-                                                     long *speaker_id, float *output);
+extern "C" VOICEVOX_CORE_API bool yukarin_sa_forward(int64_t length, int64_t *vowel_phoneme_list, int64_t *consonant_phoneme_list,
+                                                     int64_t *start_accent_list, int64_t *end_accent_list,
+                                                     int64_t *start_accent_phrase_list, int64_t *end_accent_phrase_list,
+                                                     int64_t *speaker_id, float *output);
 
 /**
  * @fn
@@ -82,8 +82,8 @@ extern "C" VOICEVOX_CORE_API bool yukarin_sa_forward(int length, long *vowel_pho
  * @param speaker_id 話者番号
  * @return 音声波形
  */
-extern "C" VOICEVOX_CORE_API bool decode_forward(int length, int phoneme_size, float *f0, float *phoneme,
-                                                 long *speaker_id, float *output);
+extern "C" VOICEVOX_CORE_API bool decode_forward(int64_t length, int64_t phoneme_size, float *f0, float *phoneme,
+                                                 int64_t *speaker_id, float *output);
 
 /**
  * @fn


### PR DESCRIPTION
## 内容
関数の引数ではlongで定義されているものが、実際に使用する前にint64_tへキャストしてから使用していたので、引数の定義をint64_tへ変えてキャストしないようにしました。

この変更に伴い、cython関連のコードも変更しています。
ビルドは通りましたが、cythonのコードがビルドに関連しているかわからないので、確認をお願いします。

## 関連 Issue

無し

## その他

無し
