### PR TITLE
デフォルト引数はC言語では使えないのでC++のみに有効になるように変更した

### DIFF
--- a/core/src/core.h
+++ b/core/src/core.h
@@ -43,7 +43,11 @@ typedef enum {
  * 何度も実行可能。use_gpuを変更して実行しなおすことも可能。
  * 最後に実行したuse_gpuに従って他の関数が実行される。
  */
-VOICEVOX_CORE_API bool initialize(bool use_gpu, int cpu_num_threads = 0);
+VOICEVOX_CORE_API bool initialize(bool use_gpu, int cpu_num_threads
+#ifdef __cplusplus
+                                                = 0
+#endif
+);
 
 /**
  * @fn


### PR DESCRIPTION
## 内容
core.hはC APIを意識して定義されてるが、デフォルト引数はC言語では使えないのでC++のみに有効になるように変更した

本当はデフォルト引数を消したかったが、使ってる人がいる可能性があるためC++で使ってる場合はそのままにするように修正した

