### PR TITLE
AquesTalkライク記法によるTTS関数の追加とそれに伴うバグの修正

### DIFF
--- a/core/src/core.h
+++ b/core/src/core.h
@@ -144,6 +144,18 @@ VOICEVOX_CORE_API VoicevoxResultCode voicevox_tts(const char *text, int64_t spea
 
 /**
  * @fn
+ * text to spearchをAquesTalkライクな記法で実行する
+ * @param text 音声データに変換するtextデータ
+ * @param speaker_id 話者番号
+ * @param output_binary_size 音声データのサイズを出力する先のポインタ
+ * @param output_wav 音声データを出力する先のポインタ。使用が終わったらvoicevox_wav_freeで開放する必要がある
+ * @return 結果コード
+ */
+VOICEVOX_CORE_API VoicevoxResultCode voicevox_tts_from_aquestalk_notation(const char *text, int64_t speaker_id,
+                                                                          int *output_binary_size,uint8_t **output_wav);
+
+/**
+ * @fn
  * voicevox_ttsで生成した音声データを開放する
  * @param wav 開放する音声データのポインタ
  */

--- a/core/src/core.h
+++ b/core/src/core.h
@@ -151,8 +151,8 @@ VOICEVOX_CORE_API VoicevoxResultCode voicevox_tts(const char *text, int64_t spea
  * @param output_wav 音声データを出力する先のポインタ。使用が終わったらvoicevox_wav_freeで開放する必要がある
  * @return 結果コード
  */
-VOICEVOX_CORE_API VoicevoxResultCode voicevox_tts_from_aquestalk_notation(const char *text, int64_t speaker_id,
-                                                                          int *output_binary_size,uint8_t **output_wav);
+VOICEVOX_CORE_API VoicevoxResultCode voicevox_tts_from_kana(const char *text, int64_t speaker_id,
+                                                            int *output_binary_size, uint8_t **output_wav);
 
 /**
  * @fn

--- a/core/src/engine.cpp
+++ b/core/src/engine.cpp
@@ -35,8 +35,8 @@ VoicevoxResultCode voicevox_tts(const char *text, int64_t speaker_id, int *outpu
   return VOICEVOX_RESULT_SUCCEED;
 }
 
-VoicevoxResultCode voicevox_tts_from_aquestalk_notation(const char *text, int64_t speaker_id, int *output_binary_size,
-                                                        uint8_t **output_wav) {
+VoicevoxResultCode voicevox_tts_from_kana(const char *text, int64_t speaker_id, int *output_binary_size,
+                                          uint8_t **output_wav) {
   std::vector<AccentPhraseModel> accent_phrases = parse_kana(std::string(text));
   accent_phrases = engine.replace_mora_data(accent_phrases, &speaker_id);
   const AudioQueryModel audio_query = {

--- a/core/src/engine.cpp
+++ b/core/src/engine.cpp
@@ -4,8 +4,8 @@
 #include <vector>
 
 #include "core.h"
-#include "engine/model.h"
 #include "engine/kana_parser.h"
+#include "engine/model.h"
 #include "engine/synthesis_engine.h"
 
 using namespace voicevox::core::engine;

--- a/core/src/engine/kana_parser.cpp
+++ b/core/src/engine/kana_parser.cpp
@@ -67,7 +67,7 @@ AccentPhraseModel text_to_accent_phrase(std::string phrase) {
   std::vector<MoraModel> moras;
 
   int base_index = 0;
-  std::string stack = "";
+  std::string stack;
   std::optional<std::string> matched_text = std::nullopt;
 
   const std::map<std::string, MoraModel> text2mora = text2mora_with_unvoice();
@@ -120,7 +120,7 @@ AccentPhraseModel text_to_accent_phrase(std::string phrase) {
 std::vector<AccentPhraseModel> parse_kana(std::string text) {
   std::vector<AccentPhraseModel> parsed_results;
 
-  std::string phrase = "";
+  std::string phrase;
 
   size_t char_size;
   for (size_t pos = 0; pos <= text.size(); pos += char_size) {
@@ -157,7 +157,7 @@ std::vector<AccentPhraseModel> parse_kana(std::string text) {
 }
 
 std::string create_kana(std::vector<AccentPhraseModel> accent_phrases) {
-  std::string text = "";
+  std::string text;
   for (int i = 0; i < accent_phrases.size(); i++) {
     AccentPhraseModel phrase = accent_phrases[i];
     std::vector<MoraModel> moras = phrase.moras;

--- a/core/src/engine/kana_parser.cpp
+++ b/core/src/engine/kana_parser.cpp
@@ -43,7 +43,7 @@ static const std::map<std::string, MoraModel> text2mora_with_unvoice() {
   return text2mora_with_unvoice;
 }
 
-std::string extract_one_character(const std::string& text, size_t pos, size_t &size) {
+std::string extract_one_character(const std::string& text, size_t pos, size_t& size) {
   // UTF-8の文字は可変長なので、leadの値で長さを判別する
   unsigned char lead = text[pos];
 

--- a/core/src/engine/kana_parser.cpp
+++ b/core/src/engine/kana_parser.cpp
@@ -65,7 +65,6 @@ AccentPhraseModel text_to_accent_phrase(std::string phrase) {
   std::optional<unsigned int> accent_index = std::nullopt;
 
   std::vector<MoraModel> moras;
-  int count = 0;
 
   int base_index = 0;
   std::string stack = "";
@@ -102,8 +101,7 @@ AccentPhraseModel text_to_accent_phrase(std::string phrase) {
     if (matched_text == std::nullopt) {
       throw std::runtime_error("unknown text in accent phrase: " + stack);
     } else {
-      moras[count] = text2mora.at(*matched_text);
-      count++;
+      moras.push_back(text2mora.at(*matched_text));
       base_index += matched_text->size();
       stack = "";
       matched_text = std::nullopt;
@@ -123,7 +121,7 @@ std::vector<AccentPhraseModel> parse_kana(std::string text) {
   std::vector<AccentPhraseModel> parsed_results;
 
   std::string phrase = "";
-  int count = 0;
+
   size_t char_size;
   for (size_t pos = 0; pos <= text.size(); pos += char_size) {
     std::string letter;
@@ -150,8 +148,7 @@ std::vector<AccentPhraseModel> parse_kana(std::string text) {
         accent_phrase.pause_mora = pause_mora;
       }
       accent_phrase.is_interrogative = is_interrogative;
-      parsed_results[count] = accent_phrase;
-      count++;
+      parsed_results.push_back(accent_phrase);
       phrase = "";
     }
   }

--- a/core/src/engine/kana_parser.cpp
+++ b/core/src/engine/kana_parser.cpp
@@ -61,7 +61,7 @@ std::string extract_one_character(const std::string& text, N pos, N* size) {
   return text.substr(pos, *size);
 }
 
-AccentPhraseModel text_to_accent_phrase(std::string phrase) {
+AccentPhraseModel text_to_accent_phrase(const std::string& phrase) {
   std::optional<unsigned int> accent_index = std::nullopt;
 
   std::vector<MoraModel> moras;
@@ -117,7 +117,7 @@ AccentPhraseModel text_to_accent_phrase(std::string phrase) {
   return accent_phrase;
 }
 
-std::vector<AccentPhraseModel> parse_kana(std::string text) {
+std::vector<AccentPhraseModel> parse_kana(const std::string& text) {
   std::vector<AccentPhraseModel> parsed_results;
 
   std::string phrase;

--- a/core/src/engine/kana_parser.cpp
+++ b/core/src/engine/kana_parser.cpp
@@ -128,7 +128,6 @@ std::vector<AccentPhraseModel> parse_kana(std::string text) {
     if (pos != text.size()) {
       letter = extract_one_character(text, pos, &char_size);
     }
-    phrase += letter;
     if (pos == text.size() || letter == PAUSE_DELIMITER || letter == NOPAUSE_DELIMITER) {
       if (phrase.empty()) {
         throw std::runtime_error("accent phrase at position of " + std::to_string(parsed_results.size() + 1) +
@@ -150,6 +149,8 @@ std::vector<AccentPhraseModel> parse_kana(std::string text) {
       accent_phrase.is_interrogative = is_interrogative;
       parsed_results.push_back(accent_phrase);
       phrase = "";
+    } else {
+      phrase += letter;
     }
   }
   return parsed_results;

--- a/core/src/engine/kana_parser.cpp
+++ b/core/src/engine/kana_parser.cpp
@@ -43,6 +43,24 @@ static const std::map<std::string, MoraModel> text2mora_with_unvoice() {
   return text2mora_with_unvoice;
 }
 
+template <typename N>
+std::string extract_one_character(const std::string& text, N pos, N* size) {
+  // UTF-8の文字は可変長なので、leadの値で長さを判別する
+  unsigned char lead = text[pos];
+
+  if (lead < 0x80) {
+    *size = 1;
+  } else if (lead < 0xE0) {
+    *size = 2;
+  } else if (lead < 0xF0) {
+    *size = 3;
+  } else {
+    *size = 4;
+  }
+
+  return text.substr(pos, *size);
+}
+
 AccentPhraseModel text_to_accent_phrase(std::string phrase) {
   std::optional<unsigned int> accent_index = std::nullopt;
 

--- a/core/src/engine/kana_parser.h
+++ b/core/src/engine/kana_parser.h
@@ -16,6 +16,9 @@ const std::string WIDE_INTERROGATION_MARK = "？";
 
 static const std::map<std::string, MoraModel> text2mora_with_unvoice();
 
+template <typename N>
+std::string extract_one_character(const std::string& text, N pos, N* size);
+
 AccentPhraseModel text_to_accent_phrase(std::string phrase);
 std::vector<AccentPhraseModel> parse_kana(std::string text);
 std::string create_kana(std::vector<AccentPhraseModel> accent_phrases);

--- a/core/src/engine/kana_parser.h
+++ b/core/src/engine/kana_parser.h
@@ -16,8 +16,7 @@ const std::string WIDE_INTERROGATION_MARK = "？";
 
 static const std::map<std::string, MoraModel> text2mora_with_unvoice();
 
-template <typename N>
-std::string extract_one_character(const std::string& text, N pos, N* size);
+std::string extract_one_character(const std::string& text, size_t pos, size_t &size);
 
 AccentPhraseModel text_to_accent_phrase(const std::string& phrase);
 std::vector<AccentPhraseModel> parse_kana(const std::string& text);

--- a/core/src/engine/kana_parser.h
+++ b/core/src/engine/kana_parser.h
@@ -19,7 +19,7 @@ static const std::map<std::string, MoraModel> text2mora_with_unvoice();
 template <typename N>
 std::string extract_one_character(const std::string& text, N pos, N* size);
 
-AccentPhraseModel text_to_accent_phrase(std::string phrase);
-std::vector<AccentPhraseModel> parse_kana(std::string text);
+AccentPhraseModel text_to_accent_phrase(const std::string& phrase);
+std::vector<AccentPhraseModel> parse_kana(const std::string& text);
 std::string create_kana(std::vector<AccentPhraseModel> accent_phrases);
 }  // namespace voicevox::core::engine

--- a/core/src/engine/kana_parser.h
+++ b/core/src/engine/kana_parser.h
@@ -16,7 +16,7 @@ const std::string WIDE_INTERROGATION_MARK = "？";
 
 static const std::map<std::string, MoraModel> text2mora_with_unvoice();
 
-std::string extract_one_character(const std::string& text, size_t pos, size_t &size);
+std::string extract_one_character(const std::string& text, size_t pos, size_t& size);
 
 AccentPhraseModel text_to_accent_phrase(const std::string& phrase);
 std::vector<AccentPhraseModel> parse_kana(const std::string& text);


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
題の通りです。
元々AquesTalkライク記法を解釈するための関数(`parse_kana`)を備えていましたが、それが盛大にバグを含んでいたので、同時に修正です。

こちらに動作確認用のテストコードを置いています。
https://gist.github.com/y-chan/91f180f525be2415f7785b545e5011c1
