### PR TITLE
`OpenJtalk`を引数として渡す

### DIFF
--- a/crates/voicevox_core/src/engine/mod.rs
+++ b/crates/voicevox_core/src/engine/mod.rs
@@ -8,6 +8,7 @@ mod synthesis_engine;
 
 use super::*;
 
+pub use self::open_jtalk::OpenJtalk;
 pub use acoustic_feature_extractor::*;
 pub use full_context_label::*;
 pub use kana_parser::*;

--- a/crates/voicevox_core/src/engine/synthesis_engine.rs
+++ b/crates/voicevox_core/src/engine/synthesis_engine.rs
@@ -1,3 +1,4 @@
+use derive_new::new;
 use std::io::{Cursor, Write};
 use std::path::Path;
 
@@ -12,9 +13,10 @@ const MORA_PHONEME_LIST: &[&str] = &[
     "a", "i", "u", "e", "o", "N", "A", "I", "U", "E", "O", "cl", "pau",
 ];
 
+#[derive(new)]
 pub struct SynthesisEngine {
-    open_jtalk: OpenJtalk,
     inference_core: InferenceCore,
+    open_jtalk: OpenJtalk,
 }
 
 #[allow(unsafe_code)]
@@ -24,13 +26,6 @@ unsafe impl Sync for SynthesisEngine {}
 
 impl SynthesisEngine {
     pub const DEFAULT_SAMPLING_RATE: u32 = 24000;
-
-    pub fn new(inference_core: InferenceCore) -> Self {
-        Self {
-            open_jtalk: OpenJtalk::initialize(),
-            inference_core,
-        }
-    }
 
     pub fn inference_core(&self) -> &InferenceCore {
         &self.inference_core
@@ -663,7 +658,7 @@ mod tests {
     #[async_std::test]
     async fn load_openjtalk_dict_works() {
         let core = InferenceCore::new(false, None);
-        let mut synthesis_engine = SynthesisEngine::new(core);
+        let mut synthesis_engine = SynthesisEngine::new(core, OpenJtalk::initialize());
         let open_jtalk_dic_dir = download_open_jtalk_dict_if_no_exists().await;
 
         let result = synthesis_engine.load_openjtalk_dict(&open_jtalk_dic_dir);
@@ -677,7 +672,7 @@ mod tests {
     #[async_std::test]
     async fn is_openjtalk_dict_loaded_works() {
         let core = InferenceCore::new(false, None);
-        let mut synthesis_engine = SynthesisEngine::new(core);
+        let mut synthesis_engine = SynthesisEngine::new(core, OpenJtalk::initialize());
         let open_jtalk_dic_dir = download_open_jtalk_dict_if_no_exists().await;
 
         let _ = synthesis_engine.load_openjtalk_dict(&open_jtalk_dic_dir);

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -25,7 +25,10 @@ pub struct Internal {
 impl Internal {
     pub fn new_with_mutex() -> Mutex<Internal> {
         Mutex::new(Internal {
-            synthesis_engine: SynthesisEngine::new(InferenceCore::new(false, None)),
+            synthesis_engine: SynthesisEngine::new(
+                InferenceCore::new(false, None),
+                OpenJtalk::initialize(),
+            ),
         })
     }
 


### PR DESCRIPTION
- Re-export `OpenJtalk` in `crate::engine::synthesis_engine`
- Pass `OpenJtalk` as an argument

## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

`OpenJtalk`を明示的に`SynthesisEngine::new`の引数として渡すようにします。

引数の順番は`inference_core`, `open_jtalk`の順にしました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

Closes #214.

## その他
