### PR TITLE
append unit testing framework

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,14 +229,14 @@ jobs:
         if: startsWith(matrix.os, 'windows')
         shell: bash
         run: |
-          cmake -DONNXRUNTIME_DIR=download/onnxruntime ${{ matrix.cmake_additional_options }} .
+          cmake -DNO_TEST=true -DONNXRUNTIME_DIR=download/onnxruntime ${{ matrix.cmake_additional_options }} .
 
       # libcore.dylib for macOS universal
       - name: Configure (macOS)
         if: startsWith(matrix.os, 'macos')
         shell: bash
         run: |
-          env CMAKE_OSX_ARCHITECTURES="x86_64;arm64" cmake -DONNXRUNTIME_DIR=download/onnxruntime ${{ matrix.cmake_additional_options }} .
+          env CMAKE_OSX_ARCHITECTURES="x86_64;arm64" cmake -DNO_TEST=true -DONNXRUNTIME_DIR=download/onnxruntime ${{ matrix.cmake_additional_options }} .
 
       - name: Configure (Linux)
         if: startsWith(matrix.os, 'ubuntu')
@@ -245,7 +245,7 @@ jobs:
           CC: ${{ env.ARCH_PREFIX }}gcc-${{ matrix.cc_version }}
           CXX: ${{ env.ARCH_PREFIX }}g++-${{ matrix.cxx_version }}
         run: |
-          cmake -DONNXRUNTIME_DIR=download/onnxruntime ${{ matrix.cmake_additional_options }} .
+          cmake -DNO_TEST=true -DONNXRUNTIME_DIR=download/onnxruntime ${{ matrix.cmake_additional_options }} .
 
       - name: Build
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,14 +229,14 @@ jobs:
         if: startsWith(matrix.os, 'windows')
         shell: bash
         run: |
-          cmake -DNO_TEST=true -DONNXRUNTIME_DIR=download/onnxruntime ${{ matrix.cmake_additional_options }} .
+          cmake -DONNXRUNTIME_DIR=download/onnxruntime ${{ matrix.cmake_additional_options }} .
 
       # libcore.dylib for macOS universal
       - name: Configure (macOS)
         if: startsWith(matrix.os, 'macos')
         shell: bash
         run: |
-          env CMAKE_OSX_ARCHITECTURES="x86_64;arm64" cmake -DNO_TEST=true -DONNXRUNTIME_DIR=download/onnxruntime ${{ matrix.cmake_additional_options }} .
+          env CMAKE_OSX_ARCHITECTURES="x86_64;arm64" cmake -DONNXRUNTIME_DIR=download/onnxruntime ${{ matrix.cmake_additional_options }} .
 
       - name: Configure (Linux)
         if: startsWith(matrix.os, 'ubuntu')
@@ -245,7 +245,7 @@ jobs:
           CC: ${{ env.ARCH_PREFIX }}gcc-${{ matrix.cc_version }}
           CXX: ${{ env.ARCH_PREFIX }}g++-${{ matrix.cxx_version }}
         run: |
-          cmake -DNO_TEST=true -DONNXRUNTIME_DIR=download/onnxruntime ${{ matrix.cmake_additional_options }} .
+          cmake -DONNXRUNTIME_DIR=download/onnxruntime ${{ matrix.cmake_additional_options }} .
 
       - name: Build
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ directml*/
 
 # Build artifacts
 build/
+test_build/
 lib/
 bin/
 core/_core.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,7 @@ set(DEPENDENT_DLLS
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 option(DIRECTML "Enables building for DirectML" OFF)
-set(DIRECTML_DIR
-    "${CMAKE_CURRENT_SOURCE_DIR}/directml"
-    CACHE PATH "Path to ONNX Runtime")
+set(DIRECTML_DIR "${CMAKE_CURRENT_SOURCE_DIR}/directml" CACHE PATH "Path to ONNX Runtime")
 if(DIRECTML)
   # DirectML読み込み用にCPUのアーキテクチャを求める
   set(DML_ARCH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,9 @@ set(MODEL_DIR
 set(CORE_DIR
     "${CMAKE_CURRENT_SOURCE_DIR}/core"
     CACHE PATH "Path to core")
+set(DEPENDENT_DLLS
+    ""
+    CACHE INTERNAL "Dependent DLLs of core.dll")
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 add_subdirectory(core)
 add_subdirectory(open_jtalk/src)
 
-if(NOT NO_TEST)
+if(BUILD_TEST)
   enable_testing()
   add_subdirectory(tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,13 +2,22 @@ cmake_minimum_required(VERSION 3.16)
 project(VoiceVoxCore)
 
 # TODO: download onnxruntime
-set(ONNXRUNTIME_DIR "${CMAKE_CURRENT_SOURCE_DIR}/onnxruntime" CACHE PATH "Path to ONNX Runtime")
-set(MODEL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/model" CACHE PATH "Path to model")
+set(ONNXRUNTIME_DIR
+    "${CMAKE_CURRENT_SOURCE_DIR}/onnxruntime"
+    CACHE PATH "Path to ONNX Runtime")
+set(MODEL_DIR
+    "${CMAKE_CURRENT_SOURCE_DIR}/model"
+    CACHE PATH "Path to model")
+set(CORE_DIR
+    "${CMAKE_CURRENT_SOURCE_DIR}/core"
+    CACHE PATH "Path to core")
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 option(DIRECTML "Enables building for DirectML" OFF)
-set(DIRECTML_DIR "${CMAKE_CURRENT_SOURCE_DIR}/directml" CACHE PATH "Path to ONNX Runtime")
+set(DIRECTML_DIR
+    "${CMAKE_CURRENT_SOURCE_DIR}/directml"
+    CACHE PATH "Path to ONNX Runtime")
 if(DIRECTML)
   # DirectML読み込み用にCPUのアーキテクチャを求める
   set(DML_ARCH)
@@ -18,3 +27,8 @@ endif()
 
 add_subdirectory(core)
 add_subdirectory(open_jtalk/src)
+
+if(NOT NO_TEST)
+  enable_testing()
+  add_subdirectory(tests)
+endif()

--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ cmake --build . --config Release
 cmake --install .
 cd ..
 
+#(省略可能) C++のテスト実行
+ctest --test-dir build --verbose
+
 # (省略可能) pythonモジュールのテスト
 python setup.py test
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ cmake --install .
 cd ..
 
 #(省略可能) C++のテスト実行
-ctest --test-dir build --verbose
+cmake -S . -B test_build -DBUILD_TEST=YES
+cmake --build test_build
+ctest --test-dir test_build --verbose
 
 # (省略可能) pythonモジュールのテスト
 python setup.py test

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -27,6 +27,7 @@ message("core will be installed to: ${CMAKE_INSTALL_PREFIX}")
 
 file(GLOB_RECURSE core_sources "src/*.cpp")
 # coreライブラリのビルド設定
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 add_library(core
 		SHARED ${core_sources}
 		${EMBED_YUKARIN_S_OUTPUTS}
@@ -51,6 +52,9 @@ if(NOT DIRECTML)
 		"${ONNXRUNTIME_DIR}/lib/*.lib"
 		"${ONNXRUNTIME_DIR}/lib/*.so"
 		"${ONNXRUNTIME_DIR}/lib/*.so.*")
+	file(GLOB ONNXRUNTIME_DLLS
+		"${ONNXRUNTIME_DIR}/lib/*.dll")
+	set(DEPENDENT_DLLS "${DEPENDENT_DLLS};${ONNXRUNTIME_DLLS}" PARENT_SCOPE)
 	target_include_directories(core
 		PRIVATE ${ONNXRUNTIME_DIR}/include)
 	target_link_directories(core PUBLIC ${ONNXRUNTIME_DIR}/lib)
@@ -79,6 +83,9 @@ else()
 		file(GLOB DIRECTML_LIBS
 		"${DIRECTML_DIR}/bin/${DML_ARCH}-win/*.dll"
 		"${DIRECTML_DIR}/bin/${DML_ARCH}-win/*.lib")
+		file(GLOB DIRECTML_DLLS
+		"${DIRECTML_DIR}/bin/${DML_ARCH}-win/*.dll")
+		set(DEPENDENT_DLLS "${DEPENDENT_DLLS};${DIRECTML_DLLS}" PARENT_SCOPE)
 
 		target_include_directories(core PRIVATE ${DIRECTML_DIR}/include)
 		target_link_directories(core PUBLIC ${DIRECTML_DIR}/bin/${DML_ARCH}-win/)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -91,7 +91,7 @@ else()
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D DIRECTML")
 endif()
 
-set_property(TARGET core PROPERTY CXX_STANDARD 17)
+set_property(TARGET core PROPERTY CXX_STANDARD 20)
 set_property(TARGET core PROPERTY POSITION_INDEPENDENT_CODE ON) # fPIC
 # rpath設定
 if (APPLE)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -102,8 +102,13 @@ elseif (UNIX)
 endif ()
 
 target_compile_options(core PRIVATE
-	$<$<CXX_COMPILER_ID:MSVC>: /W4 /O2 /utf-8 /DVOICEVOX_CORE_EXPORTS>
-	$<$<CXX_COMPILER_ID:GNU>: -Wall -Wextra -O2 -DVOICEVOX_CORE_EXPORTS>
+	$<$<CXX_COMPILER_ID:MSVC>: /W4 /utf-8 /DVOICEVOX_CORE_EXPORTS>
+	$<$<CXX_COMPILER_ID:GNU>: -Wall -Wextra  -DVOICEVOX_CORE_EXPORTS>
+)
+
+add_compile_options(TARGET core 
+	$<$<CONFIG:Release>:$<CXX_COMPILER_ID:MSVC>: /O2>
+	$<$<CONFIG:Release>:$<CXX_COMPILER_ID:GNU>: -O2>
 )
 
 target_include_directories(core

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ target_compile_options(
   unit_test PRIVATE $<$<CXX_COMPILER_ID:MSVC>: /W4 /utf-8>
                     $<$<CXX_COMPILER_ID:GNU>: -Wall -Wextra>)
 set_property(TARGET unit_test PROPERTY CXX_STANDARD 20)
+set_property(TARGET Catch2 PROPERTY CXX_STANDARD 20)
 target_include_directories(unit_test PRIVATE ${Catch2_SOURCE_DIR}/src)
 target_include_directories(unit_test PRIVATE ${CORE_DIR}/src)
 target_link_libraries(unit_test PRIVATE Catch2::Catch2WithMain)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(VoiceVoxCoreTest)
+
+include(FetchContent)
+FetchContent_Declare(
+  Catch2
+  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+  GIT_TAG v3.0.0-preview5)
+FetchContent_MakeAvailable(Catch2)
+file(GLOB_RECURSE unit_test_files "unit_tests/*.cpp")
+add_executable(unit_test ${unit_test_files})
+target_include_directories(unit_test PRIVATE ${Catch2_SOURCE_DIR}/src)
+target_include_directories(unit_test PRIVATE ${CORE_DIR}/src)
+target_link_libraries(unit_test PRIVATE Catch2::Catch2WithMain)
+target_link_libraries(unit_test PRIVATE core)
+list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)
+include(Catch)
+include(CTest)
+catch_discover_tests(unit_test)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,12 @@ target_include_directories(unit_test PRIVATE ${Catch2_SOURCE_DIR}/src)
 target_include_directories(unit_test PRIVATE ${CORE_DIR}/src)
 target_link_libraries(unit_test PRIVATE Catch2::Catch2WithMain)
 target_link_libraries(unit_test PRIVATE core)
+if (WIN32)
+  add_custom_command(TARGET unit_test POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    "$<TARGET_FILE:core>;${DEPENDENT_DLLS}" $<TARGET_FILE_DIR:unit_test>
+    COMMAND_EXPAND_LISTS )
+endif (WIN32)
 list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)
 include(Catch)
 include(CTest)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,11 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(Catch2)
 file(GLOB_RECURSE unit_test_files "unit_tests/*.cpp")
 add_executable(unit_test ${unit_test_files})
+add_compile_options(TARGET unit_test "$<$<C_COMPILER_ID:MSVC>:/utf-8>")
+add_compile_options(TARGET unit_test "$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
+add_compile_options(TARGET unit_test
+                    "$<$<CXX_COMPILER_ID:MSVC>:/Zc:__cplusplus>")
+set_property(TARGET unit_test PROPERTY CXX_STANDARD 20)
 target_include_directories(unit_test PRIVATE ${Catch2_SOURCE_DIR}/src)
 target_include_directories(unit_test PRIVATE ${CORE_DIR}/src)
 target_link_libraries(unit_test PRIVATE Catch2::Catch2WithMain)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,10 +10,10 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(Catch2)
 file(GLOB_RECURSE unit_test_files "unit_tests/*.cpp")
 add_executable(unit_test ${unit_test_files})
-add_compile_options(TARGET unit_test "$<$<C_COMPILER_ID:MSVC>:/utf-8>")
-add_compile_options(TARGET unit_test "$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
-add_compile_options(TARGET unit_test
-                    "$<$<CXX_COMPILER_ID:MSVC>:/Zc:__cplusplus>")
+add_compile_options(TARGET unit_test 
+  "$<$<C_COMPILER_ID:MSVC>:/utf-8>"
+  "$<$<CXX_COMPILER_ID:MSVC>:/utf-8 /Zc:__cplusplus>"
+)
 set_property(TARGET unit_test PROPERTY CXX_STANDARD 20)
 target_include_directories(unit_test PRIVATE ${Catch2_SOURCE_DIR}/src)
 target_include_directories(unit_test PRIVATE ${CORE_DIR}/src)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,10 +10,9 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(Catch2)
 file(GLOB_RECURSE unit_test_files "unit_tests/*.cpp")
 add_executable(unit_test ${unit_test_files})
-add_compile_options(TARGET unit_test 
-  "$<$<C_COMPILER_ID:MSVC>:/utf-8>"
-  "$<$<CXX_COMPILER_ID:MSVC>:/utf-8 /Zc:__cplusplus>"
-)
+target_compile_options(
+  unit_test PRIVATE $<$<CXX_COMPILER_ID:MSVC>: /W4 /utf-8>
+                    $<$<CXX_COMPILER_ID:GNU>: -Wall -Wextra>)
 set_property(TARGET unit_test PROPERTY CXX_STANDARD 20)
 target_include_directories(unit_test PRIVATE ${Catch2_SOURCE_DIR}/src)
 target_include_directories(unit_test PRIVATE ${CORE_DIR}/src)

--- a/tests/unit_tests/core/engine/kana_parser_test.cpp
+++ b/tests/unit_tests/core/engine/kana_parser_test.cpp
@@ -1,0 +1,38 @@
+#include "engine/kana_parser.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
+using namespace voicevox::core::engine;
+
+TEST_CASE("extract_one_character") {
+  struct Given {
+    std::string text;
+    size_t pos;
+  };
+  struct Expected {
+    std::string one_char;
+    size_t after_size;
+  };
+  struct TestCase {
+    std::string name;
+    Given given;
+    Expected expected;
+  };
+  auto t = GENERATE(TestCase{.name = "target_is_alphabet",
+                             .given = {.text = "abcd", .pos = 2},
+                             .expected = {.one_char = "c", .after_size = 1}},
+                    TestCase{.name = "target_is_hiragana",
+                             .given = {.text = "acあd", .pos = 2},
+                             .expected = {.one_char = "あ", .after_size = 3}},
+                    TestCase{.name = "target_is_4byte_kanji",
+                             .given = {.text = "ace𠀋", .pos = 3},
+                             .expected = {.one_char = "𠀋", .after_size = 4}});
+
+  SECTION(t.name) {
+    size_t size;
+    auto actual_one_char = extract_one_character(t.given.text, t.given.pos, size);
+    CHECK(t.expected.one_char == actual_one_char);
+    CHECK(t.expected.after_size == size);
+  }
+}

--- a/tests/unit_tests/core/engine/kana_parser_test.cpp
+++ b/tests/unit_tests/core/engine/kana_parser_test.cpp
@@ -6,18 +6,16 @@
 using namespace voicevox::core::engine;
 
 TEST_CASE("extract_one_character") {
-  struct Given {
-    std::string text;
-    size_t pos;
-  };
-  struct Expected {
-    std::string one_char;
-    size_t after_size;
-  };
   struct TestCase {
     std::string name;
-    Given given;
-    Expected expected;
+    struct {
+      std::string text;
+      size_t pos;
+    } given;
+    struct {
+      std::string one_char;
+      size_t after_size;
+    } expected;
   };
   auto t = GENERATE(TestCase{.name = "target_is_alphabet",
                              .given = {.text = "abcd", .pos = 2},


### PR DESCRIPTION
## 内容
projectにunit test frameworkを導入しました。たたき台的な感じです。


## 関連 Issue

ref https://github.com/VOICEVOX/voicevox_project/issues/1#issuecomment-1115204346


## その他
とりあえず導入を急ぐのと、どういう書き口で書けるのか見せるため実装してるテストケースは一つのみです。テストケースの充実は各々その機能を実装するときにでもやっていただければと思います。
Catch2で書きましたが、とりあえずコード見たほうが議論しやすいだろうと思って書いたものであり、Catch2採用が決定してるわけではないです
またCIでのテスト実行もこのPRではやりません。PR分けたほうが良さそうなので
リリース時にはテスト実行は不要なのでCIに引数を追加してます


テストコードの配置場所についてですが、とりあえず  `tests/unit_tests` の下に実装が書いてあるソースコードに対応する感じのディレクトリ構成にしました

念の為レビュー時にWindowsでもテスト実行できることを確認していただけますでしょうか
またVSCodeに[Catch2向けの拡張](https://github.com/matepek/vscode-catch2-test-adapter) があるようです