### PR TITLE
[Rust] update open_jtalk 0.1.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,8 +686,8 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "open_jtalk"
-version = "0.1.6"
-source = "git+https://github.com/qwerty2501/open_jtalk-rs.git#2b251db09ced472aa10980053f8c0c23d9026d0f"
+version = "0.1.7"
+source = "git+https://github.com/qwerty2501/open_jtalk-rs.git#49b651ae930f4c7422b11f27d0419f53600bc39c"
 dependencies = [
  "open_jtalk-sys",
  "thiserror",
@@ -696,7 +696,7 @@ dependencies = [
 [[package]]
 name = "open_jtalk-sys"
 version = "0.1.111"
-source = "git+https://github.com/qwerty2501/open_jtalk-rs.git#2b251db09ced472aa10980053f8c0c23d9026d0f"
+source = "git+https://github.com/qwerty2501/open_jtalk-rs.git#49b651ae930f4c7422b11f27d0419f53600bc39c"
 dependencies = [
  "bindgen",
  "cmake",

--- a/crates/voicevox_core/Cargo.toml
+++ b/crates/voicevox_core/Cargo.toml
@@ -21,7 +21,7 @@ onnxruntime = { git = "https://github.com/qwerty2501/onnxruntime-rs.git", versio
 serde = "1.0.137"
 serde_json = "1.0.81"
 thiserror = "1.0.31"
-open_jtalk = { git = "https://github.com/qwerty2501/open_jtalk-rs.git", version = "0.1.6" }
+open_jtalk = { git = "https://github.com/qwerty2501/open_jtalk-rs.git", version = "0.1.7" }
 
 [dev-dependencies]
 rstest = "0.12.0"


### PR DESCRIPTION
## 内容
open_jtalk内の各オブジェクトのinitialize,clearはユーザーで勝手に呼び出されると予期しない動作をする可能性があるため、簡単に呼び出されないようにinitialize,clearにunsafeをつけたものを反映するためにopen_jtalkをupdateする

## 関連 Issue
refs #128


## その他
