### PR TITLE
Windows ARM64環境でビルドできない問題の改善

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "open_jtalk"]
 	path = open_jtalk
-	url = https://github.com/y-chan/open_jtalk
+	url = https://github.com/VOICEVOX/open_jtalk


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
題の通り。
mecabの問題でしたので、依存するsubmoduleを変更しておきました。
ただし、私(y-chan)のリポジトリを指しているので、それを改善するまで(OpenJTalk側に出したPRがマージされるまで)Draftにします


