### PR TITLE
[Rust] macOS 向けの libcore.dylib の identification name を設定し直す

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -90,6 +90,10 @@ jobs:
           cp -v -n target/${{ matrix.target }}/release/build/onnxruntime-sys-*/out/onnxruntime_*/onnxruntime-*/lib/libonnxruntime.dylib "artifact/${{ env.ASSET_NAME }}" || true
           cp -v README.md "artifact/${{ env.ASSET_NAME }}/README.txt"
           echo "${{ env.VERSION }}" > "artifact/${{ env.ASSET_NAME }}/VERSION"
+      - name: Set libcore.dylib's identification name (macOS)
+        if: startsWith(matrix.os, 'macos')
+        shell: bash
+        run: install_name_tool -id "@rpath/libcore.dylib" "artifact/${{ env.ASSET_NAME }}/libcore.dylib"
       - name: Code signing (Windows)
         if: startsWith(matrix.os, 'windows') && github.event.inputs.code_signing == 'true'
         shell: bash


### PR DESCRIPTION
## 内容

macOS で cargo でビルドした libcore.dylib について、`otool -D libcore.dylib` で identification name を調べると

```
libcore.dylib:
/Users/runner/work/voicevox_core/voicevox_core/target/ターゲット名/release/deps/libcore.dylib
```

という、ビルド環境を反映した結果が返ってきます。これは自然ではないので修正します。

例えば `libonnxruntime.1.11.1.dylib` の場合、`otool -D libonnxruntime.1.11.1.dylib` で調べると

```
libonnxruntime.1.11.1.dylib:
@rpath/libonnxruntime.1.11.1.dylib
```

という結果となります。このように、配布する動的ライブラリの identification name は `@rpath/ファイル名` とするのが良さそうなので、このように設定しなおす処理を追加しました。

## 関連 Issue

ref #128 