### PR TITLE
[Rust]C++ Windows向けのexampleを修正します

### DIFF
--- a/example/cpp/windows/README.md
+++ b/example/cpp/windows/README.md
@@ -10,16 +10,23 @@ Visual Studio Installerを使用しインストールしてください。
 
 ### 環境構築・ビルド方法
 
-ビルドして実行するには、「core.dll」「core.lib」「Open JTalk辞書フォルダ」が必要です。
 以下はDebug x64でビルドする場合です。他の構成・プラットフォーム向けにビルドする場合は、適宜読み替えてください。  
 
-Releasesから「voicevox_core-windows-x64-cpu-{バージョン名}.zip」をダウンロードします。
-zipファイルを展開し、展開されたフォルダに含まれているdllファイルを「core.dll」にリネームします。
 出力フォルダを作成するために、一度ビルドします。「windows_example.sln」をVisual Studioで開き、メニューの「ビルド」→「ソリューションのビルド」を押します。
 この段階では、ビルドは失敗します。「bin」フォルダと「lib」フォルダが生成されていればOKです。  
+Releasesから「voicevox_core-windows-x64-cpu-{バージョン名}.zip」をダウンロードし、展開します。  
+展開してできたファイルをそれぞれ下記のフォルダへ配置します。
 
-「core.lib」を「simple_tts\lib\x64」に配置します。  
-「core.dll」を「simple_tts\bin\x64\Debug」に配置します。
+- simple_tts に配置
+  - core.h
+
+- simple_tts\bin\x64\Debug に配置
+  - core.dll
+  - onnxruntime.dll
+  - onnxruntime_providers_shared.dll
+
+- simple_tts\lib\x64 に配置
+  - core.lib
 
 もう一度ビルドします。今度は成功するはずです。失敗した場合は、「core.lib」の場所を確認してください。
 
@@ -31,7 +38,7 @@ http://open-jtalk.sourceforge.net/ を開き、Dictionary for Open JTalk 欄の 
 最終的には以下のようなフォルダ構成になっているはずです。
 ```
 simple_tts
-│  packages.config
+│  core.h
 │  simple_tts.cpp
 │  simple_tts.h
 │  simple_tts.vcxproj

--- a/example/cpp/windows/simple_tts/packages.config
+++ b/example/cpp/windows/simple_tts/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.ML.OnnxRuntime" version="1.10.0" targetFramework="native" />
-</packages>

--- a/example/cpp/windows/simple_tts/simple_tts.cpp
+++ b/example/cpp/windows/simple_tts/simple_tts.cpp
@@ -74,7 +74,7 @@ int main() {
 std::string GetOpenJTalkDict() {
   wchar_t buff[MAX_PATH] = {0};
   PathCchCombine(buff, MAX_PATH, GetExeDirectory().c_str(), OPENJTALK_DICT_NAME);
-  std::string retVal = wide_to_multi_capi(buff);
+  std::string retVal = wide_to_utf8_cppapi(buff);
   return retVal;
 }
 
@@ -118,26 +118,6 @@ void OutErrorMessage(VoicevoxResultCode messageCode) {
   const char* utf8Str = voicevox_error_result_to_message(messageCode);
   std::wstring wideStr = utf8_to_wide_cppapi(utf8Str);
   std::wcout << wideStr << std::endl;
-}
-
-/// <summary>
-/// ワイド文字列をShift_JISに変換します。
-/// </summary>
-/// <param name="src">ワイド文字列</param>
-/// <returns>Shift_JIS文字列</returns>
-/// <remarks>
-/// https://nekko1119.hatenablog.com/entry/2017/01/02/054629 から引用
-/// </remarks>
-std::string wide_to_multi_capi(std::wstring const& src) {
-  std::size_t converted{};
-  std::vector<char> dest(src.size() * sizeof(wchar_t) + 1, '\0');
-  if (::_wcstombs_s_l(&converted, dest.data(), dest.size(), src.data(), _TRUNCATE, ::_create_locale(LC_ALL, "jpn")) !=
-      0) {
-    throw std::system_error{errno, std::system_category()};
-  }
-  dest.resize(std::char_traits<char>::length(dest.data()));
-  dest.shrink_to_fit();
-  return std::string(dest.begin(), dest.end());
 }
 
 /// <summary>

--- a/example/cpp/windows/simple_tts/simple_tts.h
+++ b/example/cpp/windows/simple_tts/simple_tts.h
@@ -1,9 +1,12 @@
 #pragma once
 #include <iostream>
+#include "core.h"
 
 std::string GetOpenJTalkDict();
 std::wstring GetWaveFileName();
 std::wstring GetExePath();
 std::wstring GetExeDirectory();
+void OutErrorMessage(VoicevoxResultCode messageCode);
 std::string wide_to_multi_capi(std::wstring const& src);
 std::string wide_to_utf8_cppapi(std::wstring const& src);
+std::wstring utf8_to_wide_cppapi(std::string const& src);

--- a/example/cpp/windows/simple_tts/simple_tts.h
+++ b/example/cpp/windows/simple_tts/simple_tts.h
@@ -7,6 +7,5 @@ std::wstring GetWaveFileName();
 std::wstring GetExePath();
 std::wstring GetExeDirectory();
 void OutErrorMessage(VoicevoxResultCode messageCode);
-std::string wide_to_multi_capi(std::wstring const& src);
 std::string wide_to_utf8_cppapi(std::wstring const& src);
 std::wstring utf8_to_wide_cppapi(std::string const& src);

--- a/example/cpp/windows/simple_tts/simple_tts.vcxproj
+++ b/example/cpp/windows/simple_tts/simple_tts.vcxproj
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.ML.OnnxRuntime.1.10.0\build\native\Microsoft.ML.OnnxRuntime.props" Condition="Exists('..\packages\Microsoft.ML.OnnxRuntime.1.10.0\build\native\Microsoft.ML.OnnxRuntime.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -165,18 +164,6 @@
   <ItemGroup>
     <ClInclude Include="simple_tts.h" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.ML.OnnxRuntime.1.10.0\build\native\Microsoft.ML.OnnxRuntime.targets" Condition="Exists('..\packages\Microsoft.ML.OnnxRuntime.1.10.0\build\native\Microsoft.ML.OnnxRuntime.targets')" />
-  </ImportGroup>
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>このプロジェクトは、このコンピューター上にない NuGet パッケージを参照しています。それらのパッケージをダウンロードするには、[NuGet パッケージの復元] を使用します。詳細については、http://go.microsoft.com/fwlink/?LinkID=322105 を参照してください。見つからないファイルは {0} です。</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.ML.OnnxRuntime.1.10.0\build\native\Microsoft.ML.OnnxRuntime.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ML.OnnxRuntime.1.10.0\build\native\Microsoft.ML.OnnxRuntime.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.ML.OnnxRuntime.1.10.0\build\native\Microsoft.ML.OnnxRuntime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ML.OnnxRuntime.1.10.0\build\native\Microsoft.ML.OnnxRuntime.targets'))" />
-  </Target>
+  <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/example/cpp/windows/simple_tts/simple_tts.vcxproj.filters
+++ b/example/cpp/windows/simple_tts/simple_tts.vcxproj.filters
@@ -24,8 +24,4 @@
       <Filter>ヘッダー ファイル</Filter>
     </ClInclude>
   </ItemGroup>
-  <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\onnxruntime_providers_shared.dll" />
-    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\onnxruntime.dll" />
-  </ItemGroup>
 </Project>

--- a/example/cpp/windows/simple_tts/simple_tts.vcxproj.filters
+++ b/example/cpp/windows/simple_tts/simple_tts.vcxproj.filters
@@ -27,6 +27,5 @@
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\onnxruntime_providers_shared.dll" />
     <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\onnxruntime.dll" />
-    <None Include="packages.config" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## 内容

rust版coreに対応するための修正をしました。

initialize関数に引数を追加しました。
initialize関数の返り値を見てfalseの場合にメッセージを表示するようにしました。

voicevox_error_result_to_message関数の返り値をワイド文字に変換してからコンソール画面に表示する関数OutErrorMessageを作成しました。

## 関連 Issue

ref #128 

## その他
別でissueを出すべきだと思いますが、日本語を含むパスで動作しませんでした。
