### PR TITLE
[Rust] SynthesisEngine::replace_mora_data を実装

### DIFF
--- a/crates/voicevox_core/src/engine/acoustic_feature_extractor.rs
+++ b/crates/voicevox_core/src/engine/acoustic_feature_extractor.rs
@@ -1,0 +1,68 @@
+use derive_getters::Getters;
+use derive_new::new;
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+
+macro_rules! make_phoneme_map {
+    ($(($key:expr, $value:expr)),*) => {
+        {
+            let mut m = HashMap::new();
+            $(m.insert($key.to_string(), $value);)*
+            m
+        }
+    };
+}
+
+#[allow(unused)]
+#[rustfmt::skip]
+static PHONEME_MAP: Lazy<HashMap<String, i64>> = Lazy::new(|| {
+    make_phoneme_map!(
+        ("pau", 0), ("A", 1),   ("E", 2),   ("I", 3),   ("N", 4),   ("O", 5),   ("U", 6),   ("a", 7),   ("b", 8),
+        ("by", 9),  ("ch", 10), ("cl", 11), ("d", 12),  ("dy", 13), ("e", 14),  ("f", 15),  ("g", 16),  ("gw", 17),
+        ("gy", 18), ("h", 19),  ("hy", 20), ("i", 21),  ("j", 22),  ("k", 23),  ("kw", 24), ("ky", 25), ("m", 26),
+        ("my", 27), ("n", 28),  ("ny", 29), ("o", 30),  ("p", 31),  ("py", 32), ("r", 33),  ("ry", 34), ("s", 35),
+        ("sh", 36), ("t", 37),  ("ts", 38), ("ty", 39), ("u", 40),  ("v", 41),  ("w", 42),  ("y", 43),  ("z", 44)
+    )
+});
+
+#[allow(unused)]
+#[derive(Debug, Clone, new, Default, Getters)]
+pub struct OjtPhoneme {
+    phoneme: String,
+    start: f32,
+    end: f32,
+}
+
+#[allow(unused)]
+impl OjtPhoneme {
+    pub fn num_phoneme() -> usize {
+        PHONEME_MAP.len()
+    }
+
+    pub fn space_phoneme() -> String {
+        "pau".into()
+    }
+
+    pub fn phoneme_id(&self) -> i64 {
+        if self.phoneme.is_empty() {
+            -1
+        } else {
+            *PHONEME_MAP.get(&self.phoneme).unwrap()
+        }
+    }
+
+    pub fn convert(phonemes: &[OjtPhoneme]) -> Vec<OjtPhoneme> {
+        let mut phonemes = phonemes.to_owned();
+        if let Some(first_phoneme) = phonemes.first_mut() {
+            if !first_phoneme.phoneme.contains("sil") {
+                first_phoneme.phoneme = OjtPhoneme::space_phoneme();
+            }
+        }
+        if let Some(last_phoneme) = phonemes.last_mut() {
+            if !last_phoneme.phoneme.contains("sil") {
+                last_phoneme.phoneme = OjtPhoneme::space_phoneme();
+            }
+        }
+        phonemes
+    }
+}

--- a/crates/voicevox_core/src/engine/acoustic_feature_extractor.rs
+++ b/crates/voicevox_core/src/engine/acoustic_feature_extractor.rs
@@ -13,7 +13,6 @@ macro_rules! make_phoneme_map {
     };
 }
 
-#[allow(unused)]
 #[rustfmt::skip]
 static PHONEME_MAP: Lazy<HashMap<String, i64>> = Lazy::new(|| {
     make_phoneme_map!(
@@ -25,16 +24,17 @@ static PHONEME_MAP: Lazy<HashMap<String, i64>> = Lazy::new(|| {
     )
 });
 
-#[allow(unused)]
 #[derive(Debug, Clone, new, Default, Getters)]
 pub struct OjtPhoneme {
     phoneme: String,
+    #[allow(dead_code)]
     start: f32,
+    #[allow(dead_code)]
     end: f32,
 }
 
-#[allow(unused)]
 impl OjtPhoneme {
+    #[allow(dead_code)]
     pub fn num_phoneme() -> usize {
         PHONEME_MAP.len()
     }

--- a/crates/voicevox_core/src/engine/kana_parser.rs
+++ b/crates/voicevox_core/src/engine/kana_parser.rs
@@ -40,6 +40,8 @@ static TEXT2MORA_WITH_UNVOICE: Lazy<HashMap<String, MoraModel>> = Lazy::new(|| {
                 consonant.clone(),
                 consonant_length,
                 upper_vowel,
+                0.,
+                0.,
             );
             text2mora_with_unvoice.insert(UNVOICE_SYMBOL.to_string() + text, unvoice_mora);
         }
@@ -49,6 +51,8 @@ static TEXT2MORA_WITH_UNVOICE: Lazy<HashMap<String, MoraModel>> = Lazy::new(|| {
             consonant,
             consonant_length,
             vowel.to_string(),
+            0.,
+            0.,
         );
         text2mora_with_unvoice.insert(text.to_string(), mora);
     }
@@ -156,6 +160,8 @@ fn parse_kana(text: &str) -> KanaParseResult<Vec<AccentPhraseModel>> {
                         None,
                         None,
                         "pau".to_string(),
+                        0.,
+                        0.,
                     )));
                 }
                 accent_phrase.set_is_interrogative(is_interrogative);

--- a/crates/voicevox_core/src/engine/mod.rs
+++ b/crates/voicevox_core/src/engine/mod.rs
@@ -1,3 +1,4 @@
+mod acoustic_feature_extractor;
 mod full_context_label;
 mod kana_parser;
 mod model;
@@ -7,4 +8,5 @@ mod synthesis_engine;
 
 use super::*;
 
+pub use acoustic_feature_extractor::*;
 pub use model::*;

--- a/crates/voicevox_core/src/engine/mod.rs
+++ b/crates/voicevox_core/src/engine/mod.rs
@@ -10,3 +10,4 @@ use super::*;
 
 pub use acoustic_feature_extractor::*;
 pub use model::*;
+pub use synthesis_engine::*;

--- a/crates/voicevox_core/src/engine/model.rs
+++ b/crates/voicevox_core/src/engine/model.rs
@@ -1,21 +1,17 @@
 use derive_getters::Getters;
 use derive_new::new;
 
-#[allow(dead_code)] // TODO: remove this feature
 #[derive(Clone, Debug, new, Getters)]
 pub struct MoraModel {
     text: String,
     consonant: Option<String>,
     consonant_length: Option<f32>,
     vowel: String,
-    #[new(default)]
     vowel_length: f32,
-    #[new(default)]
     pitch: f32,
 }
 
-#[allow(dead_code)] // TODO: remove this feature
-#[derive(Debug, new, Getters)]
+#[derive(Clone, Debug, new, Getters)]
 pub struct AccentPhraseModel {
     moras: Vec<MoraModel>,
     accent: usize,

--- a/crates/voicevox_core/src/engine/synthesis_engine.rs
+++ b/crates/voicevox_core/src/engine/synthesis_engine.rs
@@ -4,6 +4,12 @@ use super::internal::InferenceCore;
 use super::open_jtalk::OpenJtalk;
 use super::*;
 
+const UNVOICED_MORA_PHONEME_LIST: &[&str] = &["A", "I", "U", "E", "O", "cl", "pau"];
+
+const MORA_PHONEME_LIST: &[&str] = &[
+    "a", "i", "u", "e", "o", "N", "A", "I", "U", "E", "O", "cl", "pau",
+];
+
 /*
  * TODO: OpenJtalk機能を使用するようになったら、allow(dead_code),allow(unused_variables)を消す
  */
@@ -48,30 +54,201 @@ impl SynthesisEngine {
     }
 
     pub fn replace_mora_data(
-        &self,
+        &mut self,
         accent_phrases: &[AccentPhraseModel],
         speaker_id: usize,
     ) -> Result<Vec<AccentPhraseModel>> {
-        self.replace_mora_pitch(
-            &self.replace_phoneme_length(accent_phrases, speaker_id)?,
-            speaker_id,
-        )
+        let accent_phrases = self.replace_phoneme_length(accent_phrases, speaker_id)?;
+        self.replace_mora_pitch(&accent_phrases, speaker_id)
     }
 
     pub fn replace_phoneme_length(
-        &self,
+        &mut self,
         accent_phrases: &[AccentPhraseModel],
         speaker_id: usize,
     ) -> Result<Vec<AccentPhraseModel>> {
-        unimplemented!()
+        let (_, phoneme_data_list) = SynthesisEngine::initial_process(accent_phrases);
+
+        let (_, _, vowel_indexes_data) = split_mora(&phoneme_data_list);
+
+        let phoneme_list_s: Vec<i64> = phoneme_data_list
+            .iter()
+            .map(|phoneme_data| phoneme_data.phoneme_id())
+            .collect();
+        let phoneme_length = self
+            .inference_core_mut()
+            .yukarin_s_forward(&phoneme_list_s, speaker_id)?;
+
+        let mut index = 0;
+        let new_accent_phrases = accent_phrases
+            .iter()
+            .map(|accent_phrase| {
+                AccentPhraseModel::new(
+                    accent_phrase
+                        .moras()
+                        .iter()
+                        .map(|mora| {
+                            let new_mora = MoraModel::new(
+                                mora.text().clone(),
+                                mora.consonant().clone(),
+                                mora.consonant().as_ref().map(|s| {
+                                    phoneme_length[vowel_indexes_data[index + 1] as usize - 1]
+                                }),
+                                mora.vowel().clone(),
+                                phoneme_length[vowel_indexes_data[index + 1] as usize],
+                                *mora.pitch(),
+                            );
+                            index += 1;
+                            new_mora
+                        })
+                        .collect(),
+                    accent_phrase.accent().clone(),
+                    accent_phrase.pause_mora().as_ref().map(|pause_mora| {
+                        let new_pause_mora = MoraModel::new(
+                            pause_mora.text().clone(),
+                            pause_mora.consonant().clone(),
+                            Some(phoneme_length[vowel_indexes_data[index + 1] as usize]),
+                            pause_mora.vowel().clone(),
+                            *pause_mora.vowel_length(),
+                            *pause_mora.pitch(),
+                        );
+                        index += 1;
+                        new_pause_mora
+                    }),
+                    *accent_phrase.is_interrogative(),
+                )
+            })
+            .collect();
+
+        Ok(new_accent_phrases)
     }
 
     pub fn replace_mora_pitch(
-        &self,
+        &mut self,
         accent_phrases: &[AccentPhraseModel],
         speaker_id: usize,
     ) -> Result<Vec<AccentPhraseModel>> {
-        unimplemented!()
+        let (_, phoneme_data_list) = SynthesisEngine::initial_process(accent_phrases);
+
+        let mut base_start_accent_list = vec![0];
+        let mut base_end_accent_list = vec![0];
+        let mut base_start_accent_phrase_list = vec![0];
+        let mut base_end_accent_phrase_list = vec![0];
+        for accent_phrase in accent_phrases {
+            let mut accent: usize = if *accent_phrase.accent() == 1 { 0 } else { 1 };
+            SynthesisEngine::create_one_accent_list(
+                &mut base_start_accent_list,
+                accent_phrase,
+                accent as i32,
+            );
+
+            accent = *accent_phrase.accent() - 1;
+            SynthesisEngine::create_one_accent_list(
+                &mut base_end_accent_list,
+                accent_phrase,
+                accent as i32,
+            );
+            SynthesisEngine::create_one_accent_list(
+                &mut base_start_accent_phrase_list,
+                accent_phrase,
+                0,
+            );
+            SynthesisEngine::create_one_accent_list(
+                &mut base_end_accent_phrase_list,
+                accent_phrase,
+                -1,
+            );
+        }
+        base_start_accent_list.push(0);
+        base_end_accent_list.push(0);
+        base_start_accent_phrase_list.push(0);
+        base_end_accent_phrase_list.push(0);
+
+        let (consonant_phoneme_data_list, vowel_phoneme_data_list, vowel_indexes) =
+            split_mora(&phoneme_data_list);
+
+        let consonant_phoneme_list: Vec<i64> = consonant_phoneme_data_list
+            .iter()
+            .map(|phoneme_data| phoneme_data.phoneme_id())
+            .collect();
+        let vowel_phoneme_list: Vec<i64> = vowel_phoneme_data_list
+            .iter()
+            .map(|phoneme_data| phoneme_data.phoneme_id())
+            .collect();
+
+        let mut start_accent_list = Vec::with_capacity(vowel_indexes.len());
+        let mut end_accent_list = Vec::with_capacity(vowel_indexes.len());
+        let mut start_accent_phrase_list = Vec::with_capacity(vowel_indexes.len());
+        let mut end_accent_phrase_list = Vec::with_capacity(vowel_indexes.len());
+
+        for vowel_index in vowel_indexes {
+            start_accent_list.push(base_start_accent_list[vowel_index as usize]);
+            end_accent_list.push(base_end_accent_list[vowel_index as usize]);
+            start_accent_phrase_list.push(base_start_accent_phrase_list[vowel_index as usize]);
+            end_accent_phrase_list.push(base_end_accent_phrase_list[vowel_index as usize]);
+        }
+
+        let mut f0_list = self.inference_core_mut().yukarin_sa_forward(
+            vowel_phoneme_list.len() as i64,
+            &vowel_phoneme_list,
+            &consonant_phoneme_list,
+            &start_accent_list,
+            &end_accent_list,
+            &start_accent_phrase_list,
+            &end_accent_phrase_list,
+            speaker_id,
+        )?;
+
+        for i in 0..vowel_phoneme_data_list.len() {
+            if UNVOICED_MORA_PHONEME_LIST
+                .iter()
+                .find(|phoneme| **phoneme == vowel_phoneme_data_list[i].phoneme())
+                .is_some()
+            {
+                f0_list[i] = 0.;
+            }
+        }
+
+        let mut index = 0;
+        let new_accent_phrases = accent_phrases
+            .iter()
+            .map(|accent_phrase| {
+                AccentPhraseModel::new(
+                    accent_phrase
+                        .moras()
+                        .iter()
+                        .map(|mora| {
+                            let new_mora = MoraModel::new(
+                                mora.text().clone(),
+                                mora.consonant().clone(),
+                                *mora.consonant_length(),
+                                mora.vowel().clone(),
+                                *mora.vowel_length(),
+                                f0_list[index + 1],
+                            );
+                            index += 1;
+                            new_mora
+                        })
+                        .collect(),
+                    *accent_phrase.accent(),
+                    accent_phrase.pause_mora().as_ref().map(|pause_mora| {
+                        let new_pause_mora = MoraModel::new(
+                            pause_mora.text().clone(),
+                            pause_mora.consonant().clone(),
+                            *pause_mora.consonant_length(),
+                            pause_mora.vowel().clone(),
+                            *pause_mora.vowel_length(),
+                            f0_list[index + 1],
+                        );
+                        index += 1;
+                        new_pause_mora
+                    }),
+                    *accent_phrase.is_interrogative(),
+                )
+            })
+            .collect();
+
+        Ok(new_accent_phrases)
     }
 
     pub fn synthesis(
@@ -100,4 +277,104 @@ impl SynthesisEngine {
     pub fn is_openjtalk_dict_loaded(&self) -> bool {
         unimplemented!()
     }
+
+    fn initial_process(accent_phrases: &[AccentPhraseModel]) -> (Vec<MoraModel>, Vec<OjtPhoneme>) {
+        let flatten_moras = to_flatten_moras(accent_phrases);
+
+        let mut phoneme_strings = vec!["pau".to_string()];
+        for mora in flatten_moras.iter() {
+            if let Some(consonant) = mora.consonant() {
+                phoneme_strings.push(consonant.clone())
+            }
+            phoneme_strings.push(mora.vowel().clone());
+        }
+        phoneme_strings.push("pau".to_string());
+
+        let phoneme_data_list = to_phoneme_data_list(&phoneme_strings);
+
+        (flatten_moras, phoneme_data_list)
+    }
+
+    fn create_one_accent_list(
+        accent_list: &mut Vec<i64>,
+        accent_phrase: &AccentPhraseModel,
+        point: i32,
+    ) {
+        let mut one_accent_list: Vec<i64> = Vec::new();
+
+        for (i, mora) in accent_phrase.moras().iter().enumerate() {
+            let value = if i as i32 == point
+                || (point < 0 && i == (accent_phrase.moras().len() as i32 + point) as usize)
+            {
+                1
+            } else {
+                0
+            };
+            one_accent_list.push(value as i64);
+            if mora.consonant().is_some() {
+                one_accent_list.push(value as i64);
+            }
+        }
+        if accent_phrase.pause_mora().is_some() {
+            one_accent_list.push(0);
+        }
+        accent_list.extend(one_accent_list)
+    }
+}
+
+pub fn to_flatten_moras(accent_phrases: &[AccentPhraseModel]) -> Vec<MoraModel> {
+    let mut flatten_moras = Vec::new();
+
+    for accent_phrase in accent_phrases {
+        let moras = accent_phrase.moras();
+        for mora in moras {
+            flatten_moras.push(mora.clone());
+        }
+        if let Some(pause_mora) = accent_phrase.pause_mora() {
+            flatten_moras.push(pause_mora.clone());
+        }
+    }
+
+    flatten_moras
+}
+
+pub fn to_phoneme_data_list<T: AsRef<str>>(phoneme_str_list: &[T]) -> Vec<OjtPhoneme> {
+    OjtPhoneme::convert(
+        phoneme_str_list
+            .into_iter()
+            .enumerate()
+            .map(|(i, s)| OjtPhoneme::new(s.as_ref().to_string(), i as f32, i as f32 + 1.))
+            .collect::<Vec<OjtPhoneme>>()
+            .as_slice(),
+    )
+}
+
+pub fn split_mora(phoneme_list: &[OjtPhoneme]) -> (Vec<OjtPhoneme>, Vec<OjtPhoneme>, Vec<i64>) {
+    let mut vowel_indexes = Vec::new();
+    for i in 0..phoneme_list.len() {
+        let result = MORA_PHONEME_LIST
+            .iter()
+            .find(|phoneme| **phoneme == phoneme_list[i].phoneme());
+        if result.is_some() {
+            vowel_indexes.push(i as i64);
+        }
+    }
+
+    let vowel_phoneme_list = vowel_indexes
+        .iter()
+        .map(|vowel_index| phoneme_list[*vowel_index as usize].clone())
+        .collect();
+
+    let mut consonant_phoneme_list = vec![OjtPhoneme::default()];
+    for i in 0..(vowel_indexes.len() - 1) {
+        let prev = vowel_indexes[i];
+        let next = vowel_indexes[i + 1];
+        if next - prev == 1 {
+            consonant_phoneme_list.push(OjtPhoneme::default());
+        } else {
+            consonant_phoneme_list.push(phoneme_list[next as usize - 1].clone());
+        }
+    }
+
+    (consonant_phoneme_list, vowel_phoneme_list, vowel_indexes)
 }

--- a/crates/voicevox_core/src/engine/synthesis_engine.rs
+++ b/crates/voicevox_core/src/engine/synthesis_engine.rs
@@ -351,7 +351,10 @@ pub fn to_phoneme_data_list<T: AsRef<str>>(phoneme_str_list: &[T]) -> Vec<OjtPho
 pub fn split_mora(phoneme_list: &[OjtPhoneme]) -> (Vec<OjtPhoneme>, Vec<OjtPhoneme>, Vec<i64>) {
     let mut vowel_indexes = Vec::new();
     for (i, phoneme) in phoneme_list.iter().enumerate() {
-        if MORA_PHONEME_LIST.iter().any(|p| *p == phoneme.phoneme()) {
+        if MORA_PHONEME_LIST
+            .iter()
+            .any(|mora_phoneme| *mora_phoneme == phoneme.phoneme())
+        {
             vowel_indexes.push(i as i64);
         }
     }

--- a/crates/voicevox_core/src/engine/synthesis_engine.rs
+++ b/crates/voicevox_core/src/engine/synthesis_engine.rs
@@ -102,7 +102,7 @@ impl SynthesisEngine {
                             new_mora
                         })
                         .collect(),
-                    accent_phrase.accent().clone(),
+                    *accent_phrase.accent(),
                     accent_phrase.pause_mora().as_ref().map(|pause_mora| {
                         let new_pause_mora = MoraModel::new(
                             pause_mora.text().clone(),
@@ -202,8 +202,7 @@ impl SynthesisEngine {
         for i in 0..vowel_phoneme_data_list.len() {
             if UNVOICED_MORA_PHONEME_LIST
                 .iter()
-                .find(|phoneme| **phoneme == vowel_phoneme_data_list[i].phoneme())
-                .is_some()
+                .any(|phoneme| *phoneme == vowel_phoneme_data_list[i].phoneme())
             {
                 f0_list[i] = 0.;
             }
@@ -341,7 +340,7 @@ pub fn to_flatten_moras(accent_phrases: &[AccentPhraseModel]) -> Vec<MoraModel> 
 pub fn to_phoneme_data_list<T: AsRef<str>>(phoneme_str_list: &[T]) -> Vec<OjtPhoneme> {
     OjtPhoneme::convert(
         phoneme_str_list
-            .into_iter()
+            .iter()
             .enumerate()
             .map(|(i, s)| OjtPhoneme::new(s.as_ref().to_string(), i as f32, i as f32 + 1.))
             .collect::<Vec<OjtPhoneme>>()
@@ -351,11 +350,8 @@ pub fn to_phoneme_data_list<T: AsRef<str>>(phoneme_str_list: &[T]) -> Vec<OjtPho
 
 pub fn split_mora(phoneme_list: &[OjtPhoneme]) -> (Vec<OjtPhoneme>, Vec<OjtPhoneme>, Vec<i64>) {
     let mut vowel_indexes = Vec::new();
-    for i in 0..phoneme_list.len() {
-        let result = MORA_PHONEME_LIST
-            .iter()
-            .find(|phoneme| **phoneme == phoneme_list[i].phoneme());
-        if result.is_some() {
+    for (i, phoneme) in phoneme_list.iter().enumerate() {
+        if MORA_PHONEME_LIST.iter().any(|p| *p == phoneme.phoneme()) {
             vowel_indexes.push(i as i64);
         }
     }

--- a/crates/voicevox_core/src/engine/synthesis_engine.rs
+++ b/crates/voicevox_core/src/engine/synthesis_engine.rs
@@ -36,7 +36,10 @@ impl SynthesisEngine {
         accent_phrases: &[AccentPhraseModel],
         speaker_id: usize,
     ) -> Result<Vec<AccentPhraseModel>> {
-        unimplemented!()
+        self.replace_mora_pitch(
+            &self.replace_phoneme_length(accent_phrases, speaker_id)?,
+            speaker_id,
+        )
     }
 
     pub fn replace_phoneme_length(

--- a/crates/voicevox_core/src/engine/synthesis_engine.rs
+++ b/crates/voicevox_core/src/engine/synthesis_engine.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use super::internal::InferenceCore;
 use super::open_jtalk::OpenJtalk;
 use super::*;
 
@@ -9,7 +10,13 @@ use super::*;
 #[allow(dead_code)]
 pub struct SynthesisEngine {
     open_jtalk: OpenJtalk,
+    inference_core: InferenceCore,
 }
+
+#[allow(unsafe_code)]
+unsafe impl Send for SynthesisEngine {}
+#[allow(unsafe_code)]
+unsafe impl Sync for SynthesisEngine {}
 
 #[allow(dead_code)]
 #[allow(unused_variables)]
@@ -17,10 +24,19 @@ impl SynthesisEngine {
     const DEFAULT_SAMPLING_RATE: usize = 24000;
 
     #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
+    pub fn new(inference_core: InferenceCore) -> Self {
         Self {
             open_jtalk: OpenJtalk::initialize(),
+            inference_core,
         }
+    }
+
+    pub fn inference_core(&self) -> &InferenceCore {
+        &self.inference_core
+    }
+
+    pub fn inference_core_mut(&mut self) -> &mut InferenceCore {
+        &mut self.inference_core
     }
 
     pub fn create_accent_phrases(


### PR DESCRIPTION
## 内容

`SynthesisEngine::replace_mora_data` を実装します。また、このメソッドの実装には `SynthesisEngine::replace_phoneme_length` および `SynthesisEngine::replace_mora_pitch` も必要なので、これらのメソッドも実装します。

- [x] `SynthesisEngine::replace_mora_data`
- [x] `SynthesisEngine::replace_phoneme_length`
- [x] `SynthesisEngine::replace_mora_pitch`

## 関連 Issue

ref #128 
