### PR TITLE
SynthesisEngineを仮実装した

### DIFF
--- a/crates/voicevox_core/src/engine/mod.rs
+++ b/crates/voicevox_core/src/engine/mod.rs
@@ -2,3 +2,8 @@ mod kana_parser;
 mod model;
 mod mora_list;
 mod open_jtalk;
+mod synthesis_engine;
+
+use super::*;
+
+pub use model::*;

--- a/crates/voicevox_core/src/engine/model.rs
+++ b/crates/voicevox_core/src/engine/model.rs
@@ -3,7 +3,7 @@ use derive_new::new;
 
 #[allow(dead_code)] // TODO: remove this feature
 #[derive(Clone, Debug, new, Getters)]
-pub(super) struct MoraModel {
+pub struct MoraModel {
     text: String,
     consonant: Option<String>,
     consonant_length: Option<f32>,
@@ -16,7 +16,7 @@ pub(super) struct MoraModel {
 
 #[allow(dead_code)] // TODO: remove this feature
 #[derive(Debug, new, Getters)]
-pub(super) struct AccentPhraseModel {
+pub struct AccentPhraseModel {
     moras: Vec<MoraModel>,
     accent: usize,
     pause_mora: Option<MoraModel>,
@@ -35,7 +35,7 @@ impl AccentPhraseModel {
 
 #[allow(dead_code, clippy::too_many_arguments)] // TODO: remove allow(dead_code)
 #[derive(new, Getters)]
-pub(super) struct AudioQueryModel {
+pub struct AudioQueryModel {
     accent_phrases: Vec<AccentPhraseModel>,
     speed_scale: f32,
     pitch_scale: f32,

--- a/crates/voicevox_core/src/engine/synthesis_engine.rs
+++ b/crates/voicevox_core/src/engine/synthesis_engine.rs
@@ -1,0 +1,84 @@
+use std::path::Path;
+
+use super::open_jtalk::OpenJtalk;
+use super::*;
+
+/*
+ * TODO: OpenJtalk機能を使用するようになったら、allow(dead_code),allow(unused_variables)を消す
+ */
+#[allow(dead_code)]
+pub struct SynthesisEngine {
+    open_jtalk: OpenJtalk,
+}
+
+#[allow(dead_code)]
+#[allow(unused_variables)]
+impl SynthesisEngine {
+    const DEFAULT_SAMPLING_RATE: usize = 24000;
+
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self {
+            open_jtalk: OpenJtalk::initialize(),
+        }
+    }
+
+    pub fn create_accent_phrases(
+        &self,
+        text: impl AsRef<str>,
+        speaker_id: usize,
+    ) -> Result<Vec<AccentPhraseModel>> {
+        unimplemented!()
+    }
+
+    pub fn replace_mora_data(
+        &self,
+        accent_phrases: &[AccentPhraseModel],
+        speaker_id: usize,
+    ) -> Result<Vec<AccentPhraseModel>> {
+        unimplemented!()
+    }
+
+    pub fn replace_phoneme_length(
+        &self,
+        accent_phrases: &[AccentPhraseModel],
+        speaker_id: usize,
+    ) -> Result<Vec<AccentPhraseModel>> {
+        unimplemented!()
+    }
+
+    pub fn replace_mora_pitch(
+        &self,
+        accent_phrases: &[AccentPhraseModel],
+        speaker_id: usize,
+    ) -> Result<Vec<AccentPhraseModel>> {
+        unimplemented!()
+    }
+
+    pub fn synthesis(
+        &self,
+        query: &AudioQueryModel,
+        speaker_id: usize,
+        enable_interrogative_upspeak: bool,
+    ) -> Result<Vec<f32>> {
+        unimplemented!()
+    }
+
+    pub fn synthesis_wave_format(
+        &self,
+        query: &AudioQueryModel,
+        speaker_id: usize,
+        binary_size: usize,
+        enable_interrogative_upspeak: bool,
+    ) -> Result<Vec<u8>> {
+        unimplemented!()
+    }
+
+    pub fn load_openjtalk_dict(&mut self, mecab_dict_dir: impl AsRef<Path>) -> Result<()> {
+        unimplemented!()
+    }
+
+    pub fn is_openjtalk_dict_loaded(&self) -> bool {
+        unimplemented!()
+    }
+}


### PR DESCRIPTION


## 内容
実装を複数人で分けて行う場合、SynthesisEngineの定義がないと実装が競合したり実装を進めにくくなってしまうのであらかじめ仮実装するようにした
## 関連 Issue

refs #128


