### PR TITLE
Releasesにアップロードされるzipの構造を変更

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -342,10 +342,6 @@ jobs:
           linux-arm64-cpu
           EOF
 
-          if [ -d artifacts/core ]; then
-            mv -T artifacts/core artifacts/core_
-          fi
-
           for KND in "${MAPPINGS[@]}"; do
             cp core/src/core.h "artifacts/${KND}-cpp-shared"
             echo "${{ env.BUILD_IDENTIFIER }}" > "artifacts/${KND}-cpp-shared/VERSION"
@@ -356,16 +352,6 @@ jobs:
             mv -T core "${KND}-cpp-shared"
             cd -
           done
-
-          if [ -d artifacts/core_ ]; then
-            mv -T artifacts/core_ artifacts/core
-          fi
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: core
-          path: artifacts/*
 
       - name: Upload to Release
         if: env.SKIP_UPLOADING_RELEASE_ASSET == '0'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -342,6 +342,10 @@ jobs:
           linux-arm64-cpu
           EOF
 
+          if [ -d artifacts/core ]; then
+            mv -T artifacts/core artifacts/core_
+          fi
+
           for KND in "${MAPPINGS[@]}"; do
             cp core/src/core.h "artifacts/${KND}-cpp-shared"
             echo "${{ env.BUILD_IDENTIFIER }}" > "artifacts/${KND}-cpp-shared/VERSION"
@@ -352,6 +356,10 @@ jobs:
             mv -T core "${KND}-cpp-shared"
             cd -
           done
+
+          if [ -d artifacts/core_ ]; then
+            mv -T artifacts/core_ artifacts/core
+          fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -299,7 +299,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.artifact_name }}-cpp-shared
-          path: artifact/*
+          path: artifact/${{ matrix.artifact_name }}-cpp-shared/*
           retention-days: 7
 
   # Create core.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -301,7 +301,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.artifact_name }}-cpp-shared
-          path: artifact/voicevox_core-${{ matrix.artifact_name }}-*/*
+          path: artifact/voicevox_core-${{ matrix.artifact_name }}-${{ env.BUILD_IDENTIFIER }}/*
           retention-days: 7
 
   # Create core.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,7 +270,7 @@ jobs:
         run: |
           mkdir -p "artifact/${{ env.ASSET_NAME }}"
 
-          # copy Windows DLL if exists
+          # copy core.h (and Windows DLL if exists)
           cp -v core/lib/core* "artifact/${{ env.ASSET_NAME }}" || true
           # copy Linux/macOS shared library if exists
           cp -v core/lib/libcore* "artifact/${{ env.ASSET_NAME }}" || true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -311,15 +311,13 @@ jobs:
         if: github.event.release.tag_name != '' && !startsWith(matrix.os, 'windows-')
         shell: bash
         run: |
-          mkdir release
           cd artifact
-          zip -r "../release/${{ env.ASSET_NAME }}.zip" "${{ env.ASSET_NAME }}"
+          zip -r "../${{ env.ASSET_NAME }}.zip" "${{ env.ASSET_NAME }}"
 
       - name: Archive artifact (Windows)
         if: github.event.release.tag_name != '' && startsWith(matrix.os, 'windows-')
         run: |
-          mkdir release
-          powershell Compress-Archive -Path "artifact/${{ env.ASSET_NAME }}" -DestinationPath "release/${{ env.ASSET_NAME }}.zip"
+          powershell Compress-Archive -Path "artifact/${{ env.ASSET_NAME }}" -DestinationPath "${{ env.ASSET_NAME }}.zip"
 
       - name: Upload to Release
         if: github.event.release.tag_name != '' && env.SKIP_UPLOADING_RELEASE_ASSET == '0'
@@ -327,7 +325,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.ref }} # ==> github.event.release.tag_name
-          file: release/${{ env.ASSET_NAME }}.zip
+          file: ${{ env.ASSET_NAME }}.zip
 
   build-win-cpp-example:
     runs-on: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -345,9 +345,11 @@ jobs:
           for KND in "${MAPPINGS[@]}"; do
             cp core/src/core.h "artifacts/${KND}-cpp-shared"
             echo "${{ env.BUILD_IDENTIFIER }}" > "artifacts/${KND}-cpp-shared/VERSION"
-            
-            cd "artifacts/${KND}-cpp-shared"
-            zip -r "../../release/${KND}-cpp-shared.zip" *
+
+            cd artifacts
+            mv -T "${KND}-cpp-shared" core
+            zip -r "../release/${KND}-cpp-shared.zip" core
+            mv -T core "${KND}-cpp-shared"
             cd -
           done
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -277,18 +277,22 @@ jobs:
           pip install -r requirements.txt
           python setup.py test
 
+      - name: Set BUILD_IDENTIFIER env var
+        shell: bash
+        run: |
+          echo "BUILD_IDENTIFIER=${GITHUB_REF##*/}" >> $GITHUB_ENV
+
       - name: Organize artifact
         shell: bash
         run: |
-          mkdir artifact
-
-          # remove files with duplicate names to create a flat release archive
-          rm -vf core/lib/core.h
+          mkdir -p "artifact/${{ matrix.artifact_name }}-cpp-shared"
 
           # copy Windows DLL if exists
-          cp -v core/lib/core* artifact/ || true
+          cp -v core/lib/core* "artifact/${{ matrix.artifact_name }}-cpp-shared" || true
           # copy Linux/macOS shared library if exists
-          cp -v core/lib/libcore* artifact/ || true
+          cp -v core/lib/libcore* "artifact/${{ matrix.artifact_name }}-cpp-shared" || true
+
+          echo "${{ env.BUILD_IDENTIFIER }}" > "artifact/${{ matrix.artifact_name }}-cpp-shared/VERSION"
 
       # Upload
       - name: Upload artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -284,22 +284,24 @@ jobs:
 
       - name: Organize artifact
         shell: bash
+        env:
+          ZIP_NAME: voicevox_core-${{ matrix.artifact_name }}-${{ env.BUILD_IDENTIFIER }}
         run: |
-          mkdir -p "artifact/${{ matrix.artifact_name }}-cpp-shared"
+          mkdir -p "artifact/${{ env.ZIP_NAME }}"
 
           # copy Windows DLL if exists
-          cp -v core/lib/core* "artifact/${{ matrix.artifact_name }}-cpp-shared" || true
+          cp -v core/lib/core* "artifact/${{ env.ZIP_NAME }}" || true
           # copy Linux/macOS shared library if exists
-          cp -v core/lib/libcore* "artifact/${{ matrix.artifact_name }}-cpp-shared" || true
+          cp -v core/lib/libcore* "artifact/${{ env.ZIP_NAME }}" || true
 
-          echo "${{ env.BUILD_IDENTIFIER }}" > "artifact/${{ matrix.artifact_name }}-cpp-shared/VERSION"
+          echo "${{ env.BUILD_IDENTIFIER }}" > "artifact/${{ env.ZIP_NAME }}/VERSION"
 
       # Upload
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.artifact_name }}-cpp-shared
-          path: artifact/${{ matrix.artifact_name }}-cpp-shared/*
+          path: artifact/voicevox_core-${{ matrix.artifact_name }}-*/*
           retention-days: 7
 
   # Create core.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -312,7 +312,8 @@ jobs:
         shell: bash
         run: |
           mkdir release
-          zip -r "release/${{ env.ASSET_NAME }}.zip" "artifact/${{ env.ASSET_NAME }}"
+          cd artifact
+          zip -r "../release/${{ env.ASSET_NAME }}.zip" "${{ env.ASSET_NAME }}"
 
       - name: Archive artifact (Windows)
         if: github.event.release.tag_name != '' && startsWith(matrix.os, 'windows-')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -308,11 +308,17 @@ jobs:
           retention-days: 7
 
       - name: Archive artifact
-        if: github.event.release.tag_name != ''
+        if: github.event.release.tag_name != '' && !startsWith(matrix.os, 'windows-')
         shell: bash
         run: |
           mkdir release
           zip -r "release/${{ env.ASSET_NAME }}.zip" "artifact/${{ env.ASSET_NAME }}"
+
+      - name: Archive artifact (Windows)
+        if: github.event.release.tag_name != '' && startsWith(matrix.os, 'windows-')
+        run: |
+          mkdir release
+          powershell Compress-Archive -Path "artifact/${{ env.ASSET_NAME }}" -DestinationPath "release/${{ env.ASSET_NAME }}.zip"
 
       - name: Upload to Release
         if: github.event.release.tag_name != '' && env.SKIP_UPLOADING_RELEASE_ASSET == '0'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -282,26 +282,29 @@ jobs:
         run: |
           echo "BUILD_IDENTIFIER=${GITHUB_REF##*/}" >> $GITHUB_ENV
 
+      - name: Set ASSET_NAME env var
+        shell: bash
+        run: |
+          echo "ASSET_NAME=voicevox_core-${{ matrix.artifact_name }}-${{ env.BUILD_IDENTIFIER }}" >> $GITHUB_ENV
+
       - name: Organize artifact
         shell: bash
-        env:
-          ZIP_NAME: voicevox_core-${{ matrix.artifact_name }}-${{ env.BUILD_IDENTIFIER }}
         run: |
-          mkdir -p "artifact/${{ env.ZIP_NAME }}"
+          mkdir -p "artifact/${{ env.ASSET_NAME }}"
 
           # copy Windows DLL if exists
-          cp -v core/lib/core* "artifact/${{ env.ZIP_NAME }}" || true
+          cp -v core/lib/core* "artifact/${{ env.ASSET_NAME }}" || true
           # copy Linux/macOS shared library if exists
-          cp -v core/lib/libcore* "artifact/${{ env.ZIP_NAME }}" || true
+          cp -v core/lib/libcore* "artifact/${{ env.ASSET_NAME }}" || true
 
-          echo "${{ env.BUILD_IDENTIFIER }}" > "artifact/${{ env.ZIP_NAME }}/VERSION"
+          echo "${{ env.BUILD_IDENTIFIER }}" > "artifact/${{ env.ASSET_NAME }}/VERSION"
 
       # Upload
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.artifact_name }}-cpp-shared
-          path: artifact/voicevox_core-${{ matrix.artifact_name }}-${{ env.BUILD_IDENTIFIER }}/*
+          path: artifact/${{ env.ASSET_NAME }}/*
           retention-days: 7
 
   # Create core.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -307,69 +307,20 @@ jobs:
           path: artifact/${{ env.ASSET_NAME }}/*
           retention-days: 7
 
-  # Create core.zip
-  upload-to-release-cpp-shared:
-    if: github.event.release.tag_name != ''
-    needs: [build-cpp-shared]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Set BUILD_IDENTIFIER env var
-        run: |
-          echo "BUILD_IDENTIFIER=${GITHUB_REF##*/}" >> $GITHUB_ENV
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-              zip
-
-      - name: Download and extract artifact
-        uses: actions/download-artifact@v2
-        with:
-          path: artifacts/
-
-      - name: Rearchive artifacts
+      - name: Archive artifact
+        if: github.event.release.tag_name != ''
+        shell: bash
         run: |
           mkdir release
-
-          readarray -t MAPPINGS <<EOF
-          windows-x64-cuda
-          windows-x64-directml
-          windows-x86-directml
-          windows-arm64-directml
-          windows-arm-directml
-          windows-x64-cpu
-          windows-x86-cpu
-          windows-arm64-cpu
-          windows-arm-cpu
-          osx-universal2-cpu
-          linux-x64-gpu
-          linux-x64-cpu
-          linux-armhf-cpu
-          linux-arm64-cpu
-          EOF
-
-          for KND in "${MAPPINGS[@]}"; do
-            cp core/src/core.h "artifacts/${KND}-cpp-shared"
-            echo "${{ env.BUILD_IDENTIFIER }}" > "artifacts/${KND}-cpp-shared/VERSION"
-
-            cd artifacts
-            mv -T "${KND}-cpp-shared" core
-            zip -r "../release/${KND}-cpp-shared.zip" core
-            mv -T core "${KND}-cpp-shared"
-            cd -
-          done
+          zip -r "release/${{ env.ASSET_NAME }}.zip" "artifact/${{ env.ASSET_NAME }}"
 
       - name: Upload to Release
-        if: env.SKIP_UPLOADING_RELEASE_ASSET == '0'
+        if: github.event.release.tag_name != '' && env.SKIP_UPLOADING_RELEASE_ASSET == '0'
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.ref }} # ==> github.event.release.tag_name
-          file: release/*.zip
-          file_glob: true
+          file: release/${{ env.ASSET_NAME }}.zip
 
   build-win-cpp-example:
     runs-on: windows-latest

--- a/example/cpp/windows/README.md
+++ b/example/cpp/windows/README.md
@@ -13,7 +13,7 @@ Visual Studio Installerを使用しインストールしてください。
 ビルドして実行するには、「core.dll」「core.lib」「Open JTalk辞書フォルダ」が必要です。
 以下はDebug x64でビルドする場合です。他の構成・プラットフォーム向けにビルドする場合は、適宜読み替えてください。  
 
-Releasesから「windows-x64-cpu-cpp-shared.zip」をダウンロードします。
+Releasesから「voicevox_core-windows-x64-cpu-{バージョン名}.zip」をダウンロードします。
 zipファイルを展開し、展開されたフォルダに含まれているdllファイルを「core.dll」にリネームします。
 出力フォルダを作成するために、一度ビルドします。「windows_example.sln」をVisual Studioで開き、メニューの「ビルド」→「ソリューションのビルド」を押します。
 この段階では、ビルドは失敗します。「bin」フォルダと「lib」フォルダが生成されていればOKです。  


### PR DESCRIPTION
## 内容

現在 Releases にアップロードされる zip ファイルは、ダウンロードして `unzip` や `7z` のコマンド等で解凍すると解凍時のカレントディレクトリに直接中身が展開されるようになっています。

これまでは `core.zip` をダウンロードして解凍すると `core` ディレクトリ以下に内容が入っている状態で展開されました。それと同様になるように（解凍すると `core` ディレクトリ以下にファイル群が存在するように）zip の生成方法を変更しました。

https://github.com/PickledChair/voicevox_core/releases/tag/0.12.0-pickledchair-1 で試しにリリースしたものを公開しています。 ~~また、実装はしたのですが、修正やコメント追加等を行いたいので draft とさせていただきます。~~

## その他

以前から、`upload-to-release-cpp-shared` ジョブが走るときは `core.zip` の内容を core という artifact としてアップロードするようになっています。#111 の変更においても、Releases にアップロードされる内容を core の中に全てアップロードしています。しかし、ライブラリ１ファイルあたりのバイナリサイズがかなり大きくなったため、core のサイズも顕著に大きくなりました（OSS版であっても core のサイズは 800 MB 以上になっています。 https://github.com/PickledChair/voicevox_core/actions/runs/2176719929 で確認できます。製品版ではさらに大きくなっていると予想しています）。今回の変更でこの core の存在が少しネックになったこともあって、これをどのように扱うべきか（アップロードしない or プラットフォームごとに分割してアップロードする、等）意見を聞かせていただき、必要であればこの PR で合わせて対応したいと考えました。特に、 #33 でこの部分を実装された @aoirint さんからご意見が頂ければ嬉しいです。