### PR TITLE
core.hの生成をfeatureで制御する

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -30,42 +30,42 @@ jobs:
       matrix:
         include:
           - os: windows-latest
-            feature: default
+            features: generate-c-header
             target: x86_64-pc-windows-msvc
             artifact_name: windows-x64-cpu
             use_cuda: false
           - os: windows-latest
-            feature: directml
+            features: directml,generate-c-header
             target: x86_64-pc-windows-msvc
             artifact_name: windows-x64-directml
             use_cuda: false
           - os: windows-latest
-            feature: default
+            features: generate-c-header
             target: x86_64-pc-windows-msvc
             artifact_name: windows-x64-cuda
             use_cuda: true
           - os: windows-latest
-            feature: default
+            features: generate-c-header
             target: i686-pc-windows-msvc
             artifact_name: windows-x86-cpu
             use_cuda: false
           - os: ubuntu-latest
-            feature: default
+            features: generate-c-header
             target: x86_64-unknown-linux-gnu
             artifact_name: linux-x64-cpu
             use_cuda: false
           - os: ubuntu-latest
-            feature: default
+            features: generate-c-header
             target: x86_64-unknown-linux-gnu
             artifact_name: linux-x64-gpu
             use_cuda: true
           - os: macos-latest
-            feature: default
+            features: generate-c-header
             target: aarch64-apple-darwin
             artifact_name: osx-aarch64-cpu
             use_cuda: false
           - os: macos-latest
-            feature: default
+            features: generate-c-header
             target: x86_64-apple-darwin
             artifact_name: osx-x64-cpu
             use_cuda: false
@@ -78,7 +78,7 @@ jobs:
           target: ${{ matrix.target }}
           default: true
       - name: build release
-        run: cargo build --features ${{ matrix.feature }} --target ${{ matrix.target }} --release
+        run: cargo build --features ${{ matrix.features }} --target ${{ matrix.target }} --release
         env:
           ORT_USE_CUDA: ${{ matrix.use_cuda }}
       - name: Set ASSET_NAME env var

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -30,42 +30,42 @@ jobs:
       matrix:
         include:
           - os: windows-latest
-            features: generate-c-header
+            additional-features: ""
             target: x86_64-pc-windows-msvc
             artifact_name: windows-x64-cpu
             use_cuda: false
           - os: windows-latest
-            features: directml,generate-c-header
+            additional-features: directml
             target: x86_64-pc-windows-msvc
             artifact_name: windows-x64-directml
             use_cuda: false
           - os: windows-latest
-            features: generate-c-header
+            additional-features: ""
             target: x86_64-pc-windows-msvc
             artifact_name: windows-x64-cuda
             use_cuda: true
           - os: windows-latest
-            features: generate-c-header
+            additional-features: ""
             target: i686-pc-windows-msvc
             artifact_name: windows-x86-cpu
             use_cuda: false
           - os: ubuntu-latest
-            features: generate-c-header
+            additional-features: ""
             target: x86_64-unknown-linux-gnu
             artifact_name: linux-x64-cpu
             use_cuda: false
           - os: ubuntu-latest
-            features: generate-c-header
+            additional-features: ""
             target: x86_64-unknown-linux-gnu
             artifact_name: linux-x64-gpu
             use_cuda: true
           - os: macos-latest
-            features: generate-c-header
+            additional-features: ""
             target: aarch64-apple-darwin
             artifact_name: osx-aarch64-cpu
             use_cuda: false
           - os: macos-latest
-            features: generate-c-header
+            additional-features: ""
             target: x86_64-apple-darwin
             artifact_name: osx-x64-cpu
             use_cuda: false
@@ -78,7 +78,7 @@ jobs:
           target: ${{ matrix.target }}
           default: true
       - name: build release
-        run: cargo build --features ${{ matrix.features }} --target ${{ matrix.target }} --release
+        run: cargo build --features generate-c-header,${{ matrix.additional-features }} --target ${{ matrix.target }} --release
         env:
           ORT_USE_CUDA: ${{ matrix.use_cuda }}
       - name: Set ASSET_NAME env var

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           toolchain: stable
       - name: build voicevox_core
-        run: cargo build
+        run: cargo build --features generate-c-header
       - name: 必要なfileをunix用exampleのディレクトリに移動させる
         run: |
           cp -v target/core.h example/cpp/unix/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,21 +24,21 @@ jobs:
       matrix:
         include:
           - os: windows-2019
-            features: generate-c-header
+            additional-features: ""
           - os: windows-2022
-            features: generate-c-header
+            additional-features: ""
           - os: windows-2019
-            features: directml,generate-c-header
+            additional-features: directml
           - os: windows-2022
-            features: directml,generate-c-header
+            additional-features: directml
           - os: macos-11
-            features: generate-c-header
+            additional-features: ""
           - os: macos-12
-            features: generate-c-header
+            additional-features: ""
           - os: ubuntu-18.04
-            features: generate-c-header
+            additional-features: ""
           - os: ubuntu-20.04
-            features: generate-c-header
+            additional-features: ""
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install LLVM and Clang # required for bindgen to work, see https://github.com/rust-lang/rust-bindgen/issues/1797
@@ -57,7 +57,7 @@ jobs:
       - uses: Swatinem/rust-cache@v1
         with:
           # cargoのキャッシュが原因でテストが失敗する場合はバージョン部分をカウントアップすること
-          key: "v1-cargo-test-cache-${{ matrix.features }}-${{ matrix.os }}"
+          key: "v1-cargo-test-cache-${{ matrix.additional-features }}-${{ matrix.os }}"
       # FIXME: windows-2022 では、onnxruntime-sys のビルド時にダウンロードされる onnxruntime.dll に対してパスが通らないために、テストが行えない
       #        原因が不明であるため、姑息的な回避策として target/debug/deps ディレクトリに onnxruntime.dll をコピーする。根本的な解決策を望む。
       #        cf. https://github.com/VOICEVOX/voicevox_core/pull/140#issuecomment-1140276585
@@ -68,7 +68,7 @@ jobs:
           cargo build
           find target/debug/build/onnxruntime-sys-*/out/onnxruntime_*/onnxruntime-*/lib -name onnxruntime.dll -ctime 0
           find target/debug/build/onnxruntime-sys-*/out/onnxruntime_*/onnxruntime-*/lib -name onnxruntime.dll -ctime 0 | head -n 1 | xargs -i cp {} target/debug/deps/
-      - run: cargo test --features ${{ matrix.features }}
+      - run: cargo test --features generate-c-header,${{ matrix.additional-features }}
 
   build-unix-cpp-example:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,21 +24,21 @@ jobs:
       matrix:
         include:
           - os: windows-2019
-            features: default
+            features: generate-c-header
           - os: windows-2022
-            features: default
+            features: generate-c-header
           - os: windows-2019
-            features: directml
+            features: directml,generate-c-header
           - os: windows-2022
-            features: directml
+            features: directml,generate-c-header
           - os: macos-11
-            features: default
+            features: generate-c-header
           - os: macos-12
-            features: default
+            features: generate-c-header
           - os: ubuntu-18.04
-            features: default
+            features: generate-c-header
           - os: ubuntu-20.04
-            features: default
+            features: generate-c-header
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install LLVM and Clang # required for bindgen to work, see https://github.com/rust-lang/rust-bindgen/issues/1797

--- a/crates/voicevox_core/Cargo.toml
+++ b/crates/voicevox_core/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [features]
 default = []
 directml = ["onnxruntime/directml"]
+generate-c-header = ["dep:cbindgen"]
 
 [lib]
 name = "core"
@@ -35,4 +36,4 @@ tar = "0.4.38"
 
 
 [build-dependencies]
-cbindgen = "0.23.0"
+cbindgen = { version = "0.23.0", optional = true }

--- a/crates/voicevox_core/build.rs
+++ b/crates/voicevox_core/build.rs
@@ -1,8 +1,18 @@
-use cbindgen::{Config, EnumConfig, FunctionConfig, Language, RenameRule};
-use std::env;
-use std::path::PathBuf;
-
 fn main() {
+    generate_c_header();
+
+    #[cfg(target_os = "linux")]
+    println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN");
+
+    #[cfg(target_os = "macos")]
+    println!("cargo:rustc-link-arg=-Wl,-install_name,@rpath/libcore.dylib");
+}
+
+fn generate_c_header() {
+    use cbindgen::{Config, EnumConfig, FunctionConfig, Language, RenameRule};
+    use std::env;
+    use std::path::PathBuf;
+
     let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     let output_file = target_dir().join("core.h").display().to_string();
     let config = Config {
@@ -40,12 +50,7 @@ __declspec(dllimport)
         .unwrap()
         .write_to_file(&output_file);
 
-    #[cfg(target_os = "linux")]
-    println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN");
-
-    #[cfg(target_os = "macos")]
-    println!("cargo:rustc-link-arg=-Wl,-install_name,@rpath/libcore.dylib");
-}
-fn target_dir() -> PathBuf {
-    PathBuf::from(env::var("CARGO_WORKSPACE_DIR").unwrap()).join("target")
+    fn target_dir() -> PathBuf {
+        PathBuf::from(env::var("CARGO_WORKSPACE_DIR").unwrap()).join("target")
+    }
 }

--- a/crates/voicevox_core/build.rs
+++ b/crates/voicevox_core/build.rs
@@ -1,5 +1,3 @@
-extern crate cbindgen;
-
 use cbindgen::{Config, EnumConfig, FunctionConfig, Language, RenameRule};
 use std::env;
 use std::path::PathBuf;

--- a/crates/voicevox_core/build.rs
+++ b/crates/voicevox_core/build.rs
@@ -1,4 +1,5 @@
 fn main() {
+    #[cfg(feature = "generate-c-header")]
     generate_c_header();
 
     #[cfg(target_os = "linux")]
@@ -8,6 +9,7 @@ fn main() {
     println!("cargo:rustc-link-arg=-Wl,-install_name,@rpath/libcore.dylib");
 }
 
+#[cfg(feature = "generate-c-header")]
 fn generate_c_header() {
     use cbindgen::{Config, EnumConfig, FunctionConfig, Language, RenameRule};
     use std::env;


### PR DESCRIPTION
- Remove unnecessary `extern crate`
- Isolate the part for generating core.h
- Add `generate-c-header` feature and don't generate core.h by default
- Enable `generate-c-header` for CI

## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

feature `generate-c-header`を追加し、これが有効なときのみcore.hを生成するようにしました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

Closes #215.

## その他
