### PR TITLE
[Rust] load_model と is_model_loaded のテストを実装した

### DIFF
--- a/crates/voicevox_core/src/c_export.rs
+++ b/crates/voicevox_core/src/c_export.rs
@@ -62,10 +62,10 @@ fn convert_result<T>(result: Result<T>) -> (Option<T>, VoicevoxResultCode) {
                     None,
                     VoicevoxResultCode::VOICEVOX_RESULT_UNINITIALIZED_STATUS,
                 ),
-                Error::InvalidSpeakerId(_) => {
+                Error::InvalidSpeakerId { .. } => {
                     (None, VoicevoxResultCode::VOICEVOX_RESULT_INVALID_SPEAKER_ID)
                 }
-                Error::InvalidModelIndex(_) => (
+                Error::InvalidModelIndex { .. } => (
                     None,
                     VoicevoxResultCode::VOICEVOX_RESULT_INVALID_MODEL_INDEX,
                 ),

--- a/crates/voicevox_core/src/c_export.rs
+++ b/crates/voicevox_core/src/c_export.rs
@@ -89,7 +89,7 @@ pub extern "C" fn initialize(use_gpu: bool, cpu_num_threads: c_int, load_all_mod
 
 #[no_mangle]
 pub extern "C" fn load_model(speaker_id: i64) -> bool {
-    let result = lock_internal().load_model(speaker_id);
+    let result = lock_internal().load_model(speaker_id as usize);
     //TODO: VoicevoxResultCodeを返すようにする
     if let Some(err) = result.err() {
         set_message(&format!("{}", err));

--- a/crates/voicevox_core/src/c_export.rs
+++ b/crates/voicevox_core/src/c_export.rs
@@ -31,6 +31,7 @@ pub enum VoicevoxResultCode {
     VOICEVOX_RESULT_FAILED_LOAD_METAS = 5,
     VOICEVOX_RESULT_UNINITIALIZED_STATUS = 6,
     VOICEVOX_RESULT_INVALID_SPEAKER_ID = 7,
+    VOICEVOX_RESULT_INVALID_MODEL_INDEX = 8,
 }
 
 fn convert_result<T>(result: Result<T>) -> (Option<T>, VoicevoxResultCode) {
@@ -64,6 +65,10 @@ fn convert_result<T>(result: Result<T>) -> (Option<T>, VoicevoxResultCode) {
                 Error::InvalidSpeakerId(_) => {
                     (None, VoicevoxResultCode::VOICEVOX_RESULT_INVALID_SPEAKER_ID)
                 }
+                Error::InvalidModelIndex(_) => (
+                    None,
+                    VoicevoxResultCode::VOICEVOX_RESULT_INVALID_MODEL_INDEX,
+                ),
             }
         }
     }

--- a/crates/voicevox_core/src/c_export.rs
+++ b/crates/voicevox_core/src/c_export.rs
@@ -30,6 +30,7 @@ pub enum VoicevoxResultCode {
     VOICEVOX_RESULT_CANT_GPU_SUPPORT = 4,
     VOICEVOX_RESULT_FAILED_LOAD_METAS = 5,
     VOICEVOX_RESULT_UNINITIALIZED_STATUS = 6,
+    VOICEVOX_RESULT_INVALID_SPEAKER_ID = 7,
 }
 
 fn convert_result<T>(result: Result<T>) -> (Option<T>, VoicevoxResultCode) {
@@ -60,6 +61,9 @@ fn convert_result<T>(result: Result<T>) -> (Option<T>, VoicevoxResultCode) {
                     None,
                     VoicevoxResultCode::VOICEVOX_RESULT_UNINITIALIZED_STATUS,
                 ),
+                Error::InvalidSpeakerId(_) => {
+                    (None, VoicevoxResultCode::VOICEVOX_RESULT_INVALID_SPEAKER_ID)
+                }
             }
         }
     }

--- a/crates/voicevox_core/src/error.rs
+++ b/crates/voicevox_core/src/error.rs
@@ -36,10 +36,10 @@ pub enum Error {
     UninitializedStatus,
 
     #[error("{},{0}", base_error_message(VOICEVOX_RESULT_INVALID_SPEAKER_ID))]
-    InvalidSpeakerId(usize),
+    InvalidSpeakerId { speaker_id: usize },
 
     #[error("{},{0}", base_error_message(VOICEVOX_RESULT_INVALID_MODEL_INDEX))]
-    InvalidModelIndex(usize),
+    InvalidModelIndex { model_index: usize },
 }
 
 fn base_error_message(result_code: VoicevoxResultCode) -> &'static str {

--- a/crates/voicevox_core/src/error.rs
+++ b/crates/voicevox_core/src/error.rs
@@ -34,6 +34,9 @@ pub enum Error {
 
     #[error("{}", base_error_message(VOICEVOX_RESULT_UNINITIALIZED_STATUS))]
     UninitializedStatus,
+
+    #[error("{},{0}", base_error_message(VOICEVOX_RESULT_INVALID_SPEAKER_ID))]
+    InvalidSpeakerId(usize),
 }
 
 fn base_error_message(result_code: VoicevoxResultCode) -> &'static str {

--- a/crates/voicevox_core/src/error.rs
+++ b/crates/voicevox_core/src/error.rs
@@ -37,6 +37,9 @@ pub enum Error {
 
     #[error("{},{0}", base_error_message(VOICEVOX_RESULT_INVALID_SPEAKER_ID))]
     InvalidSpeakerId(usize),
+
+    #[error("{},{0}", base_error_message(VOICEVOX_RESULT_INVALID_MODEL_INDEX))]
+    InvalidModelIndex(usize),
 }
 
 fn base_error_message(result_code: VoicevoxResultCode) -> &'static str {

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -225,7 +225,8 @@ mod tests {
         assert_eq!(
             expected_ok_at_uninitialized,
             result.is_ok(),
-            "expected load_model to be failed, but succeed wrongly",
+            "expected load_model to be failed, but succeed wrongly. got result: {:?}",
+            result
         );
 
         internal

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -75,7 +75,7 @@ impl Internal {
             if let Some((model_index, _)) = get_model_index_and_speaker_id(speaker_id) {
                 status.load_model(model_index)
             } else {
-                Err(Error::InvalidSpeakerId(speaker_id))
+                Err(Error::InvalidSpeakerId { speaker_id })
             }
         } else {
             Err(Error::UninitializedStatus)

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -211,10 +211,101 @@ mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
 
+    #[fixture]
+    #[once]
+    fn internal_uninitialized() -> Internal {
+        Internal {
+            initialized: false,
+            status_option: None,
+        }
+    }
+
+    #[fixture]
+    #[once]
+    fn internal_initialized_but_model_unloaded() -> Internal {
+        let mut internal = Internal {
+            initialized: false,
+            status_option: None,
+        };
+        internal.initialize(false, 0, false).unwrap();
+        internal
+    }
+
+    #[fixture]
+    #[once]
+    fn internal_initialized_and_model_loaded() -> Internal {
+        let mut internal = Internal {
+            initialized: false,
+            status_option: None,
+        };
+        internal.initialize(false, 0, true).unwrap();
+        internal
+    }
+
     #[rstest]
-    fn supported_devices_works() {
+    #[case(0, false, true)]
+    #[case(3, false, true)]
+    fn load_model_works(
+        #[case] speaker_id: usize,
+        #[case] expected_at_uninitialized: bool,
+        #[case] expected_at_initialized: bool,
+    ) {
         let internal = Internal::new_with_mutex();
-        let cstr_result = internal.lock().unwrap().supported_devices();
+        let result = internal.lock().unwrap().load_model(speaker_id);
+        assert_eq!(
+            expected_at_uninitialized,
+            result.is_ok(),
+            "expected load_model to be failed, but succeed wrongly",
+        );
+
+        internal
+            .lock()
+            .unwrap()
+            .initialize(false, 0, false)
+            .unwrap();
+        let result = internal.lock().unwrap().load_model(speaker_id);
+        assert_eq!(
+            expected_at_initialized,
+            result.is_ok(),
+            "got load_model result: {:?}",
+            result
+        );
+    }
+
+    #[rstest]
+    #[case(0, true)]
+    #[case(1, true)]
+    #[case(3, true)]
+    fn is_model_loaded_works(
+        #[case] speaker_id: usize,
+        internal_uninitialized: &Internal,
+        internal_initialized_but_model_unloaded: &Internal,
+        internal_initialized_and_model_loaded: &Internal,
+        #[case] expected_at_model_loaded: bool,
+    ) {
+        assert!(
+            !internal_uninitialized.is_model_loaded(speaker_id),
+            "expected is_model_loaded to return false, but got true",
+        );
+
+        assert!(
+            !internal_initialized_but_model_unloaded.is_model_loaded(speaker_id),
+            "expected is_model_loaded to return false, but got true",
+        );
+
+        assert_eq!(
+            internal_initialized_and_model_loaded.is_model_loaded(speaker_id),
+            expected_at_model_loaded,
+            "expected is_model_loaded return value against speaker_id `{}` is `{}`, but got `{}`",
+            speaker_id,
+            expected_at_model_loaded,
+            !expected_at_model_loaded
+        );
+    }
+
+    #[rstest]
+    fn supported_devices_works(internal_uninitialized: &Internal) {
+        let cstr_result = internal_uninitialized.supported_devices();
         assert!(cstr_result.to_str().is_ok(), "{:?}", cstr_result);
 
         let json_result: std::result::Result<SupportedDevices, _> =

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -192,7 +192,7 @@ static SUPPORTED_DEVICES_CSTRING: Lazy<CString> = Lazy::new(|| {
 });
 
 fn get_model_index_and_speaker_id(speaker_id: usize) -> Option<(usize, usize)> {
-    SPEAKER_ID_MAP.get(&speaker_id).map(|&x| x)
+    SPEAKER_ID_MAP.get(&speaker_id).copied()
 }
 
 pub const fn voicevox_error_result_to_message(result_code: VoicevoxResultCode) -> &'static str {

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -215,6 +215,7 @@ pub const fn voicevox_error_result_to_message(result_code: VoicevoxResultCode) -
         VOICEVOX_RESULT_SUCCEED => "エラーが発生しませんでした\0",
         VOICEVOX_RESULT_UNINITIALIZED_STATUS => "Statusが初期化されていません\0",
         VOICEVOX_RESULT_INVALID_SPEAKER_ID => "無効なspeaker_idです\0",
+        VOICEVOX_RESULT_INVALID_MODEL_INDEX => "無効なmodel_indexです\0",
     }
 }
 

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -61,13 +61,14 @@ impl Internal {
             }
         }
     }
-    pub fn load_model(&mut self, speaker_id: i64) -> Result<()> {
+    pub fn load_model(&mut self, speaker_id: usize) -> Result<()> {
         if self.initialized {
             let status = self
                 .status_option
                 .as_mut()
                 .ok_or(Error::UninitializedStatus)?;
-            status.load_model(speaker_id as usize)
+            let (model_index, _) = get_model_index_and_speaker_id(speaker_id);
+            status.load_model(model_index)
         } else {
             Err(Error::UninitializedStatus)
         }

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -244,6 +244,7 @@ mod tests {
 
     #[rstest]
     #[case(0, false, true)]
+    #[case(1, false, true)]
     #[case(3, false, true)]
     fn load_model_works(
         #[case] speaker_id: usize,

--- a/crates/voicevox_core/src/status.rs
+++ b/crates/voicevox_core/src/status.rs
@@ -143,25 +143,29 @@ impl Status {
     }
 
     pub fn load_model(&mut self, model_index: usize) -> Result<()> {
-        let model = &Self::MODELS[model_index];
-        let yukarin_s_session = self
-            .new_session(model.yukarin_s_model)
-            .map_err(Error::LoadModel)?;
-        let yukarin_sa_session = self
-            .new_session(model.yukarin_sa_model)
-            .map_err(Error::LoadModel)?;
-        let decode_model = self
-            .new_session(model.decode_model)
-            .map_err(Error::LoadModel)?;
+        if model_index < Self::MODELS.len() {
+            let model = &Self::MODELS[model_index];
+            let yukarin_s_session = self
+                .new_session(model.yukarin_s_model)
+                .map_err(Error::LoadModel)?;
+            let yukarin_sa_session = self
+                .new_session(model.yukarin_sa_model)
+                .map_err(Error::LoadModel)?;
+            let decode_model = self
+                .new_session(model.decode_model)
+                .map_err(Error::LoadModel)?;
 
-        self.models.yukarin_s.insert(model_index, yukarin_s_session);
-        self.models
-            .yukarin_sa
-            .insert(model_index, yukarin_sa_session);
+            self.models.yukarin_s.insert(model_index, yukarin_s_session);
+            self.models
+                .yukarin_sa
+                .insert(model_index, yukarin_sa_session);
 
-        self.models.decode.insert(model_index, decode_model);
+            self.models.decode.insert(model_index, decode_model);
 
-        Ok(())
+            Ok(())
+        } else {
+            Err(Error::InvalidModelIndex(model_index))
+        }
     }
 
     pub fn is_model_loaded(&self, model_index: usize) -> bool {

--- a/crates/voicevox_core/src/status.rs
+++ b/crates/voicevox_core/src/status.rs
@@ -164,7 +164,7 @@ impl Status {
 
             Ok(())
         } else {
-            Err(Error::InvalidModelIndex(model_index))
+            Err(Error::InvalidModelIndex { model_index })
         }
     }
 


### PR DESCRIPTION
## 内容

#152 の変更を受けて、`internal` モジュールの `load_model` と `is_model_loaded` のテストを実装しました。

~~https://github.com/VOICEVOX/voicevox_core/pull/152#discussion_r893159188 で提案した方法でテストを実装してみています。~~

## 関連 Issue

ref #128 

## その他

`load_model` 関数内で `speaker_id` から `model_index` の変換忘れを見つけたので合わせて修正しました（すみません、レビュー時に見落としていました……！）。
