### PR TITLE
[Rust] acoustic_feature_extractor のテストを追加

### DIFF
--- a/crates/voicevox_core/src/engine/acoustic_feature_extractor.rs
+++ b/crates/voicevox_core/src/engine/acoustic_feature_extractor.rs
@@ -3,28 +3,64 @@ use derive_new::new;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
 
-macro_rules! make_phoneme_map {
-    ($(($key:expr, $value:expr)),*) => {
-        {
-            let mut m = HashMap::new();
-            $(m.insert($key.to_string(), $value);)*
-            m
-        }
-    };
-}
-
 #[rustfmt::skip]
+const PHONEME_LIST: &[&str] = &[
+    "pau",
+    "A",
+    "E",
+    "I",
+    "N",
+    "O",
+    "U",
+    "a",
+    "b",
+    "by",
+    "ch",
+    "cl",
+    "d",
+    "dy",
+    "e",
+    "f",
+    "g",
+    "gw",
+    "gy",
+    "h",
+    "hy",
+    "i",
+    "j",
+    "k",
+    "kw",
+    "ky",
+    "m",
+    "my",
+    "n",
+    "ny",
+    "o",
+    "p",
+    "py",
+    "r",
+    "ry",
+    "s",
+    "sh",
+    "t",
+    "ts",
+    "ty",
+    "u",
+    "v",
+    "w",
+    "y",
+    "z",
+];
+
 static PHONEME_MAP: Lazy<HashMap<String, i64>> = Lazy::new(|| {
-    make_phoneme_map!(
-        ("pau", 0), ("A", 1),   ("E", 2),   ("I", 3),   ("N", 4),   ("O", 5),   ("U", 6),   ("a", 7),   ("b", 8),
-        ("by", 9),  ("ch", 10), ("cl", 11), ("d", 12),  ("dy", 13), ("e", 14),  ("f", 15),  ("g", 16),  ("gw", 17),
-        ("gy", 18), ("h", 19),  ("hy", 20), ("i", 21),  ("j", 22),  ("k", 23),  ("kw", 24), ("ky", 25), ("m", 26),
-        ("my", 27), ("n", 28),  ("ny", 29), ("o", 30),  ("p", 31),  ("py", 32), ("r", 33),  ("ry", 34), ("s", 35),
-        ("sh", 36), ("t", 37),  ("ts", 38), ("ty", 39), ("u", 40),  ("v", 41),  ("w", 42),  ("y", 43),  ("z", 44)
-    )
+    let mut m = HashMap::new();
+    for (i, s) in PHONEME_LIST.iter().enumerate() {
+        m.insert((*s).into(), i as i64);
+    }
+    m
 });
 
-#[derive(Debug, Clone, new, Default, Getters)]
+#[derive(Debug, Clone, PartialEq, new, Default, Getters)]
 pub struct OjtPhoneme {
     phoneme: String,
     #[allow(dead_code)]
@@ -54,15 +90,91 @@ impl OjtPhoneme {
     pub fn convert(phonemes: &[OjtPhoneme]) -> Vec<OjtPhoneme> {
         let mut phonemes = phonemes.to_owned();
         if let Some(first_phoneme) = phonemes.first_mut() {
-            if !first_phoneme.phoneme.contains("sil") {
+            if first_phoneme.phoneme.contains("sil") {
                 first_phoneme.phoneme = OjtPhoneme::space_phoneme();
             }
         }
         if let Some(last_phoneme) = phonemes.last_mut() {
-            if !last_phoneme.phoneme.contains("sil") {
+            if last_phoneme.phoneme.contains("sil") {
                 last_phoneme.phoneme = OjtPhoneme::space_phoneme();
             }
         }
         phonemes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    use crate::*;
+
+    const STR_HELLO_HIHO: &str = "sil k o N n i ch i w a pau h i h o d e s U sil";
+
+    fn base_hello_hiho() -> Vec<OjtPhoneme> {
+        STR_HELLO_HIHO
+            .split_whitespace()
+            .enumerate()
+            .map(|(i, s)| OjtPhoneme::new(s.into(), i as f32, (i + 1) as f32))
+            .collect()
+    }
+
+    fn ojt_hello_hiho() -> Vec<OjtPhoneme> {
+        OjtPhoneme::convert(&base_hello_hiho())
+    }
+
+    #[rstest]
+    #[case(1, "A")]
+    #[case(14, "e")]
+    #[case(26, "m")]
+    #[case(38, "ts")]
+    #[case(41, "v")]
+    fn test_phoneme_list(#[case] index: usize, #[case] phoneme_str: &str) {
+        assert_eq!(PHONEME_LIST[index], phoneme_str);
+    }
+
+    #[rstest]
+    fn test_num_phoneme_works() {
+        assert_eq!(OjtPhoneme::num_phoneme(), 45);
+    }
+
+    #[rstest]
+    fn test_space_phoneme_works() {
+        assert_eq!(OjtPhoneme::space_phoneme(), "pau");
+    }
+
+    #[rstest]
+    #[case(ojt_hello_hiho(), "pau k o N n i ch i w a pau h i h o d e s U pau")]
+    fn test_convert_works(#[case] ojt_phonemes: Vec<OjtPhoneme>, #[case] expected: &str) {
+        let ojt_str_hello_hiho: String = ojt_phonemes
+            .iter()
+            .map(|phoneme| phoneme.phoneme().clone())
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert_eq!(ojt_str_hello_hiho, expected);
+    }
+
+    #[rstest]
+    #[case(ojt_hello_hiho(), 9, OjtPhoneme::new("a".into(), 9., 10.), true)]
+    #[case(ojt_hello_hiho(), 9, OjtPhoneme::new("k".into(), 9., 10.), false)]
+    #[case(ojt_hello_hiho(), 9, OjtPhoneme::new("a".into(), 10., 11.), false)]
+    fn test_ojt_phoneme_equality(
+        #[case] ojt_phonemes: Vec<OjtPhoneme>,
+        #[case] index: usize,
+        #[case] phoneme: OjtPhoneme,
+        #[case] is_equal: bool,
+    ) {
+        assert_eq!(ojt_phonemes[index] == phoneme, is_equal);
+    }
+
+    #[rstest]
+    #[case(ojt_hello_hiho(), &[0, 23, 30, 4, 28, 21, 10, 21, 42, 7, 0, 19, 21, 19, 30, 12, 14, 35, 6, 0])]
+    fn test_phoneme_id_works(#[case] ojt_phonemes: Vec<OjtPhoneme>, #[case] expected_ids: &[i64]) {
+        let ojt_ids = ojt_phonemes
+            .iter()
+            .map(|phoneme| phoneme.phoneme_id())
+            .collect::<Vec<_>>();
+        assert_eq!(ojt_ids, expected_ids);
     }
 }

--- a/crates/voicevox_core/src/engine/acoustic_feature_extractor.rs
+++ b/crates/voicevox_core/src/engine/acoustic_feature_extractor.rs
@@ -52,10 +52,10 @@ const PHONEME_LIST: &[&str] = &[
     "z",
 ];
 
-static PHONEME_MAP: Lazy<HashMap<String, i64>> = Lazy::new(|| {
+static PHONEME_MAP: Lazy<HashMap<&str, i64>> = Lazy::new(|| {
     let mut m = HashMap::new();
     for (i, s) in PHONEME_LIST.iter().enumerate() {
-        m.insert((*s).into(), i as i64);
+        m.insert(*s, i as i64);
     }
     m
 });
@@ -83,7 +83,7 @@ impl OjtPhoneme {
         if self.phoneme.is_empty() {
             -1
         } else {
-            *PHONEME_MAP.get(&self.phoneme).unwrap()
+            *PHONEME_MAP.get(&self.phoneme.as_str()).unwrap()
         }
     }
 


### PR DESCRIPTION
## 内容

https://github.com/VOICEVOX/voicevox_engine/blob/fd9f89795bd1ca9eb39d81b571404e789f9067d3/test/test_acoustic_feature_extractor.py#L178 を参考に、`acoustic_feature_extractor` のテストを現在実装している機能の範囲で追加しました。また、テストによって発見した実装の誤りを修正しました。

## 関連 Issue

ref #128 
