### PR TITLE
[Rust}GitHub Actions上でRustのキャッシュが引き継がれるようにしてテストを高速に終わるようにした

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - uses: Swatinem/rust-cache@v1
       - run: cargo clippy --all-features --tests -- -D clippy::all -D warnings --no-deps
       - run: cargo fmt -- --check
 
@@ -29,6 +30,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - uses: Swatinem/rust-cache@v1
       - run: cargo test --all-features .
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## 内容

タイトル通りです

## 関連 Issue

refs #128 

## その他
使用した [GitHub Action](https://github.com/marketplace/actions/rust-cache)
