### PR TITLE
[Rust] voicevox_tts と voicevox_wav_free の実装

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,9 +1117,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libloading"
@@ -2320,6 +2320,7 @@ dependencies = [
  "derive-getters",
  "derive-new",
  "flate2",
+ "libc",
  "once_cell",
  "onnxruntime",
  "open_jtalk",

--- a/crates/voicevox_core/Cargo.toml
+++ b/crates/voicevox_core/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0.57"
 cfg-if = "1.0.0"
 derive-getters = "0.2.0"
 derive-new = "0.5.9"
+libc = "0.2.126"
 once_cell = "1.10.0"
 onnxruntime = { git = "https://github.com/qwerty2501/onnxruntime-rs.git", version = "0.0.24" }
 serde = "1.0.137"

--- a/crates/voicevox_core/src/c_export.rs
+++ b/crates/voicevox_core/src/c_export.rs
@@ -33,6 +33,7 @@ pub enum VoicevoxResultCode {
     VOICEVOX_RESULT_INVALID_SPEAKER_ID = 7,
     VOICEVOX_RESULT_INVALID_MODEL_INDEX = 8,
     VOICEVOX_RESULT_INFERENCE_FAILED = 9,
+    VOICEVOX_RESULT_FAILED_EXTRACT_FULL_CONTEXT_LABEL = 10,
 }
 
 fn convert_result<T>(result: Result<T>) -> (Option<T>, VoicevoxResultCode) {
@@ -73,6 +74,10 @@ fn convert_result<T>(result: Result<T>) -> (Option<T>, VoicevoxResultCode) {
                 Error::InferenceFailed => {
                     (None, VoicevoxResultCode::VOICEVOX_RESULT_INFERENCE_FAILED)
                 }
+                Error::FailedExtractFullContextLabel(_) => (
+                    None,
+                    VoicevoxResultCode::VOICEVOX_RESULT_FAILED_EXTRACT_FULL_CONTEXT_LABEL,
+                ),
             }
         }
     }

--- a/crates/voicevox_core/src/c_export.rs
+++ b/crates/voicevox_core/src/c_export.rs
@@ -240,7 +240,8 @@ pub extern "C" fn decode_forward(
 #[no_mangle]
 pub extern "C" fn voicevox_load_openjtalk_dict(dict_path: *const c_char) -> VoicevoxResultCode {
     let (_, result_code) = convert_result(
-        lock_internal().voicevox_load_openjtalk_dict(unsafe { CStr::from_ptr(dict_path) }),
+        lock_internal()
+            .voicevox_load_openjtalk_dict(unsafe { CStr::from_ptr(dict_path) }.to_str().unwrap()),
     );
     result_code
 }
@@ -252,9 +253,10 @@ pub extern "C" fn voicevox_tts(
     output_binary_size: *mut c_int,
     output_wav: *mut *mut u8,
 ) -> VoicevoxResultCode {
-    let (output_opt, result_code) = convert_result(
-        lock_internal().voicevox_tts(unsafe { CStr::from_ptr(text) }, speaker_id as usize),
-    );
+    let (output_opt, result_code) = convert_result(lock_internal().voicevox_tts(
+        unsafe { CStr::from_ptr(text) }.to_str().unwrap(),
+        speaker_id as usize,
+    ));
     if let Some(output) = output_opt {
         unsafe {
             output_binary_size.write(output.len() as c_int);

--- a/crates/voicevox_core/src/engine/full_context_label.rs
+++ b/crates/voicevox_core/src/engine/full_context_label.rs
@@ -40,11 +40,13 @@ static I3_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"(@(\d+|xx)\+)").unwrap(
 static J1_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"(/J:(\d+|xx)_)").unwrap());
 
 fn string_feature_by_regex(re: &Regex, label: &str) -> Result<String> {
-    re.find(label)
-        .map(|m| m.as_str().to_string())
-        .ok_or_else(|| FullContextLabelError::LabelParse {
+    if let Some(caps) = re.captures(label) {
+        Ok(caps.get(2).unwrap().as_str().to_string())
+    } else {
+        Err(FullContextLabelError::LabelParse {
             label: label.into(),
         })
+    }
 }
 
 #[allow(dead_code)]

--- a/crates/voicevox_core/src/engine/mod.rs
+++ b/crates/voicevox_core/src/engine/mod.rs
@@ -9,5 +9,6 @@ mod synthesis_engine;
 use super::*;
 
 pub use acoustic_feature_extractor::*;
+pub use full_context_label::*;
 pub use model::*;
 pub use synthesis_engine::*;

--- a/crates/voicevox_core/src/engine/model.rs
+++ b/crates/voicevox_core/src/engine/model.rs
@@ -1,7 +1,7 @@
-use derive_getters::Getters;
+use derive_getters::{Dissolve, Getters};
 use derive_new::new;
 
-#[derive(Clone, Debug, new, Getters)]
+#[derive(Clone, Debug, new, Dissolve, Getters)]
 pub struct MoraModel {
     text: String,
     consonant: Option<String>,

--- a/crates/voicevox_core/src/engine/model.rs
+++ b/crates/voicevox_core/src/engine/model.rs
@@ -1,7 +1,7 @@
-use derive_getters::{Dissolve, Getters};
+use derive_getters::Getters;
 use derive_new::new;
 
-#[derive(Clone, Debug, new, Dissolve, Getters)]
+#[derive(Clone, Debug, new, Getters)]
 pub struct MoraModel {
     text: String,
     consonant: Option<String>,

--- a/crates/voicevox_core/src/engine/synthesis_engine.rs
+++ b/crates/voicevox_core/src/engine/synthesis_engine.rs
@@ -29,7 +29,7 @@ unsafe impl Sync for SynthesisEngine {}
 #[allow(dead_code)]
 #[allow(unused_variables)]
 impl SynthesisEngine {
-    const DEFAULT_SAMPLING_RATE: u32 = 24000;
+    pub const DEFAULT_SAMPLING_RATE: u32 = 24000;
 
     #[allow(clippy::new_without_default)]
     pub fn new(inference_core: InferenceCore) -> Self {
@@ -432,7 +432,6 @@ impl SynthesisEngine {
         &mut self,
         query: &AudioQueryModel,
         speaker_id: usize,
-        binary_size: usize,
         enable_interrogative_upspeak: bool,
     ) -> Result<Vec<u8>> {
         let wave = self.synthesis(query, speaker_id, enable_interrogative_upspeak)?;

--- a/crates/voicevox_core/src/engine/synthesis_engine.rs
+++ b/crates/voicevox_core/src/engine/synthesis_engine.rs
@@ -445,32 +445,32 @@ impl SynthesisEngine {
         let buf: Vec<u8> = Vec::new();
         let mut cur = Cursor::new(buf);
 
-        cur.write("RIFF".as_bytes()).unwrap();
+        cur.write_all("RIFF".as_bytes()).unwrap();
 
         let bytes_size = wave.len() as u32 * repeat_count * 2;
         let wave_size = bytes_size + 44 - 8;
 
-        cur.write(&wave_size.to_le_bytes()).unwrap();
-        cur.write("WAVEfmt ".as_bytes()).unwrap();
-        cur.write(&16_u32.to_le_bytes()).unwrap(); // fmt header length
-        cur.write(&1_u16.to_le_bytes()).unwrap(); //linear PCM
-        cur.write(&num_channels.to_le_bytes()).unwrap();
-        cur.write(&output_sampling_rate.to_le_bytes()).unwrap();
+        cur.write_all(&wave_size.to_le_bytes()).unwrap();
+        cur.write_all("WAVEfmt ".as_bytes()).unwrap();
+        cur.write_all(&16_u32.to_le_bytes()).unwrap(); // fmt header length
+        cur.write_all(&1_u16.to_le_bytes()).unwrap(); //linear PCM
+        cur.write_all(&num_channels.to_le_bytes()).unwrap();
+        cur.write_all(&output_sampling_rate.to_le_bytes()).unwrap();
 
         let block_rate = output_sampling_rate * block_size as u32;
 
-        cur.write(&block_rate.to_le_bytes()).unwrap();
-        cur.write(&block_size.to_le_bytes()).unwrap();
-        cur.write(&bit_depth.to_le_bytes()).unwrap();
-        cur.write("data".as_bytes()).unwrap();
-        cur.write(&bytes_size.to_le_bytes()).unwrap();
+        cur.write_all(&block_rate.to_le_bytes()).unwrap();
+        cur.write_all(&block_size.to_le_bytes()).unwrap();
+        cur.write_all(&bit_depth.to_le_bytes()).unwrap();
+        cur.write_all("data".as_bytes()).unwrap();
+        cur.write_all(&bytes_size.to_le_bytes()).unwrap();
 
         for value in wave {
             // clip
             let v = (value * volume_scale).max(-1.).min(1.);
             let data = (v * 0x7fff as f32) as i16;
             for _ in 0..repeat_count {
-                cur.write(&data.to_le_bytes()).unwrap();
+                cur.write_all(&data.to_le_bytes()).unwrap();
             }
         }
 

--- a/crates/voicevox_core/src/engine/synthesis_engine.rs
+++ b/crates/voicevox_core/src/engine/synthesis_engine.rs
@@ -445,15 +445,14 @@ impl SynthesisEngine {
             (output_sampling_rate / Self::DEFAULT_SAMPLING_RATE) * num_channels as u32;
         let block_size: u16 = bit_depth * num_channels / 8;
 
-        let buf: Vec<u8> = Vec::new();
+        let bytes_size = wave.len() as u32 * repeat_count * 2;
+        let wave_size = bytes_size + 44;
+
+        let buf: Vec<u8> = Vec::with_capacity(wave_size as usize);
         let mut cur = Cursor::new(buf);
 
         cur.write_all("RIFF".as_bytes()).unwrap();
-
-        let bytes_size = wave.len() as u32 * repeat_count * 2;
-        let wave_size = bytes_size + 44 - 8;
-
-        cur.write_all(&wave_size.to_le_bytes()).unwrap();
+        cur.write_all(&(wave_size - 8).to_le_bytes()).unwrap();
         cur.write_all("WAVEfmt ".as_bytes()).unwrap();
         cur.write_all(&16_u32.to_le_bytes()).unwrap(); // fmt header length
         cur.write_all(&1_u16.to_le_bytes()).unwrap(); //linear PCM

--- a/crates/voicevox_core/src/engine/synthesis_engine.rs
+++ b/crates/voicevox_core/src/engine/synthesis_engine.rs
@@ -349,7 +349,9 @@ impl SynthesisEngine {
             let mut count_of_f0_bigger_than_zero = 0;
 
             for mora in flatten_moras {
-                let (_, _, consonant_length, _, vowel_length, pitch) = mora.dissolve();
+                let consonant_length = *mora.consonant_length();
+                let vowel_length = *mora.vowel_length();
+                let pitch = *mora.pitch();
 
                 if let Some(consonant_length) = consonant_length {
                     phoneme_length_list.push(consonant_length);

--- a/crates/voicevox_core/src/engine/synthesis_engine.rs
+++ b/crates/voicevox_core/src/engine/synthesis_engine.rs
@@ -162,7 +162,7 @@ impl SynthesisEngine {
                             let new_mora = MoraModel::new(
                                 mora.text().clone(),
                                 mora.consonant().clone(),
-                                mora.consonant().as_ref().map(|s| {
+                                mora.consonant().as_ref().map(|_| {
                                     phoneme_length[vowel_indexes_data[index + 1] as usize - 1]
                                 }),
                                 mora.vowel().clone(),
@@ -178,7 +178,10 @@ impl SynthesisEngine {
                         let new_pause_mora = MoraModel::new(
                             pause_mora.text().clone(),
                             pause_mora.consonant().clone(),
-                            Some(phoneme_length[vowel_indexes_data[index + 1] as usize]),
+                            pause_mora
+                                .consonant()
+                                .as_ref()
+                                .map(|_| phoneme_length[vowel_indexes_data[index + 1] as usize]),
                             pause_mora.vowel().clone(),
                             *pause_mora.vowel_length(),
                             *pause_mora.pitch(),
@@ -395,7 +398,7 @@ impl SynthesisEngine {
 
                 for _ in 0..phoneme_length {
                     let mut phonemes_vec = vec![0.; OjtPhoneme::num_phoneme()];
-                    phonemes_vec[phoneme_id as usize] = 1.0;
+                    phonemes_vec[phoneme_id as usize] = 1.;
                     phoneme.push(phonemes_vec)
                 }
                 sum_of_phoneme_length += phoneme_length;

--- a/crates/voicevox_core/src/error.rs
+++ b/crates/voicevox_core/src/error.rs
@@ -1,7 +1,10 @@
 use std::fmt::Display;
 
+use crate::engine::FullContextLabelError;
+
 use super::*;
 use c_export::VoicevoxResultCode::{self, *};
+//use engine::
 use thiserror::Error;
 
 /*
@@ -45,6 +48,12 @@ pub enum Error {
 
     #[error("{}", base_error_message(VOICEVOX_RESULT_INFERENCE_FAILED))]
     InferenceFailed,
+
+    #[error(
+        "{},{0}",
+        base_error_message(VOICEVOX_RESULT_FAILED_EXTRACT_FULL_CONTEXT_LABEL)
+    )]
+    FailedExtractFullContextLabel(#[source] FullContextLabelError),
 }
 
 fn base_error_message(result_code: VoicevoxResultCode) -> &'static str {

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -155,9 +155,8 @@ impl Internal {
             "".into(),
         );
 
-        Ok(self
-            .synthesis_engine
-            .synthesis_wave_format(&audio_query, speaker_id, false)?)
+        self.synthesis_engine
+            .synthesis_wave_format(&audio_query, speaker_id, false)
     }
 
     //TODO:仮実装がlinterエラーにならないようにするための属性なのでこの関数を正式に実装する際にallow(unused_variables)を取り除くこと

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -132,14 +132,30 @@ impl Internal {
 
     //TODO:仮実装がlinterエラーにならないようにするための属性なのでこの関数を正式に実装する際にallow(unused_variables)を取り除くこと
     #[allow(unused_variables)]
-    pub fn voicevox_tts(
-        &self,
-        text: &CStr,
-        speaker_id: i64,
-        output_binary_size: *mut c_int,
-        output_wav: *const *mut u8,
-    ) -> Result<()> {
-        unimplemented!()
+    pub fn voicevox_tts(&mut self, text: &CStr, speaker_id: usize) -> Result<Vec<u8>> {
+        if !self.synthesis_engine.is_openjtalk_dict_loaded() {
+            return Err(Error::NotLoadedOpenjtalkDict);
+        }
+        let accent_phrases = self
+            .synthesis_engine
+            .create_accent_phrases(text.to_str().unwrap(), speaker_id)?;
+
+        let audio_query = AudioQueryModel::new(
+            accent_phrases,
+            1.,
+            0.,
+            1.,
+            1.,
+            0.1,
+            0.1,
+            SynthesisEngine::DEFAULT_SAMPLING_RATE,
+            false,
+            "".into(),
+        );
+
+        Ok(self
+            .synthesis_engine
+            .synthesis_wave_format(&audio_query, speaker_id, false)?)
     }
 
     //TODO:仮実装がlinterエラーにならないようにするための属性なのでこの関数を正式に実装する際にallow(unused_variables)を取り除くこと
@@ -151,12 +167,6 @@ impl Internal {
         output_binary_size: *mut c_int,
         output_wav: *const *mut u8,
     ) -> Result<()> {
-        unimplemented!()
-    }
-
-    //TODO:仮実装がlinterエラーにならないようにするための属性なのでこの関数を正式に実装する際にallow(unused_variables)を取り除くこと
-    #[allow(unused_variables)]
-    pub fn voicevox_wav_free(&self, wav: *mut u8) -> Result<()> {
         unimplemented!()
     }
 }

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -514,6 +514,7 @@ pub const fn voicevox_error_result_to_message(result_code: VoicevoxResultCode) -
         VOICEVOX_RESULT_FAILED_EXTRACT_FULL_CONTEXT_LABEL => {
             "入力テキストからのフルコンテキストラベル抽出に失敗しました\0"
         }
+        VOICEVOX_RESULT_INVALID_UTF8_INPUT => "入力テキストが無効なUTF-8データでした\0",
     }
 }
 

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -124,23 +124,19 @@ impl Internal {
         )
     }
 
-    pub fn voicevox_load_openjtalk_dict(&mut self, dict_path: &CStr) -> Result<()> {
-        self.synthesis_engine.load_openjtalk_dict(
-            dict_path
-                .to_str()
-                .map_err(|_| Error::NotLoadedOpenjtalkDict)?,
-        )
+    pub fn voicevox_load_openjtalk_dict(&mut self, dict_path: &str) -> Result<()> {
+        self.synthesis_engine.load_openjtalk_dict(dict_path)
     }
 
     //TODO:仮実装がlinterエラーにならないようにするための属性なのでこの関数を正式に実装する際にallow(unused_variables)を取り除くこと
     #[allow(unused_variables)]
-    pub fn voicevox_tts(&mut self, text: &CStr, speaker_id: usize) -> Result<Vec<u8>> {
+    pub fn voicevox_tts(&mut self, text: &str, speaker_id: usize) -> Result<Vec<u8>> {
         if !self.synthesis_engine.is_openjtalk_dict_loaded() {
             return Err(Error::NotLoadedOpenjtalkDict);
         }
         let accent_phrases = self
             .synthesis_engine
-            .create_accent_phrases(text.to_str().unwrap(), speaker_id)?;
+            .create_accent_phrases(text, speaker_id)?;
 
         let audio_query = AudioQueryModel::new(
             accent_phrases,
@@ -724,11 +720,10 @@ mod tests {
     async fn voicevox_load_openjtalk_dict_works() {
         let internal = Internal::new_with_mutex();
         let open_jtalk_dic_dir = download_open_jtalk_dict_if_no_exists().await;
-        let result = internal.lock().unwrap().voicevox_load_openjtalk_dict(
-            CString::new(open_jtalk_dic_dir.to_str().unwrap())
-                .unwrap()
-                .as_c_str(),
-        );
+        let result = internal
+            .lock()
+            .unwrap()
+            .voicevox_load_openjtalk_dict(open_jtalk_dic_dir.to_str().unwrap());
         assert_eq!(result, Ok(()));
     }
 }

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -504,6 +504,9 @@ pub const fn voicevox_error_result_to_message(result_code: VoicevoxResultCode) -
         VOICEVOX_RESULT_INVALID_SPEAKER_ID => "無効なspeaker_idです\0",
         VOICEVOX_RESULT_INVALID_MODEL_INDEX => "無効なmodel_indexです\0",
         VOICEVOX_RESULT_INFERENCE_FAILED => "推論に失敗しました\0",
+        VOICEVOX_RESULT_FAILED_EXTRACT_FULL_CONTEXT_LABEL => {
+            "入力テキストからのフルコンテキストラベル抽出に失敗しました\0"
+        }
     }
 }
 


### PR DESCRIPTION
## 内容

`voicevox_tts` と `voicevox_wav_free` を実装します。
~~ビルド結果のコアを cpp example で呼び出せることを確認していますが、wav 自体は出力できる（wav ヘッダも問題ないように見える）ものの、音が鳴る wav を出力できていないので draft にしています。~~

ビルド結果のコアを cpp example から呼び出せます。おそらく期待通りに音声合成できていそうでした。

## 関連 Issue

ref #128 
