### PR TITLE
use safer text2mecab

### DIFF
--- a/core/src/engine/openjtalk.cpp
+++ b/core/src/engine/openjtalk.cpp
@@ -15,7 +15,13 @@
 namespace voicevox::core::engine {
 std::vector<std::string> OpenJTalk::extract_fullcontext(std::string text) {
   char buff[8192];
-  text2mecab(buff, text.c_str());
+  errno_t result = text2mecab(buff, 8192, text.c_str());
+  if (result == EINVAL) {
+    throw std::runtime_error("text2mecab failed: invalid parameter.");
+  }
+  if (result == ERANGE) {
+    throw std::range_error("text2mecab failed: Buffer is small.");
+  }
   Mecab_analysis(&mecab, buff);
   mecab2njd(&njd, Mecab_get_feature(&mecab), Mecab_get_size(&mecab));
   njd_set_pronunciation(&njd);


### PR DESCRIPTION
## 内容
https://github.com/VOICEVOX/open_jtalk/pull/4 に追従

text2mecabが失敗した時は例外を投げる

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

https://github.com/VOICEVOX/voicevox_core/pull/112#discussion_r844909490

> 現在のcore.dll実装には voicevox_tts に長すぎる文字列を与えるとbuffer overflowでクラッシュする

これを解決

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他
