### PR TITLE
Windows環境でテストエラーになるのを防ぐ処理を追加

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,6 @@
 [env]
 CARGO_WORKSPACE_DIR = { value = "", relative = true }
+
+# Windows環境でテストエラーになるのを防ぐために設定するworkaround
+# https://github.com/VOICEVOX/onnxruntime-rs/issues/3#issuecomment-1207381367
+ORT_OUT_DIR = { value = "target/debug/deps", relative = true }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,16 +58,6 @@ jobs:
         with:
           # cargoのキャッシュが原因でテストが失敗する場合はバージョン部分をカウントアップすること
           key: "v1-cargo-test-cache-${{ matrix.additional-features }}-${{ matrix.os }}"
-      # FIXME: windows-2022 では、onnxruntime-sys のビルド時にダウンロードされる onnxruntime.dll に対してパスが通らないために、テストが行えない
-      #        原因が不明であるため、姑息的な回避策として target/debug/deps ディレクトリに onnxruntime.dll をコピーする。根本的な解決策を望む。
-      #        cf. https://github.com/VOICEVOX/voicevox_core/pull/140#issuecomment-1140276585
-      - name: Prepare onnxruntime.dll
-        if: matrix.os == 'windows-2022'
-        shell: bash
-        run: |
-          cargo build
-          find target/debug/build/onnxruntime-sys-*/out/onnxruntime_*/onnxruntime-*/lib -name onnxruntime.dll -ctime 0
-          find target/debug/build/onnxruntime-sys-*/out/onnxruntime_*/onnxruntime-*/lib -name onnxruntime.dll -ctime 0 | head -n 1 | xargs -i cp {} target/debug/deps/
       - name: Run cargo test
         shell: bash
         run: cargo test --features generate-c-header,${{ matrix.additional-features }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1312,8 +1312,8 @@ checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "onnxruntime"
-version = "0.0.28"
-source = "git+https://github.com/VOICEVOX/onnxruntime-rs.git#7d112cbb6515a42bd76efe4c40dbb44de460733f"
+version = "0.0.29"
+source = "git+https://github.com/VOICEVOX/onnxruntime-rs.git#8b45a4a993f84b53906b7d625ff5dc563e0100c3"
 dependencies = [
  "lazy_static",
  "ndarray",
@@ -1324,8 +1324,8 @@ dependencies = [
 
 [[package]]
 name = "onnxruntime-sys"
-version = "0.0.23"
-source = "git+https://github.com/VOICEVOX/onnxruntime-rs.git#7d112cbb6515a42bd76efe4c40dbb44de460733f"
+version = "0.0.24"
+source = "git+https://github.com/VOICEVOX/onnxruntime-rs.git#8b45a4a993f84b53906b7d625ff5dc563e0100c3"
 dependencies = [
  "flate2",
  "once_cell",

--- a/README.md
+++ b/README.md
@@ -162,9 +162,6 @@ cargo build --release
 ## コアライブラリのテスト
 
 ```bash
-# Windowsの場合は最初にonnxruntime.dllをカレントディレクトリにコピーする必要があります
-# find target/debug/build/onnxruntime-sys-*/out/onnxruntime_*/onnxruntime-*/lib -name onnxruntime.dll | head -n 1 | xargs -i cp {} target/debug/deps/
-
 cargo test
 ```
 

--- a/crates/voicevox_core/Cargo.toml
+++ b/crates/voicevox_core/Cargo.toml
@@ -19,7 +19,7 @@ derive-getters = "0.2.0"
 derive-new = "0.5.9"
 libc = "0.2.126"
 once_cell = "1.10.0"
-onnxruntime = { git = "https://github.com/VOICEVOX/onnxruntime-rs.git", version = "0.0.28" }
+onnxruntime = { git = "https://github.com/VOICEVOX/onnxruntime-rs.git", version = "0.0.29" }
 serde = "1.0.137"
 serde_json = "1.0.81"
 thiserror = "1.0.31"


### PR DESCRIPTION


## 内容

workaroundが自動化されるのでCIテスト、READMEのworkaround手順を削除

## 関連 Issue
refs #213, https://github.com/VOICEVOX/onnxruntime-rs/pull/4,https://github.com/VOICEVOX/onnxruntime-rs/issues/3
経緯については https://github.com/VOICEVOX/onnxruntime-rs/pull/4 を参照

## その他
https://github.com/VOICEVOX/onnxruntime-rs/pull/4 がmergeされたのち、CIテストを再実行してからreviewすること

