### PR TITLE
libファイルをArtifactsのzipに含める

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -283,7 +283,7 @@ jobs:
           mkdir artifact
 
           # remove files with duplicate names to create a flat release archive
-          rm -vf core/lib/core.h core/lib/core.lib
+          rm -vf core/lib/core.h
 
           # copy Windows DLL if exists
           cp -v core/lib/core* artifact/ || true


### PR DESCRIPTION
## 内容

Windowsで暗黙的リンクできるように、libファイルをArtifactsのzipに含めます。
#112 は、暗黙的リンクを使用しています。

## 関連 Issue

とくになし

## その他

Releaseへのアップロードに失敗します。
モデルファイル埋め込みによるサイズの増加が原因だと思うので、#111 がマージされると解消されると思います。

