### PR TITLE
[Rust]linux,macosのshared libraryをバージョンつきのものを配置するように変更

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -86,8 +86,8 @@ jobs:
           cp -v target/core.h "artifact/${{ env.ASSET_NAME }}"
           cp -v target/${{ matrix.target }}/release/*.{dll,so,dylib} "artifact/${{ env.ASSET_NAME }}" || true
           cp -v target/${{ matrix.target }}/release/core.dll.lib "artifact/${{ env.ASSET_NAME }}/core.lib" || true
-          cp -v -n target/${{ matrix.target }}/release/build/onnxruntime-sys-*/out/onnxruntime_*/onnxruntime-*/lib/*.{dll,so} "artifact/${{ env.ASSET_NAME }}" || true
-          cp -v -n target/${{ matrix.target }}/release/build/onnxruntime-sys-*/out/onnxruntime_*/onnxruntime-*/lib/libonnxruntime.dylib "artifact/${{ env.ASSET_NAME }}" || true
+          cp -v -n target/${{ matrix.target }}/release/build/onnxruntime-sys-*/out/onnxruntime_*/onnxruntime-*/lib/*.{dll,so.*} "artifact/${{ env.ASSET_NAME }}" || true
+          cp -v -n target/${{ matrix.target }}/release/build/onnxruntime-sys-*/out/onnxruntime_*/onnxruntime-*/lib/libonnxruntime.*.dylib "artifact/${{ env.ASSET_NAME }}" || true
           cp -v README.md "artifact/${{ env.ASSET_NAME }}/README.txt"
           echo "${{ env.VERSION }}" > "artifact/${{ env.ASSET_NAME }}/VERSION"
       - name: Code signing (Windows)


### PR DESCRIPTION


## 内容

サンプル実装より、現在配置してるshared libraryはバージョンなしのため実行に失敗する。そのためバージョンつきのものに変更する必要がある


## 関連 Issue

refs #128 https://github.com/VOICEVOX/voicevox_core/pull/197#issuecomment-1193085365


