### PR TITLE
[Rust] voicevox_load_openjtalk_dict を実装した

### DIFF
--- a/crates/voicevox_core/src/engine/open_jtalk.rs
+++ b/crates/voicevox_core/src/engine/open_jtalk.rs
@@ -31,7 +31,6 @@ pub struct OpenJtalk {
 }
 
 impl OpenJtalk {
-    #[allow(dead_code)]
     pub fn initialize() -> Self {
         Self {
             mecab: ManagedResource::initialize(),
@@ -81,17 +80,21 @@ impl OpenJtalk {
         }
     }
 
-    #[allow(dead_code)]
     pub fn load(&mut self, mecab_dict_dir: impl AsRef<Path>) -> Result<()> {
         let result = self.mecab.load(mecab_dict_dir.as_ref());
         if result {
             self.dict_loaded = true;
             Ok(())
         } else {
+            self.dict_loaded = false;
             Err(OpenJtalkError::Load {
                 mecab_dict_dir: mecab_dict_dir.as_ref().into(),
             })
         }
+    }
+
+    pub fn dict_loaded(&self) -> bool {
+        self.dict_loaded
     }
 }
 

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -124,10 +124,12 @@ impl Internal {
         )
     }
 
-    //TODO:仮実装がlinterエラーにならないようにするための属性なのでこの関数を正式に実装する際にallow(unused_variables)を取り除くこと
-    #[allow(unused_variables)]
     pub fn voicevox_load_openjtalk_dict(&mut self, dict_path: &CStr) -> Result<()> {
-        unimplemented!()
+        self.synthesis_engine.load_openjtalk_dict(
+            dict_path
+                .to_str()
+                .map_err(|_| Error::NotLoadedOpenjtalkDict)?,
+        )
     }
 
     //TODO:仮実装がlinterエラーにならないようにするための属性なのでこの関数を正式に実装する際にallow(unused_variables)を取り除くこと
@@ -703,5 +705,18 @@ mod tests {
 
         assert!(result.is_ok(), "{:?}", result);
         assert_eq!(result.unwrap().len(), F0_LENGTH * 256);
+    }
+
+    #[rstest]
+    #[async_std::test]
+    async fn voicevox_load_openjtalk_dict_works() {
+        let internal = Internal::new_with_mutex();
+        let open_jtalk_dic_dir = download_open_jtalk_dict_if_no_exists().await;
+        let result = internal.lock().unwrap().voicevox_load_openjtalk_dict(
+            CString::new(open_jtalk_dic_dir.to_str().unwrap())
+                .unwrap()
+                .as_c_str(),
+        );
+        assert_eq!(result, Ok(()));
     }
 }


### PR DESCRIPTION
## 内容

`voicevox_load_openjtalk_dict` を実装しました。 #177 で一度実装していましたが、 #178 における `Internal` の設計の変更を優先するため close していました。それを再実装したものです。

`SynthesisEngine` と `Internal` それぞれで最低限のテストも実装しました。

## 関連 Issue

ref #128 
