### PR TITLE
armhfビルド: ONNX Runtimeビルドのリポジトリ切り出しに対応

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,21 +204,6 @@ jobs:
           # copy Linux/macOS shared library if exists
           cp -v core/lib/libcore* artifact/ || true
 
-          # copy libonnxruntime
-          if [ "${{ matrix.onnxruntime_artifact_name }}" != "" ]; then
-            mkdir -p "artifact/onnxruntime-${{ matrix.artifact_name }}/"
-
-            # copy docs and license (all files in root dir)
-            find "download/onnxruntime/" -maxdepth 1 -type f | xargs -I{} cp -v {} "artifact/onnxruntime-${{ matrix.artifact_name }}/"
-
-            # copy Windows DLL if exists
-            cp -v core/lib/onnxruntime* "artifact/onnxruntime-${{ matrix.artifact_name }}/" || true
-            # copy Linux shared library if exists
-            cp -v core/lib/libonnxruntime.so.* "artifact/onnxruntime-${{ matrix.artifact_name }}/" || true
-            # copy macOS shared library if exists
-            cp -v core/lib/libonnxruntime.dylib "artifact/onnxruntime-${{ matrix.artifact_name }}/" || true
-          fi
-
       # Upload
       - name: Upload artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -272,6 +272,7 @@ jobs:
           osx-x64-cpu       libcore.dylib libcore_cpu_x64.dylib
           linux-x64-gpu     libcore.so    libcore_gpu_x64_nvidia.so
           linux-x64-cpu     libcore.so    libcore_cpu_x64.so
+          linux-armhf-cpu   libcore.so    libcore_cpu_armhf.so
           EOF
 
           for line in "${MAPPINGS[@]}"; do

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
 
           - os: ubuntu-18.04
             device: cpu-armhf
-            onnxruntime_url: https://github.com/VOICEVOX/onnxruntime-builder/releases/download/1.9.1/onnxruntime-linux-armhf-cpu-v1.9.1.zip
+            onnxruntime_url: https://github.com/VOICEVOX/onnxruntime-builder/releases/download/1.9.1.1/onnxruntime-linux-armhf-cpu-v1.9.1.tgz
             artifact_name: linux-armhf-cpu
             cc_version: '8'
             cxx_version: '8'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,12 +104,10 @@ jobs:
 
       # ONNX Runtime
       - name: Export ONNX Runtime url to calc hash
-        if: matrix.onnxruntime_artifact_name == ''
         shell: bash
         run: echo "${{ matrix.onnxruntime_url }}" > download/onnxruntime_url.txt
 
       - name: Cache ONNX Runtime
-        if: matrix.onnxruntime_artifact_name == ''
         uses: actions/cache@v2
         id: onnxruntime-cache
         with:
@@ -118,7 +116,7 @@ jobs:
 
       # download/onnxruntime/lib/onnxruntime.dll
       - name: Download ONNX Runtime (zip)
-        if: matrix.onnxruntime_artifact_name == '' && steps.onnxruntime-cache.outputs.cache-hit != 'true' && endsWith(matrix.onnxruntime_url, '.zip')
+        if: steps.onnxruntime-cache.outputs.cache-hit != 'true' && endsWith(matrix.onnxruntime_url, '.zip')
         shell: bash
         run: |
           curl -L "${{ matrix.onnxruntime_url }}" > download/onnxruntime.zip
@@ -135,20 +133,13 @@ jobs:
       # download/onnxruntime/lib/libonnxruntime.so
       # download/onnxruntime/lib/libonnxruntime.dylib
       - name: Download ONNX Runtime (tgz)
-        if: matrix.onnxruntime_artifact_name == '' && steps.onnxruntime-cache.outputs.cache-hit != 'true' && endsWith(matrix.onnxruntime_url, '.tgz')
+        if: steps.onnxruntime-cache.outputs.cache-hit != 'true' && endsWith(matrix.onnxruntime_url, '.tgz')
         shell: bash
         run: |
           curl -L "${{ matrix.onnxruntime_url }}" > download/onnxruntime.tgz
           mkdir -p download/onnxruntime
           tar xf download/onnxruntime.tgz -C download/onnxruntime --strip-components 1
           rm download/onnxruntime.tgz
-
-      - name: Download ONNX Runtime (artifact)
-        if: matrix.onnxruntime_artifact_name != ''
-        uses: actions/download-artifact@v2
-        with:
-          name: ${{ matrix.onnxruntime_artifact_name }}
-          path: download/onnxruntime/
 
       # Build
       - if: startsWith(matrix.os, 'windows')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,14 @@ jobs:
             cc_version: '8'
             cxx_version: '8'
 
+          - os: ubuntu-18.04
+            device: cpu-armhf
+            onnxruntime_url: https://github.com/VOICEVOX/onnxruntime-builder/releases/download/1.9.1/onnxruntime-linux-armhf-cpu-v1.9.1.zip
+            artifact_name: linux-armhf-cpu
+            cc_version: '8'
+            cxx_version: '8'
+            arch: arm-linux-gnueabihf
+
     runs-on: ${{ matrix.os }}
 
     env:

--- a/README.md
+++ b/README.md
@@ -24,8 +24,11 @@ CUDA の macOS サポートは現在終了しているため、VOICEVOX CORE の
 
 ### Raspberry Pi (armhf)の場合
 
-`core.zip`に Raspberry Pi 用の ONNX Runtime を同梱しています。
-利用には、libgomp のインストールが必要です。
+Raspberry Pi 用の ONNX Runtime は以下からダウンロードできます。
+
+- <https://github.com/VOICEVOX/onnxruntime-builder/releases>
+
+動作には、libgomp のインストールが必要です。
 
 ```shell
 sudo apt install libgomp1


### PR DESCRIPTION
## 内容

armhfビルドについて、 #55 で ONNX Runtimeのビルドが [別リポジトリ](https://github.com/VOICEVOX/onnxruntime-builder)に切り出されたため、
そのReleaseを使ったビルドに書き換えて再開します。

ONNX Runtimeのビルド成果物は切り出し先のReleaseにアップロードされるようになったので、
同梱しないようにしています。

切り出し先Releaseの圧縮ファイル構造の修正が必要です。

- <https://github.com/VOICEVOX/onnxruntime-builder/pull/2>
- <https://github.com/VOICEVOX/voicevox_core/issues/54#issuecomment-1003274192>

構造が修正されたReleaseでビルドの動作を確認したらDraftを外します。

- <https://github.com/aoirint/voicevox_core/actions/runs/1640531481>

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

- close #54 

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他
