### PR TITLE
Actionsのgccをバージョン9に、Ubuntuを20.04に変更

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-osx-universal2-1.10.0.tgz
             artifact_name: osx-universal2-cpu
 
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             device: gpu
             python_architecture: 'x64'
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-gpu-1.10.0.tgz
@@ -65,7 +65,7 @@ jobs:
             cc_version: '9'
             cxx_version: '9'
 
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             device: cpu-x64
             python_architecture: 'x64'
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-1.10.0.tgz
@@ -73,7 +73,7 @@ jobs:
             cc_version: '9'
             cxx_version: '9'
 
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             device: cpu-armhf
             onnxruntime_url: https://github.com/VOICEVOX/onnxruntime-builder/releases/download/1.10.0.1/onnxruntime-linux-armhf-cpu-v1.10.0.tgz
             artifact_name: linux-armhf-cpu
@@ -81,7 +81,7 @@ jobs:
             cxx_version: '9'
             arch: arm-linux-gnueabihf
 
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             device: cpu-arm64
             onnxruntime_url: https://github.com/VOICEVOX/onnxruntime-builder/releases/download/1.10.0.1/onnxruntime-linux-arm64-cpu-v1.10.0.tgz
             artifact_name: linux-arm64-cpu

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,31 +62,31 @@ jobs:
             python_architecture: 'x64'
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-gpu-1.10.0.tgz
             artifact_name: linux-x64-gpu
-            cc_version: '8'
-            cxx_version: '8'
+            cc_version: '9'
+            cxx_version: '9'
 
           - os: ubuntu-18.04
             device: cpu-x64
             python_architecture: 'x64'
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-1.10.0.tgz
             artifact_name: linux-x64-cpu
-            cc_version: '8'
-            cxx_version: '8'
+            cc_version: '9'
+            cxx_version: '9'
 
           - os: ubuntu-18.04
             device: cpu-armhf
             onnxruntime_url: https://github.com/VOICEVOX/onnxruntime-builder/releases/download/1.10.0.1/onnxruntime-linux-armhf-cpu-v1.10.0.tgz
             artifact_name: linux-armhf-cpu
-            cc_version: '8'
-            cxx_version: '8'
+            cc_version: '9'
+            cxx_version: '9'
             arch: arm-linux-gnueabihf
 
           - os: ubuntu-18.04
             device: cpu-arm64
             onnxruntime_url: https://github.com/VOICEVOX/onnxruntime-builder/releases/download/1.10.0.1/onnxruntime-linux-arm64-cpu-v1.10.0.tgz
             artifact_name: linux-arm64-cpu
-            cc_version: '8'
-            cxx_version: '8'
+            cc_version: '9'
+            cxx_version: '9'
             arch: aarch64-linux-gnu
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## 内容

Discordで議論されていた、releaseで配布されているlibcore.soをpython以外で使用すると、initializeを実行するときstd::filesystem関連でセグフォを起こし終了する問題を解決するため、github actionsで使用するgccのバージョンを9へ引き上げます

gcc9版のARMクロスコンパイルパッケージがUbuntu18.04では配布されていないようだったため、20.04に変更します

## 関連 Issue

VOICEVOX Discord 技術相談チャンネルの2022/03/04以降の発言

## その他
Windows11 WSL2 Ubuntu20.04でのみ動作検証済みです。動作検証できる方はご協力よろしくお願いします