### PR TITLE
[Rust] Moraをカタカナに変換する処理を実装

### DIFF
--- a/crates/voicevox_core/src/engine/mora_list.rs
+++ b/crates/voicevox_core/src/engine/mora_list.rs
@@ -187,7 +187,7 @@ pub(super) const MORA_LIST_MINIMUM: &[[&str; 3]] = &[
 ];
 
 #[allow(dead_code)] // TODO: remove this feature
-fn mora2text(mora: &str) -> &str {
+pub fn mora2text(mora: &str) -> &str {
     for &[text, consonant, vowel] in MORA_LIST_MINIMUM {
         if mora.len() >= consonant.len()
             && &mora[..consonant.len()] == consonant

--- a/crates/voicevox_core/src/engine/mora_list.rs
+++ b/crates/voicevox_core/src/engine/mora_list.rs
@@ -186,7 +186,6 @@ pub(super) const MORA_LIST_MINIMUM: &[[&str; 3]] = &[
     ["ア", "", "a"],
 ];
 
-#[allow(dead_code)] // TODO: remove this feature
 pub fn mora2text(mora: &str) -> &str {
     for &[text, consonant, vowel] in MORA_LIST_MINIMUM {
         if mora.len() >= consonant.len()

--- a/crates/voicevox_core/src/engine/synthesis_engine.rs
+++ b/crates/voicevox_core/src/engine/synthesis_engine.rs
@@ -65,16 +65,12 @@ impl SynthesisEngine {
                             .moras()
                             .iter()
                             .map(|mora| {
-                                let mut mora_text = mora
+                                let mora_text = mora
                                     .phonemes()
                                     .iter()
                                     .map(|phoneme| phoneme.phoneme().to_string())
                                     .collect::<Vec<_>>()
                                     .join("");
-                                mora_text = mora_text.to_lowercase();
-                                if mora_text == "n" {
-                                    mora_text = String::from("N");
-                                }
 
                                 let (consonant, consonant_length) =
                                     if let Some(consonant) = mora.consonant() {
@@ -84,7 +80,7 @@ impl SynthesisEngine {
                                     };
 
                                 MoraModel::new(
-                                    mora_text,
+                                    mora_to_text(&mora_text),
                                     consonant,
                                     consonant_length,
                                     mora.vowel().phoneme().into(),
@@ -590,6 +586,21 @@ pub fn split_mora(phoneme_list: &[OjtPhoneme]) -> (Vec<OjtPhoneme>, Vec<OjtPhone
     }
 
     (consonant_phoneme_list, vowel_phoneme_list, vowel_indexes)
+}
+
+fn mora_to_text(mora: impl AsRef<str>) -> String {
+    let last_char = mora.as_ref().chars().last().unwrap();
+    let mora = if ['A', 'I', 'U', 'E', 'O'].contains(&last_char) {
+        format!(
+            "{}{}",
+            &mora.as_ref()[0..mora.as_ref().len() - 1],
+            last_char.to_lowercase()
+        )
+    } else {
+        mora.as_ref().to_string()
+    };
+    // もしカタカナに変換できなければ、引数で与えた文字列がそのまま返ってくる
+    mora_list::mora2text(&mora).to_string()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 内容

https://github.com/VOICEVOX/voicevox_core/pull/186/files/7d5507c3cf0e548717120c85bb8c73c7848e8952#r922725224 の指摘で、Moraをカタカナに変換する処理が抜けていたことに気づきました。これを追加します。

https://github.com/VOICEVOX/voicevox_engine/blob/master/voicevox_engine/synthesis_engine/synthesis_engine_base.py の実装を参考にしました。

## 関連 Issue

#128 
