### PR TITLE
add_libraryに追加するファイルをメンテしやすいように修正

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -25,20 +25,14 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 message("core will be installed to: ${CMAKE_INSTALL_PREFIX}")
 
+file(GLOB_RECURSE core_sources "src/*.cpp")
 # coreライブラリのビルド設定
 add_library(core
-		SHARED src/core.cpp
+		SHARED ${core_sources}
 		${EMBED_YUKARIN_S_OUTPUTS}
 		${EMBED_YUKARIN_SA_OUTPUTS}
 		${EMBED_DECODE_OUTPUTS}
-		${EMBED_METAS_OUTPUTS}
-		src/engine/full_context_label.cpp
-		src/engine/acoustic_feature_extractor.cpp
-		src/engine/openjtalk.cpp
-		src/engine/kana_parser.cpp
-		src/engine/mora_list.cpp
-		src/engine/synthesis_engine.cpp
-		src/engine.cpp)
+		${EMBED_METAS_OUTPUTS})
 
 # -DONNXRUNTIME_DIRで指定されたパスをもとにonnxruntimeのライブラリを取得する。失敗した場合はfatal error
 get_filename_component(ONNXRUNTIME_DIR ${ONNXRUNTIME_DIR} ABSOLUTE)


### PR DESCRIPTION
## 内容
現在のcoreのソースコードはadd_library追加方法だと新たにcpp fileを追加するたびにadd_libraryを追加する必要がある
これではメンテの手間が増えるため、GLOB_RECURSEにより追加したsrc配下にあるcpp fileを自動的にadd_libraryするように修正した


## その他
今の実装が意図的にfile名を個別にしていてこの方法では問題あるようでしたらrejectしてください