### PR TITLE
[Rust] GPUを使う場合、初期化時にメモリ確保する。また、イントネーションの推論を常にCPUで行うようにする

### DIFF
--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -50,8 +50,23 @@ impl Internal {
                 for model_index in 0..Status::MODELS_COUNT {
                     status.load_model(model_index)?;
                 }
-                // TODO: ここにGPUメモリを確保させる処理を実装する
-                // https://github.com/VOICEVOX/voicevox_core/blob/main/core/src/core.cpp#L210-L219
+                // 一回走らせて十分なGPUメモリを確保させる
+                // TODO: 全MODELに対して行う
+                if use_gpu {
+                    const LENGTH: usize = 500;
+                    const PHONEME_SIZE: usize = 45;
+                    let f0 = [0.; LENGTH];
+                    let phoneme = [0.; PHONEME_SIZE * LENGTH];
+                    let speaker_id = 0;
+
+                    let _ = self.decode_forward(
+                        LENGTH,
+                        PHONEME_SIZE,
+                        f0.as_ptr(),
+                        phoneme.as_ptr(),
+                        speaker_id,
+                    )?;
+                }
             }
 
             self.status_option = Some(status);


### PR DESCRIPTION
## 内容

- `initialize` 関数中で TODO となっていた「GPUメモリを確保させる処理」を実装しました
- C++ 版では #143 の問題に対する workaround として #146 が実装されていましたが、Rust 版では未実装だったので実装しました

## 関連 Issue

ref #128 
ref #143 

## その他

手元に GPU 環境がないため、正しく機能するかどうか動作確認できておりません。検証可能な方がいらっしゃれば動作テストしていただけると助かります……！
