### PR TITLE
debug用と思われるcoutを消去

### DIFF
--- a/core/src/engine/full_context_label.cpp
+++ b/core/src/engine/full_context_label.cpp
@@ -26,7 +26,6 @@ Phoneme *Phoneme::from_label(const std::string &label) {
   contexts["h1"] = string_feature_by_regex(R"(/H\:(\d+|xx)_)", label);
   contexts["i3"] = string_feature_by_regex(R"(\@(\d+|xx)\+)", label);
   contexts["j1"] = string_feature_by_regex(R"(/J\:(\d+|xx)_)", label);
-  std::cout << contexts["p3"] << std::endl;
 
   return new Phoneme(contexts, label);
 }
@@ -210,4 +209,4 @@ Utterance extract_full_context_label(OpenJTalk *openjtalk, std::string text) {
   for (std::string label : labels) phonemes.push_back(Phoneme::from_label(label));
   return Utterance::from_phonemes(phonemes);
 }
-}
+}  // namespace voicevox::core::engine

--- a/core/src/engine/full_context_label.cpp
+++ b/core/src/engine/full_context_label.cpp
@@ -1,6 +1,5 @@
 #include "full_context_label.h"
 
-#include <iostream>
 #include <regex>
 
 namespace voicevox::core::engine {


### PR DESCRIPTION
## 内容

cpp-libraryブランチにおいて`core\src\engine\full_context_label.cpp`のdebug用と思われるcoutを消去

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他
