### PR TITLE
[Rust] voicevox_load_openjtalk_dict を実装した

### DIFF
--- a/crates/voicevox_core/src/engine/mod.rs
+++ b/crates/voicevox_core/src/engine/mod.rs
@@ -8,3 +8,4 @@ mod synthesis_engine;
 use super::*;
 
 pub use model::*;
+pub use synthesis_engine::*;

--- a/crates/voicevox_core/src/engine/synthesis_engine.rs
+++ b/crates/voicevox_core/src/engine/synthesis_engine.rs
@@ -3,13 +3,15 @@ use std::path::Path;
 use super::open_jtalk::OpenJtalk;
 use super::*;
 
-/*
- * TODO: OpenJtalk機能を使用するようになったら、allow(dead_code),allow(unused_variables)を消す
- */
-#[allow(dead_code)]
 pub struct SynthesisEngine {
     open_jtalk: OpenJtalk,
+    is_openjtalk_dict_loaded: bool,
 }
+
+#[allow(unsafe_code)]
+unsafe impl Send for SynthesisEngine {}
+#[allow(unsafe_code)]
+unsafe impl Sync for SynthesisEngine {}
 
 #[allow(dead_code)]
 #[allow(unused_variables)]
@@ -20,6 +22,7 @@ impl SynthesisEngine {
     pub fn new() -> Self {
         Self {
             open_jtalk: OpenJtalk::initialize(),
+            is_openjtalk_dict_loaded: false,
         }
     }
 
@@ -75,10 +78,14 @@ impl SynthesisEngine {
     }
 
     pub fn load_openjtalk_dict(&mut self, mecab_dict_dir: impl AsRef<Path>) -> Result<()> {
-        unimplemented!()
+        let result = self.open_jtalk.load(mecab_dict_dir);
+        if result.is_ok() {
+            self.is_openjtalk_dict_loaded = true;
+        }
+        result.map_err(|_| Error::NotLoadedOpenjtalkDict)
     }
 
     pub fn is_openjtalk_dict_loaded(&self) -> bool {
-        unimplemented!()
+        self.is_openjtalk_dict_loaded
     }
 }

--- a/crates/voicevox_core/src/engine/synthesis_engine.rs
+++ b/crates/voicevox_core/src/engine/synthesis_engine.rs
@@ -79,9 +79,7 @@ impl SynthesisEngine {
 
     pub fn load_openjtalk_dict(&mut self, mecab_dict_dir: impl AsRef<Path>) -> Result<()> {
         let result = self.open_jtalk.load(mecab_dict_dir);
-        if result.is_ok() {
-            self.is_openjtalk_dict_loaded = true;
-        }
+        self.is_openjtalk_dict_loaded = result.is_ok();
         result.map_err(|_| Error::NotLoadedOpenjtalkDict)
     }
 

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -8,6 +8,7 @@ use onnxruntime::{
 use std::collections::BTreeMap;
 use std::ffi::CStr;
 use std::os::raw::c_int;
+use std::path::Path;
 use std::sync::Mutex;
 
 use status::*;
@@ -25,6 +26,7 @@ static SPEAKER_ID_MAP: Lazy<BTreeMap<usize, (usize, usize)>> = Lazy::new(|| {
 pub struct Internal {
     initialized: bool,
     status_option: Option<Status>,
+    synthesis_engine: SynthesisEngine,
 }
 
 impl Internal {
@@ -32,6 +34,7 @@ impl Internal {
         Mutex::new(Internal {
             initialized: false,
             status_option: None,
+            synthesis_engine: SynthesisEngine::new(),
         })
     }
     pub fn initialize(
@@ -340,10 +343,13 @@ impl Internal {
             .collect()
     }
 
-    //TODO:仮実装がlinterエラーにならないようにするための属性なのでこの関数を正式に実装する際にallow(unused_variables)を取り除くこと
-    #[allow(unused_variables)]
     pub fn voicevox_load_openjtalk_dict(&mut self, dict_path: &CStr) -> Result<()> {
-        unimplemented!()
+        let mecab_dict_dir = Path::new(
+            dict_path
+                .to_str()
+                .map_err(|_| Error::NotLoadedOpenjtalkDict)?,
+        );
+        self.synthesis_engine.load_openjtalk_dict(mecab_dict_dir)
     }
 
     //TODO:仮実装がlinterエラーにならないようにするための属性なのでこの関数を正式に実装する際にallow(unused_variables)を取り除くこと

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -8,7 +8,6 @@ use onnxruntime::{
 use std::collections::BTreeMap;
 use std::ffi::CStr;
 use std::os::raw::c_int;
-use std::path::Path;
 use std::sync::Mutex;
 
 use status::*;
@@ -344,12 +343,11 @@ impl Internal {
     }
 
     pub fn voicevox_load_openjtalk_dict(&mut self, dict_path: &CStr) -> Result<()> {
-        let mecab_dict_dir = Path::new(
+        self.synthesis_engine.load_openjtalk_dict(
             dict_path
                 .to_str()
                 .map_err(|_| Error::NotLoadedOpenjtalkDict)?,
-        );
-        self.synthesis_engine.load_openjtalk_dict(mecab_dict_dir)
+        )
     }
 
     //TODO:仮実装がlinterエラーにならないようにするための属性なのでこの関数を正式に実装する際にallow(unused_variables)を取り除くこと

--- a/crates/voicevox_core/src/lib.rs
+++ b/crates/voicevox_core/src/lib.rs
@@ -8,6 +8,7 @@ mod internal;
 mod result;
 mod status;
 
+use engine::*;
 use error::*;
 use result::*;
 


### PR DESCRIPTION
## 内容

`SynthesisEngine::load_openjtalk_dict`, `Internal::voicevox_load_openjtalk_dict` を実装しました。

テストはまだ実装していません。
open_jtalk-rs では https://github.com/qwerty2501/open_jtalk-rs/blob/49b651ae930f4c7422b11f27d0419f53600bc39c/crates/open_jtalk/src/mecab/mod.rs#L112-L120 のようにクレート内にテストデータを配置して、それを用いてテストしていますが、voicevox_core でもとりあえずは同様にテストを実装することになりそうでしょうか？　ご意見をお聞きしたいと思います。議論の結果に応じた方法でテストを実装したい（あるいは TODO としたい）と思います。

ちなみに、`voicevox_tts` 関数のテストも OpenJTalk の辞書の読み込みが必須となると思います。

## 関連 Issue

ref #128 
