### PR TITLE
コードはMITライセンスであることを明示する

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,6 @@ python run.py \
 
 ## ライセンス
 
-サンプルコードおよび [core.h](./core/src/core.h) は [MIT LICENSE](./LICENSE) です。
+ソースコードのライセンスは [MIT LICENSE](./LICENSE) です。
 
 [Releases](https://github.com/VOICEVOX/voicevox_core/releases) にあるビルド済みのコアライブラリは別ライセンスなのでご注意ください。


### PR DESCRIPTION
## 内容

自然言語によりコードの一部だけがMITライセンスっぽくなっていたので、コードは全部MITライセンスであることを明示してみました。


## その他

現在のコードの大半は @Yosshi999 さん作になりそうです。
MITライセンスにしちゃいたいのですが、大丈夫でしょうか･･･？👀
