### PR TITLE
static castやnullopt比較をやめ、value関数などを使うようにする

### DIFF
--- a/core/src/engine/full_context_label.cpp
+++ b/core/src/engine/full_context_label.cpp
@@ -40,14 +40,14 @@ bool Phoneme::is_pause() const { return contexts.at("f1") == "xx"; }
 void Mora::set_context(const std::string &key, const std::string &value) {
   vowel.contexts[key] = value;
 
-  if (!consonant.has_value()) {
+  if (!consonant) {
     consonant.value().contexts[key] = value;
   }
 }
 
 std::vector<Phoneme> Mora::phonemes() const {
   std::vector<Phoneme> phonemes;
-  if (consonant.has_value()) {
+  if (consonant) {
     phonemes = {consonant.value(), vowel};
   } else {
     phonemes = {vowel};

--- a/core/src/engine/kana_parser.cpp
+++ b/core/src/engine/kana_parser.cpp
@@ -97,13 +97,13 @@ AccentPhraseModel text_to_accent_phrase(const std::string& phrase) {
         matched_text = stack;
       }
     }
-    if (matched_text == std::nullopt) {
-      throw std::runtime_error("unknown text in accent phrase: " + stack);
-    } else {
-      moras.push_back(text2mora.at(*matched_text));
+    if (matched_text.has_value()) {
+      moras.push_back(text2mora.at(matched_text.value()));
       base_index += matched_text->size();
       stack = "";
       matched_text = std::nullopt;
+    } else {
+      throw std::runtime_error("unknown text in accent phrase: " + stack);
     }
     if (outer_loop > LOOP_LIMIT) throw std::runtime_error("detect infinity loop!");
   }
@@ -111,7 +111,7 @@ AccentPhraseModel text_to_accent_phrase(const std::string& phrase) {
 
   AccentPhraseModel accent_phrase = {
       moras,
-      static_cast<unsigned int>(*accent_index),
+      accent_index.value(),
   };
   return accent_phrase;
 }
@@ -178,7 +178,7 @@ std::string create_kana(std::vector<AccentPhraseModel> accent_phrases) {
     }
 
     if (i < accent_phrases.size()) {
-      if (phrase.pause_mora != std::nullopt)
+      if (phrase.pause_mora.has_value())
         text += PAUSE_DELIMITER;
       else
         text += NOPAUSE_DELIMITER;

--- a/core/src/engine/kana_parser.cpp
+++ b/core/src/engine/kana_parser.cpp
@@ -97,7 +97,7 @@ AccentPhraseModel text_to_accent_phrase(const std::string& phrase) {
         matched_text = stack;
       }
     }
-    if (matched_text.has_value()) {
+    if (matched_text) {
       moras.push_back(text2mora.at(matched_text.value()));
       base_index += matched_text->size();
       stack = "";
@@ -178,7 +178,7 @@ std::string create_kana(std::vector<AccentPhraseModel> accent_phrases) {
     }
 
     if (i < accent_phrases.size()) {
-      if (phrase.pause_mora.has_value())
+      if (phrase.pause_mora)
         text += PAUSE_DELIMITER;
       else
         text += NOPAUSE_DELIMITER;

--- a/core/src/engine/synthesis_engine.cpp
+++ b/core/src/engine/synthesis_engine.cpp
@@ -20,8 +20,8 @@ std::vector<MoraModel> to_flatten_moras(std::vector<AccentPhraseModel> accent_ph
     for (MoraModel mora : moras) {
       flatten_moras.push_back(mora);
     }
-    if (accent_phrase.pause_mora != std::nullopt) {
-      MoraModel pause_mora = static_cast<MoraModel>(*accent_phrase.pause_mora);
+    if (accent_phrase.pause_mora.has_value()) {
+      MoraModel pause_mora = accent_phrase.pause_mora.value();
       flatten_moras.push_back(pause_mora);
     }
   }
@@ -204,7 +204,7 @@ std::vector<AccentPhraseModel> SynthesisEngine::replace_phoneme_length(std::vect
     std::vector<MoraModel> moras = accent_phrase.moras;
     for (size_t j = 0; j < moras.size(); j++) {
       MoraModel mora = moras[j];
-      if (mora.consonant != std::nullopt) {
+      if (mora.consonant.has_value()) {
         mora.consonant_length = phoneme_length[vowel_indexes_data[index + 1] - 1];
       }
       mora.vowel_length = phoneme_length[vowel_indexes_data[index + 1]];
@@ -212,7 +212,7 @@ std::vector<AccentPhraseModel> SynthesisEngine::replace_phoneme_length(std::vect
       moras[j] = mora;
     }
     accent_phrase.moras = moras;
-    if (accent_phrase.pause_mora != std::nullopt) {
+    if (accent_phrase.pause_mora.has_value()) {
       std::optional<MoraModel> pause_mora = accent_phrase.pause_mora;
       pause_mora->vowel_length = phoneme_length[vowel_indexes_data[index + 1]];
       index++;
@@ -310,7 +310,7 @@ std::vector<AccentPhraseModel> SynthesisEngine::replace_mora_pitch(std::vector<A
       moras[j] = mora;
     }
     accent_phrase.moras = moras;
-    if (accent_phrase.pause_mora != std::nullopt) {
+    if (accent_phrase.pause_mora.has_value()) {
       std::optional<MoraModel> pause_mora = accent_phrase.pause_mora;
       pause_mora->pitch = f0_list[index + 1];
       index++;
@@ -427,8 +427,8 @@ std::vector<float> SynthesisEngine::synthesis(AudioQueryModel query, int64_t *sp
   int count = 0;
 
   for (MoraModel mora : flatten_moras) {
-    if (mora.consonant != std::nullopt) {
-      phoneme_length_list.push_back(static_cast<float>(*mora.consonant_length));
+    if (mora.consonant.has_value()) {
+      phoneme_length_list.push_back(mora.consonant_length.value());
     }
     phoneme_length_list.push_back(mora.vowel_length);
     float f0_single = mora.pitch * std::pow(2.0f, pitch_scale);
@@ -509,7 +509,7 @@ void SynthesisEngine::initial_process(std::vector<AccentPhraseModel> &accent_phr
   phoneme_str_list.push_back("pau");
   for (MoraModel mora : flatten_moras) {
     std::optional<std::string> consonant = mora.consonant;
-    if (consonant != std::nullopt) phoneme_str_list.push_back(static_cast<std::string>(*consonant));
+    if (consonant.has_value()) phoneme_str_list.push_back(consonant.value());
     phoneme_str_list.push_back(mora.vowel);
   }
   phoneme_str_list.push_back("pau");
@@ -530,11 +530,11 @@ void SynthesisEngine::create_one_accent_list(std::vector<int64_t> &accent_list, 
     else
       value = 0;
     one_accent_list.push_back(value);
-    if (mora.consonant != std::nullopt) {
+    if (mora.consonant.has_value()) {
       one_accent_list.push_back(value);
     }
   }
-  if (accent_phrase.pause_mora != std::nullopt) one_accent_list.push_back(0);
+  if (accent_phrase.pause_mora.has_value()) one_accent_list.push_back(0);
   std::copy(one_accent_list.begin(), one_accent_list.end(), std::back_inserter(accent_list));
 }
 }  // namespace voicevox::core::engine

--- a/core/src/engine/synthesis_engine.cpp
+++ b/core/src/engine/synthesis_engine.cpp
@@ -20,7 +20,7 @@ std::vector<MoraModel> to_flatten_moras(std::vector<AccentPhraseModel> accent_ph
     for (MoraModel mora : moras) {
       flatten_moras.push_back(mora);
     }
-    if (accent_phrase.pause_mora.has_value()) {
+    if (accent_phrase.pause_mora) {
       MoraModel pause_mora = accent_phrase.pause_mora.value();
       flatten_moras.push_back(pause_mora);
     }
@@ -138,7 +138,7 @@ std::vector<AccentPhraseModel> SynthesisEngine::create_accent_phrases(std::strin
         if (moras_text == "n") moras_text = "N";
         std::optional<std::string> consonant = std::nullopt;
         std::optional<float> consonant_length = std::nullopt;
-        if (mora.consonant.has_value()) {
+        if (mora.consonant) {
           consonant = mora.consonant.value().phoneme();
           consonant_length = 0.0f;
         }
@@ -204,7 +204,7 @@ std::vector<AccentPhraseModel> SynthesisEngine::replace_phoneme_length(std::vect
     std::vector<MoraModel> moras = accent_phrase.moras;
     for (size_t j = 0; j < moras.size(); j++) {
       MoraModel mora = moras[j];
-      if (mora.consonant.has_value()) {
+      if (mora.consonant) {
         mora.consonant_length = phoneme_length[vowel_indexes_data[index + 1] - 1];
       }
       mora.vowel_length = phoneme_length[vowel_indexes_data[index + 1]];
@@ -212,7 +212,7 @@ std::vector<AccentPhraseModel> SynthesisEngine::replace_phoneme_length(std::vect
       moras[j] = mora;
     }
     accent_phrase.moras = moras;
-    if (accent_phrase.pause_mora.has_value()) {
+    if (accent_phrase.pause_mora) {
       std::optional<MoraModel> pause_mora = accent_phrase.pause_mora;
       pause_mora->vowel_length = phoneme_length[vowel_indexes_data[index + 1]];
       index++;
@@ -310,7 +310,7 @@ std::vector<AccentPhraseModel> SynthesisEngine::replace_mora_pitch(std::vector<A
       moras[j] = mora;
     }
     accent_phrase.moras = moras;
-    if (accent_phrase.pause_mora.has_value()) {
+    if (accent_phrase.pause_mora) {
       std::optional<MoraModel> pause_mora = accent_phrase.pause_mora;
       pause_mora->pitch = f0_list[index + 1];
       index++;
@@ -427,7 +427,7 @@ std::vector<float> SynthesisEngine::synthesis(AudioQueryModel query, int64_t *sp
   int count = 0;
 
   for (MoraModel mora : flatten_moras) {
-    if (mora.consonant.has_value()) {
+    if (mora.consonant) {
       phoneme_length_list.push_back(mora.consonant_length.value());
     }
     phoneme_length_list.push_back(mora.vowel_length);
@@ -509,7 +509,7 @@ void SynthesisEngine::initial_process(std::vector<AccentPhraseModel> &accent_phr
   phoneme_str_list.push_back("pau");
   for (MoraModel mora : flatten_moras) {
     std::optional<std::string> consonant = mora.consonant;
-    if (consonant.has_value()) phoneme_str_list.push_back(consonant.value());
+    if (consonant) phoneme_str_list.push_back(consonant.value());
     phoneme_str_list.push_back(mora.vowel);
   }
   phoneme_str_list.push_back("pau");
@@ -530,11 +530,11 @@ void SynthesisEngine::create_one_accent_list(std::vector<int64_t> &accent_list, 
     else
       value = 0;
     one_accent_list.push_back(value);
-    if (mora.consonant.has_value()) {
+    if (mora.consonant) {
       one_accent_list.push_back(value);
     }
   }
-  if (accent_phrase.pause_mora.has_value()) one_accent_list.push_back(0);
+  if (accent_phrase.pause_mora) one_accent_list.push_back(0);
   std::copy(one_accent_list.begin(), one_accent_list.end(), std::back_inserter(accent_list));
 }
 }  // namespace voicevox::core::engine


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
最初コードを書いていたときに、`has_value`/`value`関数を知らず、後から知って、こちらの方がコードが綺麗になることがわかったので、リファクタリングとして変更しました。

ただし、一部`std::nullopt`との比較の方が直観的で可読性が高い場所があったので、そこは残してあります。