### PR TITLE
open_jtalk-rsを0.1.6に上げた

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,8 +686,8 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "open_jtalk"
-version = "0.1.5"
-source = "git+https://github.com/qwerty2501/open_jtalk-rs.git#425e2ca31b21d95fe026218df2221d8e786d5856"
+version = "0.1.6"
+source = "git+https://github.com/qwerty2501/open_jtalk-rs.git#2b251db09ced472aa10980053f8c0c23d9026d0f"
 dependencies = [
  "open_jtalk-sys",
  "thiserror",
@@ -696,7 +696,7 @@ dependencies = [
 [[package]]
 name = "open_jtalk-sys"
 version = "0.1.111"
-source = "git+https://github.com/qwerty2501/open_jtalk-rs.git#425e2ca31b21d95fe026218df2221d8e786d5856"
+source = "git+https://github.com/qwerty2501/open_jtalk-rs.git#2b251db09ced472aa10980053f8c0c23d9026d0f"
 dependencies = [
  "bindgen",
  "cmake",

--- a/crates/voicevox_core/Cargo.toml
+++ b/crates/voicevox_core/Cargo.toml
@@ -21,7 +21,7 @@ onnxruntime = { git = "https://github.com/qwerty2501/onnxruntime-rs.git", versio
 serde = "1.0.137"
 serde_json = "1.0.81"
 thiserror = "1.0.31"
-open_jtalk = { git = "https://github.com/qwerty2501/open_jtalk-rs.git", version = "0.1.5" }
+open_jtalk = { git = "https://github.com/qwerty2501/open_jtalk-rs.git", version = "0.1.6" }
 
 [dev-dependencies]
 rstest = "0.12.0"


### PR DESCRIPTION

## 内容
[pyopenjtalkのcreate_user_dict](https://github.com/VOICEVOX/pyopenjtalk/blob/50b0296a9e1b666e5a09a41ec9e9284a2a9b608f/pyopenjtalk/__init__.py#L178-L190) を実装する目的で今後mecab_dict_index使いそうなため
mecab_dict_index関数をwrapperに追加したことによる対応です

## 関連 Issue

refs #128

