### PR TITLE
コード署名できるようにする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -289,7 +289,7 @@ jobs:
         if: startsWith(matrix.os, 'windows') && github.event.inputs.code_signing
         shell: bash
         run: |
-          bash build_util/codesign.bash "core.dll"
+          bash build_util/codesign.bash "artifact/core.dll"
         env:
           CERT_BASE64: ${{ secrets.CERT_BASE64 }}
           CERT_PASSWORD: ${{ secrets.CERT_PASSWORD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -294,12 +294,6 @@ jobs:
           CERT_BASE64: ${{ secrets.CERT_BASE64 }}
           CERT_PASSWORD: ${{ secrets.CERT_PASSWORD }}
 
-      # coreのredirectブランチ戻した？
-      # coreのredirectブランチ戻した？
-      # coreのredirectブランチ戻した？
-      # coreのredirectブランチ戻した？
-      # coreのredirectブランチ戻した？
-
       # Upload
       - name: Upload artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   build-cpp-shared:
-    environment: ${{ github.event.inputs.code_signing && 'code_signing' }}
+    environment: ${{ github.event.inputs.code_signing && 'code_signing' }} # コード署名用のenvironment
     strategy:
       fail-fast: false
       matrix:
@@ -289,10 +289,16 @@ jobs:
         if: startsWith(matrix.os, 'windows') && github.event.inputs.code_signing
         shell: bash
         run: |
-          bash codesign.bash "core.dll"
+          bash build_util/codesign.bash "core.dll"
         env:
           CERT_BASE64: ${{ secrets.CERT_BASE64 }}
           CERT_PASSWORD: ${{ secrets.CERT_PASSWORD }}
+
+      # coreのredirectブランチ戻した？
+      # coreのredirectブランチ戻した？
+      # coreのredirectブランチ戻した？
+      # coreのredirectブランチ戻した？
+      # coreのredirectブランチ戻した？
 
       # Upload
       - name: Upload artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -289,7 +289,7 @@ jobs:
         if: startsWith(matrix.os, 'windows') && github.event.inputs.code_signing
         shell: bash
         run: |
-          bash build_util/codesign.bash "artifact/core.dll"
+          bash build_util/codesign.bash "artifact/${{ env.ASSET_NAME }}/core.dll"
         env:
           CERT_BASE64: ${{ secrets.CERT_BASE64 }}
           CERT_PASSWORD: ${{ secrets.CERT_PASSWORD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ on:
       version:
         description: "バージョン情報（A.BB.C / A.BB.C-preview.D）"
         required: true
+      code_signing:
+        description: "コード署名する"
+        type: boolean
 
 env:
   # releaseタグ名か、workflow_dispatchでのバージョン名か、DEBUGが入る
@@ -24,6 +27,7 @@ env:
 
 jobs:
   build-cpp-shared:
+    environment: ${{ github.event.inputs.code_signing && 'code_signing' }}
     strategy:
       fail-fast: false
       matrix:
@@ -280,6 +284,15 @@ jobs:
           echo "${{ env.VERSION }}" > "artifact/${{ env.ASSET_NAME }}/VERSION"
 
           cp README.md "artifact/${{ env.ASSET_NAME }}/README.txt"
+
+      - name: Code signing (Windows)
+        if: startsWith(matrix.os, 'windows') && github.event.inputs.code_signing
+        shell: bash
+        run: |
+          bash codesign.bash "core.dll"
+        env:
+          CERT_BASE64: ${{ secrets.CERT_BASE64 }}
+          CERT_PASSWORD: ${{ secrets.CERT_PASSWORD }}
 
       # Upload
       - name: Upload artifact

--- a/build_util/codesign.bash
+++ b/build_util/codesign.bash
@@ -1,0 +1,49 @@
+# !!! コードサイニング証明書を取り扱うので取り扱い注意 !!!
+
+set -eu
+
+if [ -v "${CERT_BASE64}" ]; then
+    echo "CERT_BASE64が未定義です"
+    exit 1
+fi
+if [ -v "${CERT_PASSWORD}" ]; then
+    echo "CERT_PASSWORDが未定義です"
+    exit 1
+fi
+
+if [ $# -ne 1 ]; then
+    echo "引数の数が一致しません"
+    exit 1
+fi
+target_file_glob="$1"
+
+# 証明書
+CERT_PATH=cert.pfx
+echo -n "$CERT_BASE64" | base64 -d - > $CERT_PATH
+
+# 指定ファイルに署名する
+function codesign() {
+    TARGET="$1"
+    SIGNTOOL=$(find "C:/Program Files (x86)/Windows Kits/10/App Certification Kit" -name "signtool.exe" | sort -V | tail -n 1)
+    powershell "& '$SIGNTOOL' sign /fd SHA256 /td SHA256 /tr http://timestamp.digicert.com /f $CERT_PATH /p $CERT_PASSWORD '$TARGET'"
+}
+
+# 指定ファイルが署名されているか
+function is_signed() {
+    TARGET="$1"
+    SIGNTOOL=$(find "C:/Program Files (x86)/Windows Kits/10/App Certification Kit" -name "signtool.exe" | sort -V | tail -n 1)
+    powershell "& '$SIGNTOOL' verify /pa '$TARGET'" || return 1
+}
+
+# 署名されていなければ署名
+ls $target_file_glob | while read target_file; do
+    if is_signed "$target_file"; then
+        echo "署名済み: $target_file"
+    else
+        echo "署名: $target_file"
+        codesign "$target_file"
+    fi
+done
+
+# 証明書を消去
+rm $CERT_PATH


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/voicevox_core/issues/163

の解決です。

証明書.pfxファイルをbase64エンコードしたものをsecret.CERT_BASE64に登録し、
証明書のパスワードをsecret.CERT_PASSWORDに登録して、
workflow_dispatchで「コード署名する」にチェックを入れてbuild.ymlを起動すれば、
core.dllが署名されます。

もしくは`code_signing`environmentを作成し、同様にCERT_BASE64とCERT_PASSWORDを登録して実行しても署名できます。
（こちらのフローは、OSSリポジトリ上でビルドする場合を想定しています。）

「コード署名する」にチェックを入れずにビルドしたり、releaseを作ってビルドした場合は署名用のコードが実行されないので、メンテナー以外の方は今まで通りにテストビルドができます。

## 関連 Issue

close #163

## その他

こちらでビルドしてみました！
https://github.com/Hiroshiba/voicevox_core/actions/runs/2605648813

適当なwindows用のzipをダウンロードして展開、core.dllを右クリック→プロパティ→デジタル署名で署名を確認できるはずです。
