### PR TITLE
[Rust]unsafeなコードを原則禁止にした

### DIFF
--- a/crates/voicevox_core/src/lib.rs
+++ b/crates/voicevox_core/src/lib.rs
@@ -1,3 +1,6 @@
+#![deny(unsafe_code)]
+
+#[allow(unsafe_code)]
 mod c_export;
 mod engine;
 mod error;

--- a/crates/voicevox_core/src/status.rs
+++ b/crates/voicevox_core/src/status.rs
@@ -93,7 +93,9 @@ impl SupportedDevices {
     }
 }
 
+#[allow(unsafe_code)]
 unsafe impl Send for Status {}
+#[allow(unsafe_code)]
 unsafe impl Sync for Status {}
 
 impl Status {


### PR DESCRIPTION




## 内容
unsafe_codeをdenyにすることにより、うっかりunsafeコードを書くのを防ぐことが目的
例外としてc関数向けの実装である c_export moduleと、static領域に配置する必要があるStatus structについてはunsafeを使うことを許可している
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
refs #128
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

