### PR TITLE
CIで非テスト時のコードもclippyでチェックするようにした

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@v1
       - run: cargo clippy --all-features --tests -- -D clippy::all -D warnings --no-deps
+      - run: cargo clippy --all-features -- -D clippy::all -D warnings --no-deps
       - run: cargo fmt -- --check
 
   rust-test:

--- a/crates/voicevox_core/src/error.rs
+++ b/crates/voicevox_core/src/error.rs
@@ -57,6 +57,7 @@ fn base_error_message(result_code: VoicevoxResultCode) -> &'static str {
 pub struct SourceError(anyhow::Error);
 
 impl SourceError {
+    #[allow(dead_code)]
     pub fn new(source: anyhow::Error) -> Self {
         Self(source)
     }


### PR DESCRIPTION
## 内容
非テスト時のコードでdead_codeになっているものを検出できないため、 --testsなしのclippy実行も追加するようにした


## 関連 Issue

refs #128

## その他
