### PR TITLE
[Rust] 自動生成される core.h の内容の改善

### DIFF
--- a/crates/voicevox_core/build.rs
+++ b/crates/voicevox_core/build.rs
@@ -24,10 +24,10 @@ fn main() {
 
 #ifdef __cplusplus
 #include <cstdint>
-#else
+#else // __cplusplus
 #include <stdbool.h>
 #include <stdint.h>
-#endif"#
+#endif // __cplusplus"#
                 .into(),
         ),
         cpp_compat: true,

--- a/crates/voicevox_core/build.rs
+++ b/crates/voicevox_core/build.rs
@@ -11,7 +11,17 @@ fn main() {
         language: Language::C,
         no_includes: true,
         after_includes: Some(
-            r#"#ifdef __cplusplus
+            r#"#ifdef _WIN32
+#ifdef VOICEVOX_CORE_EXPORTS
+#define VOICEVOX_CORE_API __declspec(dllexport)
+#else  // VOICEVOX_CORE_EXPORTS
+#define VOICEVOX_CORE_API __declspec(dllimport)
+#endif  // VOICEVOX_CORE_EXPORTS
+#else   // _WIN32
+#define VOICEVOX_CORE_API
+#endif  // _WIN32
+
+#ifdef __cplusplus
 #include <cstdint>
 #else
 #include <stdbool.h>
@@ -22,13 +32,7 @@ fn main() {
         cpp_compat: true,
         include_guard: Some("VOICEVOX_CORE_INCLUDE_GUARD".into()),
         function: FunctionConfig {
-            prefix: Some(
-                r#"#ifdef _WIN32
-__declspec(dllimport)
-#endif
-"#
-                .into(),
-            ),
+            prefix: Some("VOICEVOX_CORE_API".into()),
             ..Default::default()
         },
         enumeration: EnumConfig {

--- a/crates/voicevox_core/build.rs
+++ b/crates/voicevox_core/build.rs
@@ -9,8 +9,16 @@ fn main() {
     let output_file = target_dir().join("core.h").display().to_string();
     let config = Config {
         language: Language::C,
-        sys_includes: vec!["stdint.h".into()],
         no_includes: true,
+        after_includes: Some(
+            r#"#ifdef __cplusplus
+#include <cstdint>
+#else
+#include <stdbool.h>
+#include <stdint.h>
+#endif"#
+                .into(),
+        ),
         cpp_compat: true,
         include_guard: Some("VOICEVOX_CORE_INCLUDE_GUARD".into()),
         function: FunctionConfig {

--- a/crates/voicevox_core/build.rs
+++ b/crates/voicevox_core/build.rs
@@ -9,6 +9,7 @@ fn main() {
     let output_file = target_dir().join("core.h").display().to_string();
     let config = Config {
         language: Language::C,
+        pragma_once: true,
         no_includes: true,
         after_includes: Some(
             r#"#ifdef _WIN32

--- a/crates/voicevox_core/src/lib.rs
+++ b/crates/voicevox_core/src/lib.rs
@@ -2,6 +2,7 @@
 
 #[allow(unsafe_code)]
 mod c_export;
+/// cbindgen:ignore
 mod engine;
 mod error;
 mod internal;


### PR DESCRIPTION
## 内容

`cbindgen` によってビルド時に core.h が自動生成されていますが、いくつか気になる点があったので改善を試みました。

もしより良い改善方法があったり、追加で必要な改善点などがありましたら、ご提案いただけると助かります……！

## 関連 Issue

ref #128 
