### PR TITLE
[Rust] supported_devices を実装した

### DIFF
--- a/crates/voicevox_core/src/c_export.rs
+++ b/crates/voicevox_core/src/c_export.rs
@@ -109,7 +109,7 @@ pub extern "C" fn last_error_message() -> *const c_char {
 
 #[no_mangle]
 pub extern "C" fn supported_devices() -> *const c_char {
-    internal::supported_devices().as_ptr()
+    internal::supported_devices().as_ptr() as *const c_char
 }
 
 #[no_mangle]

--- a/crates/voicevox_core/src/c_export.rs
+++ b/crates/voicevox_core/src/c_export.rs
@@ -109,7 +109,7 @@ pub extern "C" fn last_error_message() -> *const c_char {
 
 #[no_mangle]
 pub extern "C" fn supported_devices() -> *const c_char {
-    internal::supported_devices().as_ptr() as *const c_char
+    internal::supported_devices().as_ptr()
 }
 
 #[no_mangle]

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -75,7 +75,8 @@ pub fn supported_devices() -> MutexGuard<'static, String> {
     let mut supported_devices_string = SUPPORTED_DEVICES_STRING.lock().unwrap();
     supported_devices_string.replace_range(
         ..,
-        &(serde_json::to_string(&SupportedDevices::get_supported_devices().unwrap()).unwrap() + "\0")
+        &(serde_json::to_string(&SupportedDevices::get_supported_devices().unwrap()).unwrap()
+            + "\0"),
     );
     supported_devices_string
 }

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -69,14 +69,14 @@ pub fn metas() -> &'static CStr {
     &METAS_CSTRING
 }
 
-static SUPPORTED_DEVICES_STRING: Lazy<CString> = Lazy::new(|| {
+static SUPPORTED_DEVICES_CSTRING: Lazy<CString> = Lazy::new(|| {
     CString::new(
         serde_json::to_string(&SupportedDevices::get_supported_devices().unwrap()).unwrap(),
     )
     .unwrap()
 });
 pub fn supported_devices() -> &'static CStr {
-    &SUPPORTED_DEVICES_STRING
+    &SUPPORTED_DEVICES_CSTRING
 }
 
 //TODO:仮実装がlinterエラーにならないようにするための属性なのでこの関数を正式に実装する際にallow(unused_variables)を取り除くこと

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -174,3 +174,18 @@ pub const fn voicevox_error_result_to_message(result_code: VoicevoxResultCode) -
         VOICEVOX_RESULT_SUCCEED => "エラーが発生しませんでした\0",
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[rstest]
+    fn supported_devices_works() {
+        let cstr_result = supported_devices();
+        assert!(cstr_result.to_str().is_ok(), "{:?}", cstr_result);
+
+        let json_result: std::result::Result<SupportedDevices, _> =
+            serde_json::from_str(cstr_result.to_str().unwrap());
+        assert!(json_result.is_ok(), "{:?}", json_result);
+    }
+}

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -1,7 +1,6 @@
 use super::*;
 use c_export::VoicevoxResultCode;
 use once_cell::sync::Lazy;
-use serde_json;
 use std::ffi::CStr;
 use std::os::raw::c_int;
 use std::sync::{Mutex, MutexGuard};

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -3,7 +3,7 @@ use c_export::VoicevoxResultCode;
 use once_cell::sync::Lazy;
 use std::ffi::CStr;
 use std::os::raw::c_int;
-use std::sync::{Mutex, MutexGuard};
+use std::sync::Mutex;
 
 use status::*;
 use std::ffi::CString;
@@ -69,15 +69,14 @@ pub fn metas() -> &'static CStr {
     &METAS_CSTRING
 }
 
-static SUPPORTED_DEVICES_STRING: Lazy<Mutex<String>> = Lazy::new(|| Mutex::new(String::new()));
-pub fn supported_devices() -> MutexGuard<'static, String> {
-    let mut supported_devices_string = SUPPORTED_DEVICES_STRING.lock().unwrap();
-    supported_devices_string.replace_range(
-        ..,
-        &(serde_json::to_string(&SupportedDevices::get_supported_devices().unwrap()).unwrap()
-            + "\0"),
-    );
-    supported_devices_string
+static SUPPORTED_DEVICES_STRING: Lazy<CString> = Lazy::new(|| {
+    CString::new(
+        serde_json::to_string(&SupportedDevices::get_supported_devices().unwrap()).unwrap(),
+    )
+    .unwrap()
+});
+pub fn supported_devices() -> &'static CStr {
+    &SUPPORTED_DEVICES_STRING
 }
 
 //TODO:仮実装がlinterエラーにならないようにするための属性なのでこの関数を正式に実装する際にallow(unused_variables)を取り除くこと

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -1,9 +1,10 @@
 use super::*;
 use c_export::VoicevoxResultCode;
 use once_cell::sync::Lazy;
+use serde_json;
 use std::ffi::CStr;
 use std::os::raw::c_int;
-use std::sync::Mutex;
+use std::sync::{Mutex, MutexGuard};
 
 use status::*;
 use std::ffi::CString;
@@ -69,8 +70,14 @@ pub fn metas() -> &'static CStr {
     &METAS_CSTRING
 }
 
-pub fn supported_devices() -> &'static CStr {
-    unimplemented!()
+static SUPPORTED_DEVICES_STRING: Lazy<Mutex<String>> = Lazy::new(|| Mutex::new(String::new()));
+pub fn supported_devices() -> MutexGuard<'static, String> {
+    let mut supported_devices_string = SUPPORTED_DEVICES_STRING.lock().unwrap();
+    supported_devices_string.replace_range(
+        ..,
+        &(serde_json::to_string(&SupportedDevices::get_supported_devices().unwrap()).unwrap() + "\0")
+    );
+    supported_devices_string
 }
 
 //TODO:仮実装がlinterエラーにならないようにするための属性なのでこの関数を正式に実装する際にallow(unused_variables)を取り除くこと

--- a/crates/voicevox_core/src/status.rs
+++ b/crates/voicevox_core/src/status.rs
@@ -60,7 +60,7 @@ static ENVIRONMENT: Lazy<Environment> = Lazy::new(|| {
         .unwrap()
 });
 
-#[derive(Getters, Debug, Serialize)]
+#[derive(Getters, Debug, Serialize, Deserialize)]
 pub struct SupportedDevices {
     cpu: bool,
     cuda: bool,

--- a/crates/voicevox_core/src/status.rs
+++ b/crates/voicevox_core/src/status.rs
@@ -3,7 +3,7 @@ use once_cell::sync::Lazy;
 use onnxruntime::{
     environment::Environment, session::Session, GraphOptimizationLevel, LoggingLevel,
 };
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 cfg_if! {
     if #[cfg(not(feature="directml"))]{

--- a/crates/voicevox_core/src/status.rs
+++ b/crates/voicevox_core/src/status.rs
@@ -3,7 +3,7 @@ use once_cell::sync::Lazy;
 use onnxruntime::{
     environment::Environment, session::Session, GraphOptimizationLevel, LoggingLevel,
 };
-use serde::Deserialize;
+use serde::{Serialize, Deserialize};
 
 cfg_if! {
     if #[cfg(not(feature="directml"))]{
@@ -60,16 +60,10 @@ static ENVIRONMENT: Lazy<Environment> = Lazy::new(|| {
         .unwrap()
 });
 
-#[derive(Getters, Debug)]
+#[derive(Getters, Debug, Serialize)]
 pub struct SupportedDevices {
-    // TODO:supported_devices関数を実装したらこのattributeをはずす
-    #[allow(dead_code)]
     cpu: bool,
-    // TODO:supported_devices関数を実装したらこのattributeをはずす
-    #[allow(dead_code)]
     cuda: bool,
-    // TODO:supported_devices関数を実装したらこのattributeをはずす
-    #[allow(dead_code)]
     dml: bool,
 }
 


### PR DESCRIPTION
## 内容

dll で export する C API のうち `supported_devices` 関数を実装しました。

C++ の実装（以下を参照）に習って、API を叩くたびに onnxruntime 側に使用できるデバイスを問い合わせる仕様にしています（必要に応じて、文字列の初期化時のみに使用できるデバイスを取得するように変更することを検討します）。

https://github.com/VOICEVOX/voicevox_core/blob/1ca62a84d515f493b15715fc8c720e07642c5a0b/core/src/core.cpp#L262-L267

## 関連 Issue

ref #128 

## その他

このAPIを実装することで、Rust製コアをエンジンで読み込むことがとりあえず可能になります。