### PR TITLE
リポジトリのURLをHiroshibaからVOICEVOXに

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # VOICEVOX CORE
 
 [VOICEVOX](https://voicevox.hiroshiba.jp/) の音声合成コア。  
-[Releases](https://github.com/Hiroshiba/voicevox_core/releases) にビルド済みのコアライブラリ（.so/.dll/.dylib）があります。
+[Releases](https://github.com/VOICEVOX/voicevox_core/releases) にビルド済みのコアライブラリ（.so/.dll/.dylib）があります。
 
-（エディターは [VOICEVOX](https://github.com/Hiroshiba/voicevox/) 、
-エンジンは [VOICEVOX ENGINE](https://github.com/Hiroshiba/voicevox_engine/) 、
-全体構成は [こちら](https://github.com/Hiroshiba/voicevox/blob/main/docs/%E5%85%A8%E4%BD%93%E6%A7%8B%E6%88%90.md) に詳細があります。）
+（エディターは [VOICEVOX](https://github.com/VOICEVOX/voicevox/) 、
+エンジンは [VOICEVOX ENGINE](https://github.com/VOICEVOX/voicevox_engine/) 、
+全体構成は [こちら](https://github.com/VOICEVOX/voicevox/blob/main/docs/%E5%85%A8%E4%BD%93%E6%A7%8B%E6%88%90.md) に詳細があります。）
 
 ## 依存関係
 
@@ -40,7 +40,7 @@ sudo apt install libgomp1
 
 ## サンプルの実行
 
-まず [Releases](https://github.com/Hiroshiba/voicevox_core/releases) からコアライブラリが入った zip をダウンロードしておきます。
+まず [Releases](https://github.com/VOICEVOX/voicevox_core/releases) からコアライブラリが入った zip をダウンロードしておきます。
 
 ### Python 3
 
@@ -118,4 +118,4 @@ aplay ~/voice/おはようございます-1.wav
 
 サンプルコードおよび [core.h](./core/src/core.h) は [MIT LICENSE](./LICENSE) です。
 
-[Releases](https://github.com/Hiroshiba/voicevox_core/releases) にあるビルド済みのコアライブラリは別ライセンスなのでご注意ください。
+[Releases](https://github.com/VOICEVOX/voicevox_core/releases) にあるビルド済みのコアライブラリは別ライセンスなのでご注意ください。

--- a/example/python/Dockerfile
+++ b/example/python/Dockerfile
@@ -26,7 +26,7 @@ RUN cd /voicevox/lib \
 &&  ln -s ./libcudart-6d56b25a.so.11.0 ./libcudart.so.11.0
 
 # Set up built libraries
-RUN curl -sLO "`curl -s https://api.github.com/repos/Hiroshiba/voicevox_core/releases/latest \
+RUN curl -sLO "`curl -s https://api.github.com/repos/VOICEVOX/voicevox_core/releases/latest \
     | jq -r '.assets[]|select(.name=="core.zip")|.browser_download_url'`"
 RUN unzip -q core.zip && rm core.zip
 RUN mv core/* /voicevox/

--- a/example/python/requirements.txt
+++ b/example/python/requirements.txt
@@ -1,4 +1,4 @@
 numpy<1.21
 cython
 soundfile
-git+https://github.com/Hiroshiba/pyopenjtalk@69e5f354634f98098113f9cac5a6ea736443f9c9#egg=pyopenjtalk
+git+https://github.com/VOICEVOX/pyopenjtalk@69e5f354634f98098113f9cac5a6ea736443f9c9#egg=pyopenjtalk


### PR DESCRIPTION
## 内容

いい加減VOICEVOX org内のリポジトリで作業するのをやめて、個人リポジトリで作業できるようにしたいと思いました。
リダイレクトが死んでしまいますが、こんな感じの案内を出そうとと思います。
https://github.com/Hiroshiba/voicevox_engine

![image](https://user-images.githubusercontent.com/4987327/150676853-8f38a863-4c90-423a-85c1-e45698a21e23.png)


## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
