### PR TITLE
[Rust] yukarin_sa_forward と decode_forward を実装（yukarin_s_forward の再実装含む）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+ "opaque-debug",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,10 +59,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "base64ct"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a32fd6af2b5827bce66c29053ba0e7c42b9dcab01835835058558c10851a46b"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -109,6 +136,9 @@ name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -121,6 +151,15 @@ name = "chunked_transfer"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
+
+[[package]]
+name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "clap"
@@ -147,12 +186,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+dependencies = [
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -192,6 +266,17 @@ name = "diff"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
+
+[[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "fastrand"
@@ -237,6 +322,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,6 +350,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -292,6 +396,15 @@ name = "itoa"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+
+[[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -389,6 +502,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,8 +518,8 @@ checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "onnxruntime"
-version = "0.0.23"
-source = "git+https://github.com/qwerty2501/onnxruntime-rs.git#dec3bcdd880cf69a86207166f60cc986d0494d09"
+version = "0.0.24"
+source = "git+https://github.com/qwerty2501/onnxruntime-rs.git#3db39f03b95a2941b7b512f94b6b808565f94b2b"
 dependencies = [
  "lazy_static",
  "ndarray",
@@ -409,13 +531,19 @@ dependencies = [
 [[package]]
 name = "onnxruntime-sys"
 version = "0.0.20"
-source = "git+https://github.com/qwerty2501/onnxruntime-rs.git#dec3bcdd880cf69a86207166f60cc986d0494d09"
+source = "git+https://github.com/qwerty2501/onnxruntime-rs.git#3db39f03b95a2941b7b512f94b6b808565f94b2b"
 dependencies = [
  "flate2",
  "tar",
  "ureq",
  "zip",
 ]
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "os_str_bytes"
@@ -430,6 +558,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d791538a6dcc1e7cb7fe6f6b58aca40e7f79403c45b2bc274008b5e647af1d8"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
+dependencies = [
+ "digest",
+ "hmac",
+ "password-hash",
+ "sha2",
 ]
 
 [[package]]
@@ -479,6 +630,12 @@ checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 
 [[package]]
 name = "rawpointer"
@@ -607,6 +764,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77f4e7f65455545c2153c1253d25056825e77ee2533f0e41deb65a93a34852f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +796,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
@@ -691,14 +876,21 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
 dependencies = [
+ "itoa",
  "libc",
- "wasi",
- "winapi",
+ "num_threads",
+ "time-macros",
 ]
+
+[[package]]
+name = "time-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "tinyvec"
@@ -757,6 +949,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,6 +1011,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
 name = "voicevox_core"
 version = "0.1.0"
 dependencies = [
@@ -821,7 +1025,6 @@ dependencies = [
  "cfg-if",
  "derive-getters",
  "derive-new",
- "ndarray",
  "once_cell",
  "onnxruntime",
  "pretty_assertions",
@@ -830,12 +1033,6 @@ dependencies = [
  "serde_json",
  "thiserror",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
@@ -962,14 +1159,49 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.5.13"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815"
+checksum = "bf225bcf73bb52cbb496e70475c7bd7a3f769df699c0020f6c7bd9a96dcf0b8d"
 dependencies = [
+ "aes",
  "byteorder",
  "bzip2",
+ "constant_time_eq",
  "crc32fast",
+ "crossbeam-utils",
  "flate2",
- "thiserror",
+ "hmac",
+ "pbkdf2",
+ "sha1",
  "time",
+ "zstd",
+]
+
+[[package]]
+name = "zstd"
+version = "0.10.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4a6bd64f22b5e3e94b4e238669ff9f10815c27a5180108b849d24174a83847"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "4.1.6+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94b61c51bb270702d6167b8ce67340d2754b088d0c091b06e593aa772c3ee9bb"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "1.6.3+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
+dependencies = [
+ "cc",
+ "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,6 +821,7 @@ dependencies = [
  "cfg-if",
  "derive-getters",
  "derive-new",
+ "ndarray",
  "once_cell",
  "onnxruntime",
  "pretty_assertions",

--- a/crates/voicevox_core/Cargo.toml
+++ b/crates/voicevox_core/Cargo.toml
@@ -16,9 +16,8 @@ anyhow = "1.0.57"
 cfg-if = "1.0.0"
 derive-getters = "0.2.0"
 derive-new = "0.5.9"
-ndarray = "0.15"
 once_cell = "1.10.0"
-onnxruntime = { git = "https://github.com/qwerty2501/onnxruntime-rs.git", version = "0.0.23" }
+onnxruntime = { git = "https://github.com/qwerty2501/onnxruntime-rs.git", version = "0.0.24" }
 serde = "1.0.137"
 serde_json = "1.0.81"
 thiserror = "1.0.31"

--- a/crates/voicevox_core/Cargo.toml
+++ b/crates/voicevox_core/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0.57"
 cfg-if = "1.0.0"
 derive-getters = "0.2.0"
 derive-new = "0.5.9"
+ndarray = "0.15"
 once_cell = "1.10.0"
 onnxruntime = { git = "https://github.com/qwerty2501/onnxruntime-rs.git", version = "0.0.23" }
 serde = "1.0.137"

--- a/crates/voicevox_core/src/c_export.rs
+++ b/crates/voicevox_core/src/c_export.rs
@@ -201,8 +201,8 @@ pub extern "C" fn decode_forward(
     output: *mut f32,
 ) -> bool {
     let result = lock_internal().decode_forward(
-        length,
-        phoneme_size,
+        length as usize,
+        phoneme_size as usize,
         f0,
         phoneme,
         unsafe { *speaker_id as usize },

--- a/crates/voicevox_core/src/c_export.rs
+++ b/crates/voicevox_core/src/c_export.rs
@@ -144,8 +144,12 @@ pub extern "C" fn yukarin_s_forward(
     speaker_id: *mut i64,
     output: *mut f32,
 ) -> bool {
-    let result =
-        lock_internal().yukarin_s_forward(length, phoneme_list, &unsafe { *speaker_id }, output);
+    let result = lock_internal().yukarin_s_forward(
+        length,
+        phoneme_list,
+        unsafe { *speaker_id as usize },
+        output,
+    );
     //TODO: VoicevoxResultCodeを返すようにする
     if let Some(err) = result.err() {
         set_message(&format!("{}", err));

--- a/crates/voicevox_core/src/c_export.rs
+++ b/crates/voicevox_core/src/c_export.rs
@@ -179,7 +179,7 @@ pub extern "C" fn yukarin_sa_forward(
         end_accent_list,
         start_accent_phrase_list,
         end_accent_phrase_list,
-        speaker_id,
+        unsafe { *speaker_id as usize },
         output,
     );
     //TODO: VoicevoxResultCodeを返すようにする

--- a/crates/voicevox_core/src/c_export.rs
+++ b/crates/voicevox_core/src/c_export.rs
@@ -144,18 +144,19 @@ pub extern "C" fn yukarin_s_forward(
     speaker_id: *mut i64,
     output: *mut f32,
 ) -> bool {
-    let result = lock_internal().yukarin_s_forward(
-        length,
-        phoneme_list,
-        unsafe { *speaker_id as usize },
-        output,
-    );
+    let result =
+        lock_internal().yukarin_s_forward(length, phoneme_list, unsafe { *speaker_id as usize });
     //TODO: VoicevoxResultCodeを返すようにする
-    if let Some(err) = result.err() {
-        set_message(&format!("{}", err));
-        false
-    } else {
-        true
+    match result {
+        Ok(output_vec) => {
+            let output_slice = unsafe { std::slice::from_raw_parts_mut(output, length as usize) };
+            output_slice.clone_from_slice(&output_vec);
+            true
+        }
+        Err(err) => {
+            set_message(&format!("{}", err));
+            false
+        }
     }
 }
 
@@ -180,14 +181,18 @@ pub extern "C" fn yukarin_sa_forward(
         start_accent_phrase_list,
         end_accent_phrase_list,
         unsafe { *speaker_id as usize },
-        output,
     );
     //TODO: VoicevoxResultCodeを返すようにする
-    if let Some(err) = result.err() {
-        set_message(&format!("{}", err));
-        false
-    } else {
-        true
+    match result {
+        Ok(output_vec) => {
+            let output_slice = unsafe { std::slice::from_raw_parts_mut(output, length as usize) };
+            output_slice.clone_from_slice(&output_vec);
+            true
+        }
+        Err(err) => {
+            set_message(&format!("{}", err));
+            false
+        }
     }
 }
 
@@ -206,14 +211,19 @@ pub extern "C" fn decode_forward(
         f0,
         phoneme,
         unsafe { *speaker_id as usize },
-        output,
     );
     //TODO: VoicevoxResultCodeを返すようにする
-    if let Some(err) = result.err() {
-        set_message(&format!("{}", err));
-        false
-    } else {
-        true
+    match result {
+        Ok(output_vec) => {
+            let output_slice =
+                unsafe { std::slice::from_raw_parts_mut(output, (length as usize) * 256) };
+            output_slice.clone_from_slice(&output_vec);
+            true
+        }
+        Err(err) => {
+            set_message(&format!("{}", err));
+            false
+        }
     }
 }
 

--- a/crates/voicevox_core/src/c_export.rs
+++ b/crates/voicevox_core/src/c_export.rs
@@ -200,8 +200,14 @@ pub extern "C" fn decode_forward(
     speaker_id: *mut i64,
     output: *mut f32,
 ) -> bool {
-    let result =
-        lock_internal().decode_forward(length, phoneme_size, f0, phoneme, speaker_id, output);
+    let result = lock_internal().decode_forward(
+        length,
+        phoneme_size,
+        f0,
+        phoneme,
+        unsafe { *speaker_id as usize },
+        output,
+    );
     //TODO: VoicevoxResultCodeを返すようにする
     if let Some(err) = result.err() {
         set_message(&format!("{}", err));

--- a/crates/voicevox_core/src/c_export.rs
+++ b/crates/voicevox_core/src/c_export.rs
@@ -32,6 +32,7 @@ pub enum VoicevoxResultCode {
     VOICEVOX_RESULT_UNINITIALIZED_STATUS = 6,
     VOICEVOX_RESULT_INVALID_SPEAKER_ID = 7,
     VOICEVOX_RESULT_INVALID_MODEL_INDEX = 8,
+    VOICEVOX_RESULT_INFERENCE_FAILED = 9,
 }
 
 fn convert_result<T>(result: Result<T>) -> (Option<T>, VoicevoxResultCode) {
@@ -69,6 +70,9 @@ fn convert_result<T>(result: Result<T>) -> (Option<T>, VoicevoxResultCode) {
                     None,
                     VoicevoxResultCode::VOICEVOX_RESULT_INVALID_MODEL_INDEX,
                 ),
+                Error::InferenceFailed => {
+                    (None, VoicevoxResultCode::VOICEVOX_RESULT_INFERENCE_FAILED)
+                }
             }
         }
     }

--- a/crates/voicevox_core/src/error.rs
+++ b/crates/voicevox_core/src/error.rs
@@ -40,6 +40,9 @@ pub enum Error {
 
     #[error("{},{0}", base_error_message(VOICEVOX_RESULT_INVALID_MODEL_INDEX))]
     InvalidModelIndex { model_index: usize },
+
+    #[error("{}", base_error_message(VOICEVOX_RESULT_INFERENCE_FAILED))]
+    InferenceFailed,
 }
 
 fn base_error_message(result_code: VoicevoxResultCode) -> &'static str {

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -375,7 +375,7 @@ mod tests {
                 .lock()
                 .unwrap()
                 .yukarin_s_forward(length, phoneme_list, 0, output_ptr);
-        assert!(result.is_ok(), "{:?}", result);
+        assert_eq!(result, Ok(()));
 
         let output: Vec<f32> =
             unsafe { Vec::from_raw_parts(output_ptr, length as usize, length as usize) };

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -146,10 +146,10 @@ impl Internal {
             ndarray::arr1(&[speaker_id as i64]),
         ];
 
-        let mut result = status.yukarin_s_session_run(model_index, input_tensors)?;
+        let result = status.yukarin_s_session_run(model_index, input_tensors)?;
 
-        let mut output_vec: Vec<f32> = unsafe { Vec::from_raw_parts(output, 0, length as usize) };
-        output_vec.append(&mut result);
+        let mut output_vec: Vec<f32> = unsafe { Vec::from_raw_parts(output, 0, 0) };
+        let _ = std::mem::replace(&mut output_vec, result);
 
         for output_item in &mut output_vec {
             if *output_item < PHONEME_LENGTH_MINIMAL {

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -148,15 +148,14 @@ impl Internal {
 
         let result = status.yukarin_s_session_run(model_index, input_tensors)?;
 
-        let mut output_vec: Vec<f32> = unsafe { Vec::from_raw_parts(output, 0, 0) };
-        let _ = std::mem::replace(&mut output_vec, result);
+        let output_slice = unsafe { std::slice::from_raw_parts_mut(output, length as usize) };
+        output_slice.clone_from_slice(&result);
 
-        for output_item in &mut output_vec {
+        for output_item in output_slice {
             if *output_item < PHONEME_LENGTH_MINIMAL {
                 *output_item = PHONEME_LENGTH_MINIMAL;
             }
         }
-        std::mem::forget(output_vec);
 
         Ok(())
     }

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -263,6 +263,7 @@ impl Internal {
             return Err(Error::InvalidModelIndex { model_index });
         }
 
+        // TODO: 音が途切れてしまうのを避けるworkaround処理を入れる
         let f0_slice = unsafe { std::slice::from_raw_parts(f0, length as usize) };
         let phoneme_slice = unsafe { std::slice::from_raw_parts(phoneme, phoneme_size as usize) };
 

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -103,8 +103,7 @@ impl Internal {
     pub fn supported_devices(&self) -> &'static CStr {
         &SUPPORTED_DEVICES_CSTRING
     }
-    //TODO:仮実装がlinterエラーにならないようにするための属性なのでこの関数を正式に実装する際にallow(unused_variables)を取り除くこと
-    #[allow(unused_variables)]
+
     pub fn yukarin_s_forward(
         &mut self,
         length: i64,
@@ -158,8 +157,6 @@ impl Internal {
         Ok(())
     }
 
-    //TODO:仮実装がlinterエラーにならないようにするための属性なのでこの関数を正式に実装する際にallow(unused_variables)を取り除くこと
-    #[allow(unused_variables)]
     #[allow(clippy::too_many_arguments)]
     pub fn yukarin_sa_forward(
         &mut self,

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -503,7 +503,7 @@ mod tests {
 
         // 「テスト」という文章に対応する入力
         const F0_LENGTH: usize = 69;
-        let mut f0 = [0.; 69];
+        let mut f0 = [0.; F0_LENGTH];
         f0[9..24].fill(5.905218);
         f0[37..60].fill(5.565851);
 

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -218,6 +218,7 @@ impl Internal {
             ndarray::arr1(end_accent_list_slice).into_dyn(),
             ndarray::arr1(start_accent_phrase_list_slice).into_dyn(),
             ndarray::arr1(end_accent_phrase_list_slice).into_dyn(),
+            ndarray::arr1(&[speaker_id as i64]).into_dyn(),
         ];
 
         let result = status.yukarin_sa_session_run(model_index, input_tensors)?;

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -109,7 +109,7 @@ impl Internal {
         &mut self,
         length: i64,
         phoneme_list: *const i64,
-        speaker_id: &i64,
+        speaker_id: usize,
         output: *mut f32,
     ) -> Result<()> {
         if !self.initialized {
@@ -120,8 +120,6 @@ impl Internal {
             .status_option
             .as_mut()
             .ok_or(Error::UninitializedStatus)?;
-
-        let speaker_id = *speaker_id as usize;
 
         if !status.validate_speaker_id(speaker_id) {
             return Err(Error::InvalidSpeakerId { speaker_id });
@@ -376,7 +374,7 @@ mod tests {
             internal
                 .lock()
                 .unwrap()
-                .yukarin_s_forward(length, phoneme_list, &0, output_ptr);
+                .yukarin_s_forward(length, phoneme_list, 0, output_ptr);
         assert!(result.is_ok(), "{:?}", result);
 
         let output: Vec<f32> =

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -125,7 +125,7 @@ impl Internal {
             return Err(Error::InvalidSpeakerId { speaker_id });
         }
 
-        let (model_index, model_speaker_id) =
+        let (model_index, speaker_id) =
             if let Some((model_index, speaker_id)) = get_model_index_and_speaker_id(speaker_id) {
                 (model_index, speaker_id)
             } else {

--- a/crates/voicevox_core/src/status.rs
+++ b/crates/voicevox_core/src/status.rs
@@ -231,6 +231,29 @@ impl Status {
             Err(Error::InvalidModelIndex { model_index })
         }
     }
+
+    pub fn yukarin_sa_session_run(
+        &mut self,
+        model_index: usize,
+        inputs: Vec<Array1<i64>>,
+    ) -> Result<Vec<f32>> {
+        if let Some(model) = self.models.yukarin_sa.get_mut(&model_index) {
+            if let Ok(result) = model.run(inputs) {
+                let mut output: Vec<Vec<f32>> = result
+                    .iter()
+                    .map(|tensor| {
+                        let output_view: &ndarray::ArrayView<_, _> = &**tensor;
+                        output_view.as_slice().unwrap().to_vec()
+                    })
+                    .collect();
+                Ok(output.pop().unwrap())
+            } else {
+                Err(Error::InferenceFailed)
+            }
+        } else {
+            Err(Error::InvalidModelIndex { model_index })
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/voicevox_core/src/status.rs
+++ b/crates/voicevox_core/src/status.rs
@@ -1,5 +1,5 @@
 use super::*;
-use ndarray::Array1;
+use ndarray::{Array1, ArrayD};
 use once_cell::sync::Lazy;
 use onnxruntime::{
     environment::Environment, session::Session, GraphOptimizationLevel, LoggingLevel,
@@ -235,9 +235,32 @@ impl Status {
     pub fn yukarin_sa_session_run(
         &mut self,
         model_index: usize,
-        inputs: Vec<Array1<i64>>,
+        inputs: Vec<ArrayD<i64>>,
     ) -> Result<Vec<f32>> {
         if let Some(model) = self.models.yukarin_sa.get_mut(&model_index) {
+            if let Ok(result) = model.run(inputs) {
+                let mut output: Vec<Vec<f32>> = result
+                    .iter()
+                    .map(|tensor| {
+                        let output_view: &ndarray::ArrayView<_, _> = &**tensor;
+                        output_view.as_slice().unwrap().to_vec()
+                    })
+                    .collect();
+                Ok(output.pop().unwrap())
+            } else {
+                Err(Error::InferenceFailed)
+            }
+        } else {
+            Err(Error::InvalidModelIndex { model_index })
+        }
+    }
+
+    pub fn decode_session_run(
+        &mut self,
+        model_index: usize,
+        inputs: Vec<Array1<f32>>,
+    ) -> Result<Vec<f32>> {
+        if let Some(model) = self.models.decode.get_mut(&model_index) {
             if let Ok(result) = model.run(inputs) {
                 let mut output: Vec<Vec<f32>> = result
                     .iter()

--- a/crates/voicevox_core/src/status.rs
+++ b/crates/voicevox_core/src/status.rs
@@ -216,12 +216,8 @@ impl Status {
         inputs: Vec<&mut dyn AnyArray>,
     ) -> Result<Vec<f32>> {
         if let Some(model) = self.models.yukarin_s.get_mut(&model_index) {
-            if let Ok(result) = model.run(inputs) {
-                let mut output: Vec<Vec<f32>> = result
-                    .iter()
-                    .map(|tensor| tensor.as_slice().unwrap().to_owned())
-                    .collect();
-                Ok(output.pop().unwrap())
+            if let Ok(output_tensors) = model.run(inputs) {
+                Ok(output_tensors[0].as_slice().unwrap().to_owned())
             } else {
                 Err(Error::InferenceFailed)
             }
@@ -236,12 +232,8 @@ impl Status {
         inputs: Vec<&mut dyn AnyArray>,
     ) -> Result<Vec<f32>> {
         if let Some(model) = self.models.yukarin_sa.get_mut(&model_index) {
-            if let Ok(result) = model.run(inputs) {
-                let mut output: Vec<Vec<f32>> = result
-                    .iter()
-                    .map(|tensor| tensor.as_slice().unwrap().to_owned())
-                    .collect();
-                Ok(output.pop().unwrap())
+            if let Ok(output_tensors) = model.run(inputs) {
+                Ok(output_tensors[0].as_slice().unwrap().to_owned())
             } else {
                 Err(Error::InferenceFailed)
             }
@@ -256,12 +248,8 @@ impl Status {
         inputs: Vec<&mut dyn AnyArray>,
     ) -> Result<Vec<f32>> {
         if let Some(model) = self.models.decode.get_mut(&model_index) {
-            if let Ok(result) = model.run(inputs) {
-                let mut output: Vec<Vec<f32>> = result
-                    .iter()
-                    .map(|tensor| tensor.as_slice().unwrap().to_owned())
-                    .collect();
-                Ok(output.pop().unwrap())
+            if let Ok(output_tensors) = model.run(inputs) {
+                Ok(output_tensors[0].as_slice().unwrap().to_owned())
             } else {
                 Err(Error::InferenceFailed)
             }

--- a/crates/voicevox_core/src/status.rs
+++ b/crates/voicevox_core/src/status.rs
@@ -1,8 +1,9 @@
 use super::*;
-use ndarray::{Array1, ArrayD};
 use once_cell::sync::Lazy;
 use onnxruntime::{
-    environment::Environment, session::Session, GraphOptimizationLevel, LoggingLevel,
+    environment::Environment,
+    session::{AnyArray, Session},
+    GraphOptimizationLevel, LoggingLevel,
 };
 use serde::{Deserialize, Serialize};
 
@@ -212,16 +213,13 @@ impl Status {
     pub fn yukarin_s_session_run(
         &mut self,
         model_index: usize,
-        inputs: Vec<Array1<i64>>,
+        inputs: Vec<&mut dyn AnyArray>,
     ) -> Result<Vec<f32>> {
         if let Some(model) = self.models.yukarin_s.get_mut(&model_index) {
             if let Ok(result) = model.run(inputs) {
                 let mut output: Vec<Vec<f32>> = result
                     .iter()
-                    .map(|tensor| {
-                        let output_view: &ndarray::ArrayView<_, _> = &**tensor;
-                        output_view.as_slice().unwrap().to_vec()
-                    })
+                    .map(|tensor| tensor.as_slice().unwrap().to_owned())
                     .collect();
                 Ok(output.pop().unwrap())
             } else {
@@ -235,16 +233,13 @@ impl Status {
     pub fn yukarin_sa_session_run(
         &mut self,
         model_index: usize,
-        inputs: Vec<ArrayD<i64>>,
+        inputs: Vec<&mut dyn AnyArray>,
     ) -> Result<Vec<f32>> {
         if let Some(model) = self.models.yukarin_sa.get_mut(&model_index) {
             if let Ok(result) = model.run(inputs) {
                 let mut output: Vec<Vec<f32>> = result
                     .iter()
-                    .map(|tensor| {
-                        let output_view: &ndarray::ArrayView<_, _> = &**tensor;
-                        output_view.as_slice().unwrap().to_vec()
-                    })
+                    .map(|tensor| tensor.as_slice().unwrap().to_owned())
                     .collect();
                 Ok(output.pop().unwrap())
             } else {
@@ -258,16 +253,13 @@ impl Status {
     pub fn decode_session_run(
         &mut self,
         model_index: usize,
-        inputs: Vec<Array1<f32>>,
+        inputs: Vec<&mut dyn AnyArray>,
     ) -> Result<Vec<f32>> {
         if let Some(model) = self.models.decode.get_mut(&model_index) {
             if let Ok(result) = model.run(inputs) {
                 let mut output: Vec<Vec<f32>> = result
                     .iter()
-                    .map(|tensor| {
-                        let output_view: &ndarray::ArrayView<_, _> = &**tensor;
-                        output_view.as_slice().unwrap().to_vec()
-                    })
+                    .map(|tensor| tensor.as_slice().unwrap().to_owned())
                     .collect();
                 Ok(output.pop().unwrap())
             } else {


### PR DESCRIPTION
## 内容

`yukarin_sa_forward` と `decode_forward` の実装を目指します。
~~現在、`yukarin_sa_forward` が推論に失敗するので、draft にしています。~~
現在、`decode_forward` の実装に取り組み中なので、draft にしています。

入力テンソルのうち、`length` のみが次元０であるため、引数は複数の次元のテンソルが混在する `Vec` となっています。そのためにテンソルの型を `ArrayD<i64>` にして混在できるようにしてみました~~が、それではうまくいかないようです~~。これでうまくいきました……！

## 関連 Issue

ref #128 
