### PR TITLE
coreのビルド時にバージョン情報がちゃんと入るようにする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -277,7 +277,7 @@ jobs:
           # copy Linux/macOS shared library if exists
           cp -v core/lib/libcore* "artifact/${{ env.ASSET_NAME }}" || true
 
-          echo "${{ env.BUILD_IDENTIFIER }}" > "artifact/${{ env.ASSET_NAME }}/VERSION"
+          echo "${{ env.VERSION }}" > "artifact/${{ env.ASSET_NAME }}/VERSION"
 
           cp README.md "artifact/${{ env.ASSET_NAME }}/README.txt"
 


### PR DESCRIPTION


## 内容

ビルド時の環境変数がなくなっていて、VERSIONファイルに虚無が書き込まれていたので、直しました。


## その他

この影響で 0.12.0 のリリースのVERSIONファイルは空白になってしまっています。
