### PR TITLE
README の修正等

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ pip install -r requirements.txt
 python run.py \
     --text "これは本当に実行できているんですか" \
     --speaker_id 1 \
-    --root_dir_path="../../release"
 
 # 引数の紹介
 # --text 読み上げるテキスト
@@ -158,7 +157,6 @@ cd example/python
 python run.py \
     --text "これは本当に実行できているんですか" \
     --speaker_id 1 \
-    --root_dir_path="../../model"
 ```
 
 ## 事例紹介

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -28,9 +28,9 @@ message("core will be installed to: ${CMAKE_INSTALL_PREFIX}")
 # coreライブラリのビルド設定
 add_library(core
 		SHARED src/core.cpp
-    ${EMBED_YUKARIN_S_OUTPUTS} 
-		${EMBED_YUKARIN_SA_OUTPUTS} 
-		${EMBED_DECODE_OUTPUTS} 
+		${EMBED_YUKARIN_S_OUTPUTS}
+		${EMBED_YUKARIN_SA_OUTPUTS}
+		${EMBED_DECODE_OUTPUTS}
 		${EMBED_METAS_OUTPUTS}
 		src/engine/full_context_label.cpp
 		src/engine/acoustic_feature_extractor.cpp
@@ -85,7 +85,7 @@ else()
 		file(GLOB DIRECTML_LIBS
 		"${DIRECTML_DIR}/bin/${DML_ARCH}-win/*.dll"
 		"${DIRECTML_DIR}/bin/${DML_ARCH}-win/*.lib")
-	
+
 		target_include_directories(core PRIVATE ${DIRECTML_DIR}/include)
 		target_link_directories(core PUBLIC ${DIRECTML_DIR}/bin/${DML_ARCH}-win/)
 		target_link_libraries(core PUBLIC directml)


### PR DESCRIPTION
## 内容

#99 のマージに際してやり残した修正です。

- `example/python/run.py` の `--root_path_dir` 引数がなくなったので、それを README に反映
- main ブランチとのコンリフクト解消時に `core/CMakeLists.txt` 内のインデントを適当にしてしまった部分の修正
