### PR TITLE
DirectMLの対応CPUアーキテクチャ減らす

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,34 +53,12 @@ jobs:
             artifact_name: windows-arm-cpu
 
           - os: windows-2019
-            device: directml-x64
+            device: directml
             python_architecture: 'x64'
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/Microsoft.ML.OnnxRuntime.DirectML.1.10.0.zip
             directml_url: https://www.nuget.org/api/v2/package/Microsoft.AI.DirectML/1.8.0
             cmake_additional_options: -DDIRECTML=ON -DDIRECTML_DIR=download/directml
             artifact_name: windows-x64-directml
-
-          - os: windows-2019
-            device: directml-x86
-            python_architecture: 'x86'
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/Microsoft.ML.OnnxRuntime.DirectML.1.10.0.zip
-            directml_url: https://www.nuget.org/api/v2/package/Microsoft.AI.DirectML/1.8.0
-            cmake_additional_options: -DCMAKE_GENERATOR_PLATFORM=Win32 -DDIRECTML=ON -DDIRECTML_DIR=download/directml
-            artifact_name: windows-x86-directml
-
-          - os: windows-2019
-            device: directml-arm64
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/Microsoft.ML.OnnxRuntime.DirectML.1.10.0.zip
-            directml_url: https://www.nuget.org/api/v2/package/Microsoft.AI.DirectML/1.8.0
-            cmake_additional_options: -DCMAKE_GENERATOR_PLATFORM=arm64 -DDIRECTML=ON -DDIRECTML_DIR=download/directml
-            artifact_name: windows-arm64-directml
-
-          - os: windows-2019
-            device: directml-arm
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/Microsoft.ML.OnnxRuntime.DirectML.1.10.0.zip
-            directml_url: https://www.nuget.org/api/v2/package/Microsoft.AI.DirectML/1.8.0
-            cmake_additional_options: -DCMAKE_GENERATOR_PLATFORM=arm -DDIRECTML=ON -DDIRECTML_DIR=download/directml
-            artifact_name: windows-arm-directml
 
           - os: macos-10.15
             device: cpu-x64
@@ -328,9 +306,6 @@ jobs:
           readarray -t MAPPINGS <<EOF
           windows-x64-cuda
           windows-x64-directml
-          windows-x86-directml
-          windows-arm64-directml
-          windows-arm-directml
           windows-x64-cpu
           windows-x86-cpu
           windows-arm64-cpu


### PR DESCRIPTION
## 内容

DirectMLが増えて、リリースするビルドが４つ増えました。
４つの違いはCPUのアーキテクチャです。１つあたり200MBを超えるので、なかなかの大容量になっています。

DirectMLの場合は、x64以外はなくてもいいのかなと思ったので、x64以外を削るPRを作ってみました。
（cuda版もx64だけなので、これで揃うと思います）

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他
