### PR TITLE
C API定義の改善と実装を行った(既存実装に影響でない範囲で)

### DIFF
--- a/core/src/core.h
+++ b/core/src/core.h
@@ -28,9 +28,9 @@ extern "C" {
  */
 typedef enum {
   // 成功
-  VoicevoxResultSucceed = 0,
+  VOICEVOX_RESULT_SUCCEED = 0,
   // OpenJTalk初期化に失敗した
-  VoicevoxResultNotInitializedOpenJTalkErr = 1,
+  VOICEVOX_RESULT_NOT_INITIALIZE_OPEN_JTALK_ERR = 1,
 } VoicevoxResultCode;
 /**
  * @fn
@@ -135,12 +135,12 @@ VOICEVOX_CORE_API VoicevoxResultCode voicevox_initialize_openjtalk(const char *d
  * text to spearchを実行する
  * @param text 音声データに変換するtextデータ
  * @param speaker_id 話者番号
- * @param binary_size 音声データのサイズ
- * @param out 音声データを出力する先のポインタ。使用が終わったらvoicevox_wav_freeで開放する必要がある
+ * @param output_binary_size 音声データのサイズを出力する先のポインタ
+ * @param output_wav 音声データを出力する先のポインタ。使用が終わったらvoicevox_wav_freeで開放する必要がある
  * @return 結果コード
  */
-VOICEVOX_CORE_API VoicevoxResultCode voicevox_tts(const char *text, int64_t speaker_id, int *binary_size,
-                                                  uint8_t **wav_out);
+VOICEVOX_CORE_API VoicevoxResultCode voicevox_tts(const char *text, int64_t speaker_id, int *output_binary_size,
+                                                  uint8_t **output_wav);
 
 /**
  * @fn

--- a/core/src/core.h
+++ b/core/src/core.h
@@ -16,6 +16,22 @@
 #include <stdint.h>
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @enum
+ * 結果コード
+ * エラーの種類が増えたら定義を増やす。
+ * 必ずエラーの値を明示的に指定すること
+ */
+typedef enum {
+  // 成功
+  VoicevoxResultSucceed = 0,
+  // OpenJTalk初期化に失敗した
+  VoicevoxResultNotInitializedOpenJTalkErr = 1,
+} VoicevoxResultCode;
 /**
  * @fn
  * 初期化する
@@ -28,7 +44,7 @@
  * 何度も実行可能。use_gpuを変更して実行しなおすことも可能。
  * 最後に実行したuse_gpuに従って他の関数が実行される。
  */
-extern "C" VOICEVOX_CORE_API bool initialize(const char *root_dir_path, bool use_gpu, int cpu_num_threads = 0);
+VOICEVOX_CORE_API bool initialize(const char *root_dir_path, bool use_gpu, int cpu_num_threads = 0);
 
 /**
  * @fn
@@ -38,7 +54,7 @@ extern "C" VOICEVOX_CORE_API bool initialize(const char *root_dir_path, bool use
  * 何度も実行可能。実行せずにexitしても大抵の場合問題ないが、
  * CUDAを利用している場合これを実行しておかないと例外が起こることがある。
  */
-extern "C" VOICEVOX_CORE_API void finalize();
+VOICEVOX_CORE_API void finalize();
 
 /**
  * @fn
@@ -46,7 +62,7 @@ extern "C" VOICEVOX_CORE_API void finalize();
  * @brief 話者名や話者IDのリストを取得する
  * @return メタ情報が格納されたjson形式の文字列
  */
-extern "C" VOICEVOX_CORE_API const char *metas();
+VOICEVOX_CORE_API const char *metas();
 
 /**
  * @fn
@@ -54,7 +70,7 @@ extern "C" VOICEVOX_CORE_API const char *metas();
  * @brief cpu, cudaのうち、使用可能なデバイス情報を取得する
  * @return 各デバイスが使用可能かどうかをboolで格納したjson形式の文字列
  */
-extern "C" VOICEVOX_CORE_API const char *supported_devices();
+VOICEVOX_CORE_API const char *supported_devices();
 
 /**
  * @fn
@@ -65,8 +81,7 @@ extern "C" VOICEVOX_CORE_API const char *supported_devices();
  * @param speaker_id 話者番号
  * @return 音素ごとの長さ
  */
-extern "C" VOICEVOX_CORE_API bool yukarin_s_forward(int64_t length, int64_t *phoneme_list, int64_t *speaker_id,
-                                                    float *output);
+VOICEVOX_CORE_API bool yukarin_s_forward(int64_t length, int64_t *phoneme_list, int64_t *speaker_id, float *output);
 
 /**
  * @fn
@@ -82,11 +97,10 @@ extern "C" VOICEVOX_CORE_API bool yukarin_s_forward(int64_t length, int64_t *pho
  * @param speaker_id 話者番号
  * @return モーラごとの音高
  */
-extern "C" VOICEVOX_CORE_API bool yukarin_sa_forward(int64_t length, int64_t *vowel_phoneme_list,
-                                                     int64_t *consonant_phoneme_list, int64_t *start_accent_list,
-                                                     int64_t *end_accent_list, int64_t *start_accent_phrase_list,
-                                                     int64_t *end_accent_phrase_list, int64_t *speaker_id,
-                                                     float *output);
+VOICEVOX_CORE_API bool yukarin_sa_forward(int64_t length, int64_t *vowel_phoneme_list, int64_t *consonant_phoneme_list,
+                                          int64_t *start_accent_list, int64_t *end_accent_list,
+                                          int64_t *start_accent_phrase_list, int64_t *end_accent_phrase_list,
+                                          int64_t *speaker_id, float *output);
 
 /**
  * @fn
@@ -99,18 +113,52 @@ extern "C" VOICEVOX_CORE_API bool yukarin_sa_forward(int64_t length, int64_t *vo
  * @param speaker_id 話者番号
  * @return 音声波形
  */
-extern "C" VOICEVOX_CORE_API bool decode_forward(int64_t length, int64_t phoneme_size, float *f0, float *phoneme,
-                                                 int64_t *speaker_id, float *output);
+VOICEVOX_CORE_API bool decode_forward(int64_t length, int64_t phoneme_size, float *f0, float *phoneme,
+                                      int64_t *speaker_id, float *output);
 
 /**
  * @fn
  * 最後に発生したエラーのメッセージを取得する
  * @return エラーメッセージ
  */
-extern "C" VOICEVOX_CORE_API const char *last_error_message();
+VOICEVOX_CORE_API const char *last_error_message();
 
-extern "C" VOICEVOX_CORE_API bool initialize_openjtalk(const char *dict_path);
+/**
+ * @fn
+ * open jtalkを初期化する
+ * @return 結果コード
+ */
+VOICEVOX_CORE_API VoicevoxResultCode voicevox_initialize_openjtalk(const char *dict_path);
 
-extern "C" VOICEVOX_CORE_API uint8_t *voicevox_tts(const char *text, int64_t *speaker_id, int *file_size);
+/**
+ * @fn
+ * text to spearchを実行する
+ * @param text 音声データに変換するtextデータ
+ * @param speaker_id 話者番号
+ * @param binary_size 音声データのサイズ
+ * @param out 音声データを出力する先のポインタ。使用が終わったらvoicevox_wav_freeで開放する必要がある
+ * @return 結果コード
+ */
+VOICEVOX_CORE_API VoicevoxResultCode voicevox_tts(const char *text, int64_t speaker_id, int binary_size,
+                                                  uint8_t **wav_out);
 
-extern "C" VOICEVOX_CORE_API void voicevox_wav_free(uint8_t *wav);
+/**
+ * @fn
+ * voicevox_ttsで生成した音声データを開放する
+ * @param wav 開放する音声データのポインタ
+ */
+VOICEVOX_CORE_API void voicevox_wav_free(uint8_t *wav);
+
+/**
+ * @fn
+ * エラーで返ってきた結果コードをメッセージに変換する
+ * @return エラーメッセージ文字列
+ */
+VOICEVOX_CORE_API const char *voicevox_error_result_to_message(VoicevoxResultCode result_code);
+
+#ifdef __cplusplus
+}
+#endif
+
+// 使い終わったマクロ定義は不要なので解除する
+#undef VOICEVOX_CORE_API

--- a/core/src/core.h
+++ b/core/src/core.h
@@ -139,7 +139,7 @@ VOICEVOX_CORE_API VoicevoxResultCode voicevox_initialize_openjtalk(const char *d
  * @param out 音声データを出力する先のポインタ。使用が終わったらvoicevox_wav_freeで開放する必要がある
  * @return 結果コード
  */
-VOICEVOX_CORE_API VoicevoxResultCode voicevox_tts(const char *text, int64_t speaker_id, int binary_size,
+VOICEVOX_CORE_API VoicevoxResultCode voicevox_tts(const char *text, int64_t speaker_id, int *binary_size,
                                                   uint8_t **wav_out);
 
 /**

--- a/core/src/engine.cpp
+++ b/core/src/engine.cpp
@@ -7,48 +7,45 @@
 #include "engine/openjtalk.h"
 #include "engine/synthesis_engine.h"
 
-#define NOT_INITIALIZED_OPENJTALK_ERR "Call initialize_openjtalk() first."
-
 using namespace voicevox::core::engine;
 
 static OpenJTalk *openjtalk = nullptr;
 static SynthesisEngine *engine = nullptr;
 
-bool initialize_openjtalk(const char *dict_path) {
+VoicevoxResultCode voicevox_initialize_openjtalk(const char *dict_path) {
   // TODO: error handling
   openjtalk = new OpenJTalk(dict_path);
-  return true;
+  return VoicevoxResultSucceed;
 }
 
-
-uint8_t *voicevox_tts(const char *text, int64_t *speaker_id, int *binary_size) {
+VoicevoxResultCode voicevox_tts(const char *text, int64_t speaker_id, int binary_size, uint8_t **wav_out) {
   if (openjtalk == nullptr) {
-    throw std::runtime_error(NOT_INITIALIZED_OPENJTALK_ERR);
+    return VoicevoxResultNotInitializedOpenJTalkErr;
   }
   if (engine == nullptr) {
     engine = new SynthesisEngine(openjtalk);
   }
 
-  std::vector<AccentPhraseModel> accent_phrases = engine->create_accent_phrases(std::string(text), speaker_id);
+  std::vector<AccentPhraseModel> accent_phrases = engine->create_accent_phrases(std::string(text), &speaker_id);
   const AudioQueryModel audio_query = {
-    accent_phrases,
-    1.0f,
-    0.0f,
-    1.0f,
-    1.0f,
-    0.1f,
-    0.1f,
-    engine->default_sampling_rate,
-    false,
-    "",
+      accent_phrases, 1.0f, 0.0f, 1.0f, 1.0f, 0.1f, 0.1f, engine->default_sampling_rate, false, "",
   };
 
-  const auto wav = engine->synthesis_wave_format(audio_query, speaker_id, binary_size);
-  auto* wav_heap = new uint8_t[*binary_size];
-  std::copy(wav.begin(),wav.end(),wav_heap);
-  return wav_heap;
+  const auto wav = engine->synthesis_wave_format(audio_query, &speaker_id, &binary_size);
+  auto *wav_heap = new uint8_t[binary_size];
+  std::copy(wav.begin(), wav.end(), wav_heap);
+  *wav_out = wav_heap;
+  return VoicevoxResultSucceed;
 }
 
-void voicevox_wav_free(uint8_t *wav) {
-  delete wav;
+void voicevox_wav_free(uint8_t *wav) { delete wav; }
+
+const char *voicevox_error_result_to_message(VoicevoxResultCode result_code) {
+  switch (result_code) {
+    case VoicevoxResultNotInitializedOpenJTalkErr:
+      return "Call initialize_openjtalk() first.";
+
+    default:
+      throw std::runtime_error("Unexpected error result code.");
+  }
 }

--- a/core/src/engine.cpp
+++ b/core/src/engine.cpp
@@ -18,7 +18,7 @@ VoicevoxResultCode voicevox_initialize_openjtalk(const char *dict_path) {
   return VoicevoxResultSucceed;
 }
 
-VoicevoxResultCode voicevox_tts(const char *text, int64_t speaker_id, int binary_size, uint8_t **wav_out) {
+VoicevoxResultCode voicevox_tts(const char *text, int64_t speaker_id, int *binary_size, uint8_t **wav_out) {
   if (openjtalk == nullptr) {
     return VoicevoxResultNotInitializedOpenJTalkErr;
   }
@@ -31,8 +31,8 @@ VoicevoxResultCode voicevox_tts(const char *text, int64_t speaker_id, int binary
       accent_phrases, 1.0f, 0.0f, 1.0f, 1.0f, 0.1f, 0.1f, engine->default_sampling_rate, false, "",
   };
 
-  const auto wav = engine->synthesis_wave_format(audio_query, &speaker_id, &binary_size);
-  auto *wav_heap = new uint8_t[binary_size];
+  const auto wav = engine->synthesis_wave_format(audio_query, &speaker_id, binary_size);
+  auto *wav_heap = new uint8_t[*binary_size];
   std::copy(wav.begin(), wav.end(), wav_heap);
   *wav_out = wav_heap;
   return VoicevoxResultSucceed;

--- a/core/src/engine.cpp
+++ b/core/src/engine.cpp
@@ -15,12 +15,12 @@ static SynthesisEngine *engine = nullptr;
 VoicevoxResultCode voicevox_initialize_openjtalk(const char *dict_path) {
   // TODO: error handling
   openjtalk = new OpenJTalk(dict_path);
-  return VoicevoxResultSucceed;
+  return VOICEVOX_RESULT_SUCCEED;
 }
 
-VoicevoxResultCode voicevox_tts(const char *text, int64_t speaker_id, int *binary_size, uint8_t **wav_out) {
+VoicevoxResultCode voicevox_tts(const char *text, int64_t speaker_id, int *output_binary_size, uint8_t **output_wav) {
   if (openjtalk == nullptr) {
-    return VoicevoxResultNotInitializedOpenJTalkErr;
+    return VOICEVOX_RESULT_NOT_INITIALIZE_OPEN_JTALK_ERR;
   }
   if (engine == nullptr) {
     engine = new SynthesisEngine(openjtalk);
@@ -31,18 +31,18 @@ VoicevoxResultCode voicevox_tts(const char *text, int64_t speaker_id, int *binar
       accent_phrases, 1.0f, 0.0f, 1.0f, 1.0f, 0.1f, 0.1f, engine->default_sampling_rate, false, "",
   };
 
-  const auto wav = engine->synthesis_wave_format(audio_query, &speaker_id, binary_size);
-  auto *wav_heap = new uint8_t[*binary_size];
+  const auto wav = engine->synthesis_wave_format(audio_query, &speaker_id, output_binary_size);
+  auto *wav_heap = new uint8_t[*output_binary_size];
   std::copy(wav.begin(), wav.end(), wav_heap);
-  *wav_out = wav_heap;
-  return VoicevoxResultSucceed;
+  *output_wav = wav_heap;
+  return VOICEVOX_RESULT_SUCCEED;
 }
 
 void voicevox_wav_free(uint8_t *wav) { delete wav; }
 
 const char *voicevox_error_result_to_message(VoicevoxResultCode result_code) {
   switch (result_code) {
-    case VoicevoxResultNotInitializedOpenJTalkErr:
+    case VOICEVOX_RESULT_NOT_INITIALIZE_OPEN_JTALK_ERR:
       return "Call initialize_openjtalk() first.";
 
     default:


### PR DESCRIPTION
## 内容
- voicevox_tts内でエラー発生してもユーザーが知ることができないのでResultCode用のenumを定義し、戻り値にした
- voicevox_ttsでもともとの戻り値だった音声データのポインタはそのさらにポインタを関数の引数として受け取って成功時に出力するように変更した
- ResultCodeをメッセージに変換する関数を定義
- C言語では extern "C" を使えないのでC++を使ってるときのみ extern"C"するように変更
- VOICEVOX_CORE_APIは関数宣言時のみにあれば良いので使い終わったらundefするように変更
- engine.cpp内でthrowしてるところがあったが、他言語ではC++の例外をcatchすることができないので例外が発生したらアプリケーションが確定で終了してしまう。そのため例外を投げるのではなくError Result Codeを返すように変更した


