### PR TITLE
release buildのサイズが小さくなるようにした

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,12 @@
 [workspace]
 members = ["crates/voicevox_core"]
+
+
+# min-sized-rustを元にrelease buildのサイズが小さくなるようにした
+# https://github.com/johnthagen/min-sized-rust
+[profile.release]
+opt-level = "z"
+lto = true
+codegen-units = 1
+panic = "abort"
+strip = true


### PR DESCRIPTION
## 内容

削減できる量は少ないですがわりと簡単に設定できそうだったのでやってみました

## その他
before
```bash
> ls -lh libcore.so
-rwxrwxr-x 2 qwerty2501 qwerty2501 62M  8月  7 18:17 libcore.so
```
after
```bash
> ls -lh libcore.so
-rwxrwxr-x 2 qwerty2501 qwerty2501 57M  8月  7 18:26 libcore.so
```

