### PR TITLE
DirectML対応によるActionsの問題の修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
         uses: actions/cache@v2
         id: onnxruntime-cache
         with:
-          key: onnxruntime-cache-v1-${{ hashFiles('download/onnxruntime_url.txt') }}-
+          key: onnxruntime-cache-v1-${{ hashFiles('download/onnxruntime_url.txt') }}
           path: download/onnxruntime
 
       - name: Export DirectML url to calc hash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,7 +177,7 @@ jobs:
           # strip-components
           TEMPDIR=$(mktemp -d)
           unzip download/onnxruntime.zip -d "${TEMPDIR}"
-          mv "${TEMPDIR}"/*/* download/onnxruntime/.
+          mv "${TEMPDIR}"/*/* download/onnxruntime/
           rm -rf "${TEMPDIR}"
 
           rm download/onnxruntime.zip
@@ -192,7 +192,7 @@ jobs:
           # strip-components
           TEMPDIR=$(mktemp -d)
           unzip download/onnxruntime.zip -d "${TEMPDIR}"
-          mv "${TEMPDIR}"/* download/onnxruntime/.
+          mv "${TEMPDIR}"/* download/onnxruntime/
           rm -rf "${TEMPDIR}"
 
           rm download/onnxruntime.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,7 +168,7 @@ jobs:
 
       # download/onnxruntime/lib/onnxruntime.dll
       - name: Download ONNX Runtime (zip)
-        if: ${{steps.onnxruntime-cache.outputs.cache-hit != 'true' && endsWith(matrix.onnxruntime_url, '.zip') && !endswith(matrix.artifact_name, '-directml')}}
+        if: ${{steps.onnxruntime-cache.outputs.cache-hit != 'true' && endsWith(matrix.onnxruntime_url, '.zip')
         shell: bash
         run: |
           curl -L "${{ matrix.onnxruntime_url }}" > download/onnxruntime.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
         uses: actions/cache@v2
         id: onnxruntime-cache
         with:
-          key: onnxruntime-cache-v1-${{ hashFiles('download/onnxruntime_url.txt') }}
+          key: onnxruntime-cache-v1.2-${{ hashFiles('download/onnxruntime_url.txt') }}
           path: download/onnxruntime
 
       - name: Export DirectML url to calc hash
@@ -177,22 +177,13 @@ jobs:
           # strip-components
           TEMPDIR=$(mktemp -d)
           unzip download/onnxruntime.zip -d "${TEMPDIR}"
-          mv "${TEMPDIR}"/*/* download/onnxruntime/
-          rm -rf "${TEMPDIR}"
+          
+          if [[ ${{ matrix.artifact_name }} != *-directml ]]; then
+            mv "${TEMPDIR}"/*/* download/onnxruntime/
+          else
+            mv "${TEMPDIR}"/* download/onnxruntime/
+          fi
 
-          rm download/onnxruntime.zip
-
-      - name: Download ONNX Runtime (zip, DirectML)
-        if: ${{steps.onnxruntime-cache.outputs.cache-hit != 'true' && endsWith(matrix.onnxruntime_url, '.zip') && endswith(matrix.artifact_name, '-directml')}}
-        shell: bash
-        run: |
-          curl -L "${{ matrix.onnxruntime_url }}" > download/onnxruntime.zip
-          mkdir -p download/onnxruntime
-
-          # strip-components
-          TEMPDIR=$(mktemp -d)
-          unzip download/onnxruntime.zip -d "${TEMPDIR}"
-          mv "${TEMPDIR}"/* download/onnxruntime/
           rm -rf "${TEMPDIR}"
 
           rm download/onnxruntime.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
         uses: actions/cache@v2
         id: onnxruntime-cache
         with:
-          key: onnxruntime-cache-v1-${{ hashFiles('download/onnxruntime_url.txt')- }}
+          key: onnxruntime-cache-v1-${{ hashFiles('download/onnxruntime_url.txt') }}-
           path: download/onnxruntime
 
       - name: Export DirectML url to calc hash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
         uses: actions/cache@v2
         id: onnxruntime-cache
         with:
-          key: onnxruntime-cache-v1-${{ hashFiles('download/onnxruntime_url.txt') }}
+          key: onnxruntime-cache-v1-${{ hashFiles('download/onnxruntime_url.txt')- }}
           path: download/onnxruntime
 
       - name: Export DirectML url to calc hash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,7 +168,7 @@ jobs:
 
       # download/onnxruntime/lib/onnxruntime.dll
       - name: Download ONNX Runtime (zip)
-        if: ${{steps.onnxruntime-cache.outputs.cache-hit != 'true' && endsWith(matrix.onnxruntime_url, '.zip')
+        if: steps.onnxruntime-cache.outputs.cache-hit != 'true' && endsWith(matrix.onnxruntime_url, '.zip')
         shell: bash
         run: |
           curl -L "${{ matrix.onnxruntime_url }}" > download/onnxruntime.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
         uses: actions/cache@v2
         id: onnxruntime-cache
         with:
-          key: onnxruntime-cache-v1-${{ hashFiles('download/onnxruntime_url.txt') }}
+          key: onnxruntime-cache-v1.1-${{ hashFiles('download/onnxruntime_url.txt') }}
           path: download/onnxruntime
 
       - name: Export DirectML url to calc hash
@@ -163,7 +163,7 @@ jobs:
         uses: actions/cache@v2
         id: directml-cache
         with:
-          key: directml-cache-v1.1-${{ hashFiles('download/directml_url.txt') }}
+          key: directml-cache-v1-${{ hashFiles('download/directml_url.txt') }}
           path: download/directml
 
       # download/onnxruntime/lib/onnxruntime.dll

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,12 +163,12 @@ jobs:
         uses: actions/cache@v2
         id: directml-cache
         with:
-          key: directml-cache-v1-${{ hashFiles('download/directml_url.txt') }}
+          key: directml-cache-v1.1-${{ hashFiles('download/directml_url.txt') }}
           path: download/directml
 
       # download/onnxruntime/lib/onnxruntime.dll
       - name: Download ONNX Runtime (zip)
-        if: steps.onnxruntime-cache.outputs.cache-hit != 'true' && endsWith(matrix.onnxruntime_url, '.zip') && !endswith(matrix.artifact_name, '-directml')
+        if: ${{steps.onnxruntime-cache.outputs.cache-hit != 'true' && endsWith(matrix.onnxruntime_url, '.zip') && !endswith(matrix.artifact_name, '-directml')}}
         shell: bash
         run: |
           curl -L "${{ matrix.onnxruntime_url }}" > download/onnxruntime.zip
@@ -183,7 +183,7 @@ jobs:
           rm download/onnxruntime.zip
 
       - name: Download ONNX Runtime (zip, DirectML)
-        if: steps.onnxruntime-cache.outputs.cache-hit != 'true' && endsWith(matrix.onnxruntime_url, '.zip') && endswith(matrix.artifact_name, '-directml')
+        if: ${{steps.onnxruntime-cache.outputs.cache-hit != 'true' && endsWith(matrix.onnxruntime_url, '.zip') && endswith(matrix.artifact_name, '-directml')}}
         shell: bash
         run: |
           curl -L "${{ matrix.onnxruntime_url }}" > download/onnxruntime.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,7 +168,22 @@ jobs:
 
       # download/onnxruntime/lib/onnxruntime.dll
       - name: Download ONNX Runtime (zip)
-        if: steps.onnxruntime-cache.outputs.cache-hit != 'true' && endsWith(matrix.onnxruntime_url, '.zip')
+        if: steps.onnxruntime-cache.outputs.cache-hit != 'true' && endsWith(matrix.onnxruntime_url, '.zip') && !endswith(matrix.artifact_name, '-directml')
+        shell: bash
+        run: |
+          curl -L "${{ matrix.onnxruntime_url }}" > download/onnxruntime.zip
+          mkdir -p download/onnxruntime
+
+          # strip-components
+          TEMPDIR=$(mktemp -d)
+          unzip download/onnxruntime.zip -d "${TEMPDIR}"
+          mv "${TEMPDIR}"/*/* download/onnxruntime/.
+          rm -rf "${TEMPDIR}"
+
+          rm download/onnxruntime.zip
+
+      - name: Download ONNX Runtime (zip, DirectML)
+        if: steps.onnxruntime-cache.outputs.cache-hit != 'true' && endsWith(matrix.onnxruntime_url, '.zip') && endswith(matrix.artifact_name, '-directml')
         shell: bash
         run: |
           curl -L "${{ matrix.onnxruntime_url }}" > download/onnxruntime.zip
@@ -181,9 +196,6 @@ jobs:
           rm -rf "${TEMPDIR}"
 
           rm download/onnxruntime.zip
-
-      - run: ls download
-      - run: ls download/onnxruntime
 
       # download/onnxruntime/lib/libonnxruntime.so
       # download/onnxruntime/lib/libonnxruntime.dylib

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
         uses: actions/cache@v2
         id: onnxruntime-cache
         with:
-          key: onnxruntime-cache-v1-${{ hashFiles('download/onnxruntime_url.txt') }}
+          key: onnxruntime-cache-v1.1-${{ hashFiles('download/onnxruntime_url.txt') }}
           path: download/onnxruntime
 
       - name: Export DirectML url to calc hash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
         uses: actions/cache@v2
         id: onnxruntime-cache
         with:
-          key: onnxruntime-cache-v1.2-${{ hashFiles('download/onnxruntime_url.txt') }}
+          key: onnxruntime-cache-v1-${{ hashFiles('download/onnxruntime_url.txt') }}
           path: download/onnxruntime
 
       - name: Export DirectML url to calc hash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
         uses: actions/cache@v2
         id: onnxruntime-cache
         with:
-          key: onnxruntime-cache-v1.1-${{ hashFiles('download/onnxruntime_url.txt') }}
+          key: onnxruntime-cache-v1-${{ hashFiles('download/onnxruntime_url.txt') }}
           path: download/onnxruntime
 
       - name: Export DirectML url to calc hash


### PR DESCRIPTION
## 内容

Actionsでonnxruntimeをダウンロードする際、ファイルコピーのパスをDirectMLに合わせた事によって通常版でのコピーに失敗していたので、修正しました

## その他

Actionsのcacheによってダウンロードがスキップされていたことでこちらのリポジトリでは問題が現れませんでした。