### PR TITLE
ONNX Runtimeのバージョンを1.10にアップグレードする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,44 +23,44 @@ jobs:
           - os: windows-2019
             device: gpu
             python_architecture: 'x64'
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-win-x64-gpu-1.9.0.zip
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-win-x64-gpu-1.10.0.zip
             artifact_name: windows-x64-gpu
 
           - os: windows-2019
             device: cpu-x64
             python_architecture: 'x64'
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-win-x64-1.9.0.zip
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-win-x64-1.10.0.zip
             artifact_name: windows-x64-cpu
 
           - os: windows-2019
             device: cpu-x86
             python_architecture: 'x86'
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-win-x86-1.9.0.zip
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-win-x86-1.10.0.zip
             cmake_additional_options: -DCMAKE_GENERATOR_PLATFORM=Win32
             artifact_name: windows-x86-cpu
 
           - os: windows-2019
             device: cpu-arm64
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-win-arm64-1.9.0.zip
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-win-arm64-1.10.0.zip
             cmake_additional_options: -DCMAKE_GENERATOR_PLATFORM=arm64
             artifact_name: windows-arm64-cpu
 
           - os: windows-2019
             device: cpu-arm
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-win-arm-1.9.0.zip
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-win-arm-1.10.0.zip
             cmake_additional_options: -DCMAKE_GENERATOR_PLATFORM=arm
             artifact_name: windows-arm-cpu
 
           - os: macos-10.15
             device: cpu-x64
             python_architecture: 'x64'
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-osx-x64-1.9.0.tgz
-            artifact_name: osx-x64-cpu
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-osx-universal2-1.10.0.tgz
+            artifact_name: osx-universal2-cpu
 
           - os: ubuntu-18.04
             device: gpu
             python_architecture: 'x64'
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-gpu-1.10.0.tgz
             artifact_name: linux-x64-gpu
             cc_version: '8'
             cxx_version: '8'
@@ -68,14 +68,14 @@ jobs:
           - os: ubuntu-18.04
             device: cpu-x64
             python_architecture: 'x64'
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-1.9.0.tgz
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-1.10.0.tgz
             artifact_name: linux-x64-cpu
             cc_version: '8'
             cxx_version: '8'
 
           - os: ubuntu-18.04
             device: cpu-armhf
-            onnxruntime_url: https://github.com/VOICEVOX/onnxruntime-builder/releases/download/1.9.1.1/onnxruntime-linux-armhf-cpu-v1.9.1.tgz
+            onnxruntime_url: https://github.com/VOICEVOX/onnxruntime-builder/releases/download/1.10.0.1/onnxruntime-linux-armhf-cpu-v1.10.0.tgz
             artifact_name: linux-armhf-cpu
             cc_version: '8'
             cxx_version: '8'
@@ -161,11 +161,18 @@ jobs:
             g++-${{ matrix.cxx_version }}${{ env.ARCH_SUFFIX }} \
             cmake
 
-      - name: Configure (Windows, macOS)
-        if: ${{ !startsWith(matrix.os, 'ubuntu') }} # '!' cannot be used as a first character in YAML
+      - name: Configure (Windows)
+        if: startsWith(matrix.os, 'windows')
         shell: bash
         run: |
           cmake -DONNXRUNTIME_DIR=download/onnxruntime ${{ matrix.cmake_additional_options }} .
+
+      # libcore.dylib for macOS universal
+      - name: Configure (macOS)
+        if: startsWith(matrix.os, 'macos')
+        shell: bash
+        run: |
+          env CMAKE_OSX_ARCHITECTURES="x86_64;arm64" cmake -DONNXRUNTIME_DIR=download/onnxruntime ${{ matrix.cmake_additional_options }} .
 
       - name: Configure (Linux)
         if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -252,7 +252,7 @@ jobs:
           windows-x86-cpu   core.dll      core_cpu_x86.dll
           windows-arm64-cpu core.dll      core_cpu_arm64.dll
           windows-arm-cpu   core.dll      core_cpu_arm.dll
-          osx-x64-cpu       libcore.dylib libcore_cpu_x64.dylib
+          osx-x64-cpu       libcore.dylib libcore_cpu_universal2.dylib
           linux-x64-gpu     libcore.so    libcore_gpu_x64_nvidia.so
           linux-x64-cpu     libcore.so    libcore_cpu_x64.so
           linux-armhf-cpu   libcore.so    libcore_cpu_armhf.so


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
題の通り
1.10でONNX RuntimeでもUniversal Binaryが配布される様になったので、併せてMac版のUniversal Binaryをビルドする様にし、配布名も`libcore_cpu_x64.dylib`から`libcore_cpu_universal2.dylib`に変更しました。
残念ながら、arm64な環境のテストは実行できないので、x64のみのままにしています

<img width="425" alt="スクリーンショット 2022-01-25 2 04 05" src="https://user-images.githubusercontent.com/34832037/150829630-e329508f-02de-4e74-b6b3-94ed2ceaaf74.png">


## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
- close #60 
  - @.aoirint さん、ONNX Runtime Builder側の対応感謝します...! 

## その他

これをマージしてビルドしたコアをエンジンで利用する場合は、エンジンのGitHub ActionでONNX Runtimeのバージョンアップに対応した形に修正する必要があります。
