### PR TITLE
[Rust] cp コマンドに起因するテスト失敗への対処

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
         shell: bash
         run: |
           cargo build
-          rm -f target/debug/deps/onnxruntime.dll && cp target/debug/build/onnxruntime-sys-*/out/onnxruntime_*/onnxruntime-*/lib/onnxruntime.dll target/debug/deps/
+          \cp target/debug/build/onnxruntime-sys-*/out/onnxruntime_*/onnxruntime-*/lib/onnxruntime.dll target/debug/deps/
       - run: cargo test --all-features
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## 内容

#180 で windows-2022 のテストが落ちる問題が修正されたはずでしたが、まだ落ちることがあるようなので原因を探っています。

失敗したテストのログ： https://github.com/VOICEVOX/voicevox_core/runs/7355366635?check_suite_focus=true

root ユーザーとして cp コマンドでファイルを上書きする操作をすると失敗するという情報 (https://qiita.com/kentarosasaki/items/4090f1abfd8d05c6c801) を見つけたので、この記事の対処法でうまくいかないか試します。うまくいかない場合は close します。

## 関連 Issue

ref #128 
