### PR TITLE
[Rust]macos-10.15がdeplecatedになっていたためCIテストからとりのぞいた

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,6 @@ jobs:
         include:
           - os: windows-2019
           - os: windows-2022
-          - os: macos-10.15
           - os: macos-11
           - os: macos-12
           - os: ubuntu-18.04


### PR DESCRIPTION


## 内容
https://github.com/actions/virtual-environments/issues/5583

## 関連 Issue

refs #128 

