### PR TITLE
0.1.25にopen_jtalkをバージョンアップ

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1342,8 +1342,8 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "open_jtalk"
-version = "0.1.24"
-source = "git+https://github.com/VOICEVOX/open_jtalk-rs.git#4cd7ff11943f2c0b976f9c8e9593f47339a60444"
+version = "0.1.25"
+source = "git+https://github.com/VOICEVOX/open_jtalk-rs.git#c77112b470874a6a963426ed6c2fb21f12394a78"
 dependencies = [
  "open_jtalk-sys",
  "thiserror",
@@ -1351,8 +1351,8 @@ dependencies = [
 
 [[package]]
 name = "open_jtalk-sys"
-version = "0.15.111"
-source = "git+https://github.com/VOICEVOX/open_jtalk-rs.git#4cd7ff11943f2c0b976f9c8e9593f47339a60444"
+version = "0.16.111"
+source = "git+https://github.com/VOICEVOX/open_jtalk-rs.git#c77112b470874a6a963426ed6c2fb21f12394a78"
 dependencies = [
  "bindgen",
  "cmake",

--- a/crates/voicevox_core/Cargo.toml
+++ b/crates/voicevox_core/Cargo.toml
@@ -23,7 +23,7 @@ onnxruntime = { git = "https://github.com/VOICEVOX/onnxruntime-rs.git", version 
 serde = "1.0.137"
 serde_json = "1.0.81"
 thiserror = "1.0.31"
-open_jtalk = { git = "https://github.com/VOICEVOX/open_jtalk-rs.git", version = "0.1.24" }
+open_jtalk = { git = "https://github.com/VOICEVOX/open_jtalk-rs.git", version = "0.1.25" }
 regex = "1.6.0"
 
 [dev-dependencies]


### PR DESCRIPTION


## 内容
cmakeでエラーになる問題を解決するため
https://github.com/VOICEVOX/open_jtalk-rs/pull/2 がmergeされてからreviewとCIテストすること

