### PR TITLE
with_disable_mem_pattern を削除(C++版ではなかったコードのため)

### DIFF
--- a/crates/voicevox_core/src/status.rs
+++ b/crates/voicevox_core/src/status.rs
@@ -183,9 +183,7 @@ impl Status {
                         .with_execution_mode(onnxruntime::ExecutionMode::ORT_SEQUENTIAL)?
                 } else {
                     let options = CudaProviderOptions::default();
-                    session_builder
-                        .with_disable_mem_pattern()?
-                        .with_append_execution_provider_cuda(options)?
+                    session_builder.with_append_execution_provider_cuda(options)?
                 }
             }
         } else {


### PR DESCRIPTION
## 内容

恐らく これが linux GPU版でSIGSEGV発生してる原因になってるので修正する

## 関連 Issue
https://github.com/VOICEVOX/voicevox_core/issues/227#issuecomment-1210170995



## その他
