### PR TITLE
[Rust] yukarin_s_forward を実装した

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,6 +821,7 @@ dependencies = [
  "cfg-if",
  "derive-getters",
  "derive-new",
+ "ndarray",
  "once_cell",
  "onnxruntime",
  "pretty_assertions",

--- a/crates/voicevox_core/Cargo.toml
+++ b/crates/voicevox_core/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0.57"
 cfg-if = "1.0.0"
 derive-getters = "0.2.0"
 derive-new = "0.5.9"
+ndarray = "0.15"
 once_cell = "1.10.0"
 onnxruntime = { git = "https://github.com/qwerty2501/onnxruntime-rs.git", version = "0.0.23" }
 serde = "1.0.137"

--- a/crates/voicevox_core/src/c_export.rs
+++ b/crates/voicevox_core/src/c_export.rs
@@ -144,8 +144,12 @@ pub extern "C" fn yukarin_s_forward(
     speaker_id: *mut i64,
     output: *mut f32,
 ) -> bool {
-    let result =
-        lock_internal().yukarin_s_forward(length, phoneme_list, &unsafe { *speaker_id }, output);
+    let result = lock_internal().yukarin_s_forward(
+        length,
+        phoneme_list,
+        unsafe { *speaker_id as usize },
+        output,
+    );
     //TODO: VoicevoxResultCodeを返すようにする
     if let Some(err) = result.err() {
         set_message(&format!("{}", err));

--- a/crates/voicevox_core/src/c_export.rs
+++ b/crates/voicevox_core/src/c_export.rs
@@ -32,6 +32,7 @@ pub enum VoicevoxResultCode {
     VOICEVOX_RESULT_UNINITIALIZED_STATUS = 6,
     VOICEVOX_RESULT_INVALID_SPEAKER_ID = 7,
     VOICEVOX_RESULT_INVALID_MODEL_INDEX = 8,
+    VOICEVOX_RESULT_INFERENCE_FAILED = 9,
 }
 
 fn convert_result<T>(result: Result<T>) -> (Option<T>, VoicevoxResultCode) {
@@ -69,6 +70,9 @@ fn convert_result<T>(result: Result<T>) -> (Option<T>, VoicevoxResultCode) {
                     None,
                     VoicevoxResultCode::VOICEVOX_RESULT_INVALID_MODEL_INDEX,
                 ),
+                Error::InferenceFailed => {
+                    (None, VoicevoxResultCode::VOICEVOX_RESULT_INFERENCE_FAILED)
+                }
             }
         }
     }

--- a/crates/voicevox_core/src/error.rs
+++ b/crates/voicevox_core/src/error.rs
@@ -40,6 +40,9 @@ pub enum Error {
 
     #[error("{},{0}", base_error_message(VOICEVOX_RESULT_INVALID_MODEL_INDEX))]
     InvalidModelIndex { model_index: usize },
+
+    #[error("{}", base_error_message(VOICEVOX_RESULT_INFERENCE_FAILED))]
+    InferenceFailed,
 }
 
 fn base_error_message(result_code: VoicevoxResultCode) -> &'static str {

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -375,7 +375,7 @@ mod tests {
                 .lock()
                 .unwrap()
                 .yukarin_s_forward(length, phoneme_list, 0, output_ptr);
-        assert!(result.is_ok(), "{:?}", result);
+        assert_eq!(result, Ok(()));
 
         let output: Vec<f32> =
             unsafe { Vec::from_raw_parts(output_ptr, length as usize, length as usize) };

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -146,10 +146,10 @@ impl Internal {
             ndarray::arr1(&[speaker_id as i64]),
         ];
 
-        let mut result = status.yukarin_s_session_run(model_index, input_tensors)?;
+        let result = status.yukarin_s_session_run(model_index, input_tensors)?;
 
-        let mut output_vec: Vec<f32> = unsafe { Vec::from_raw_parts(output, 0, length as usize) };
-        output_vec.append(&mut result);
+        let mut output_vec: Vec<f32> = unsafe { Vec::from_raw_parts(output, 0, 0) };
+        let _ = std::mem::replace(&mut output_vec, result);
 
         for output_item in &mut output_vec {
             if *output_item < PHONEME_LENGTH_MINIMAL {

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -148,15 +148,14 @@ impl Internal {
 
         let result = status.yukarin_s_session_run(model_index, input_tensors)?;
 
-        let mut output_vec: Vec<f32> = unsafe { Vec::from_raw_parts(output, 0, 0) };
-        let _ = std::mem::replace(&mut output_vec, result);
+        let output_slice = unsafe { std::slice::from_raw_parts_mut(output, length as usize) };
+        output_slice.clone_from_slice(&result);
 
-        for output_item in &mut output_vec {
+        for output_item in output_slice {
             if *output_item < PHONEME_LENGTH_MINIMAL {
                 *output_item = PHONEME_LENGTH_MINIMAL;
             }
         }
-        std::mem::forget(output_vec);
 
         Ok(())
     }

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -109,7 +109,7 @@ impl Internal {
         &mut self,
         length: i64,
         phoneme_list: *const i64,
-        speaker_id: &i64,
+        speaker_id: usize,
         output: *mut f32,
     ) -> Result<()> {
         if !self.initialized {
@@ -120,8 +120,6 @@ impl Internal {
             .status_option
             .as_mut()
             .ok_or(Error::UninitializedStatus)?;
-
-        let speaker_id = *speaker_id as usize;
 
         if !status.validate_speaker_id(speaker_id) {
             return Err(Error::InvalidSpeakerId { speaker_id });
@@ -376,7 +374,7 @@ mod tests {
             internal
                 .lock()
                 .unwrap()
-                .yukarin_s_forward(length, phoneme_list, &0, output_ptr);
+                .yukarin_s_forward(length, phoneme_list, 0, output_ptr);
         assert!(result.is_ok(), "{:?}", result);
 
         let output: Vec<f32> =

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -125,7 +125,7 @@ impl Internal {
             return Err(Error::InvalidSpeakerId { speaker_id });
         }
 
-        let (model_index, model_speaker_id) =
+        let (model_index, speaker_id) =
             if let Some((model_index, speaker_id)) = get_model_index_and_speaker_id(speaker_id) {
                 (model_index, speaker_id)
             } else {


### PR DESCRIPTION
## 内容

yukarin_s_forward を実装し、テストも書きました。とりあえず動きます。
`onnxruntime-rs` が `ndarray` と蜜結合した形で記述されていたため、素直に `ndarray` クレートを導入しました。
`ndarray` を使った経験がないため、もっと適切な書き方があるかどうかわからなかったのですが、とりあえず提出しました。

## 関連 Issue

#128 
