### PR TITLE
.gitignore open_jtalk_dic in example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,3 @@ release/
 # Visual Studio
 .vs/
 packages/
-
-# Example
-example/**/open_jtalk_dic_*/

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ release/
 # Visual Studio
 .vs/
 packages/
+
+# Example
+example/**/open_jtalk_dic_*/

--- a/example/python/.gitignore
+++ b/example/python/.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# OpenJTalk-dictionary's dir
+open_jtalk_dic_utf_8-*


### PR DESCRIPTION
## 内容

Open JTalk 辞書を git 管理対象以外に

`python/example/run.py` が v0.12.1 に対応したことで、`open_jtalk_dic_utf_8-x.xx` を展開する必要が生じました。これを git 管理対象外とすることで、ローカルでブランチを往復するのを楽にしたいです。

## 関連 Issue

#138