### PR TITLE
`initialize`内の"一回走らせて十分なGPUメモリを確保させる"の部分を削除

### DIFF
--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -207,7 +207,14 @@ impl InferenceCore {
                     let phoneme = [0.; PHONEME_SIZE * LENGTH];
                     let speaker_id = 0;
 
-                    let _ = self.decode_forward(LENGTH, PHONEME_SIZE, &f0, &phoneme, speaker_id)?;
+                    let _ = Self::decode_forward_from_status(
+                        &mut status,
+                        LENGTH,
+                        PHONEME_SIZE,
+                        &f0,
+                        &phoneme,
+                        speaker_id,
+                    )?;
                 }
             }
 
@@ -383,6 +390,17 @@ impl InferenceCore {
             .as_mut()
             .ok_or(Error::UninitializedStatus)?;
 
+        Self::decode_forward_from_status(status, length, phoneme_size, f0, phoneme, speaker_id)
+    }
+
+    fn decode_forward_from_status(
+        status: &mut Status,
+        length: usize,
+        phoneme_size: usize,
+        f0: &[f32],
+        phoneme: &[f32],
+        speaker_id: usize,
+    ) -> Result<Vec<f32>> {
         if !status.validate_speaker_id(speaker_id) {
             return Err(Error::InvalidSpeakerId { speaker_id });
         }

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -198,17 +198,6 @@ impl InferenceCore {
                 for model_index in 0..Status::MODELS_COUNT {
                     status.load_model(model_index)?;
                 }
-                // 一回走らせて十分なGPUメモリを確保させる
-                // TODO: 全MODELに対して行う
-                if use_gpu {
-                    const LENGTH: usize = 500;
-                    const PHONEME_SIZE: usize = 45;
-                    let f0 = [0.; LENGTH];
-                    let phoneme = [0.; PHONEME_SIZE * LENGTH];
-                    let speaker_id = 0;
-
-                    let _ = self.decode_forward(LENGTH, PHONEME_SIZE, &f0, &phoneme, speaker_id)?;
-                }
             }
 
             self.status_option = Some(status);

--- a/crates/voicevox_core/src/internal.rs
+++ b/crates/voicevox_core/src/internal.rs
@@ -207,14 +207,7 @@ impl InferenceCore {
                     let phoneme = [0.; PHONEME_SIZE * LENGTH];
                     let speaker_id = 0;
 
-                    let _ = Self::decode_forward_from_status(
-                        &mut status,
-                        LENGTH,
-                        PHONEME_SIZE,
-                        &f0,
-                        &phoneme,
-                        speaker_id,
-                    )?;
+                    let _ = self.decode_forward(LENGTH, PHONEME_SIZE, &f0, &phoneme, speaker_id)?;
                 }
             }
 
@@ -390,17 +383,6 @@ impl InferenceCore {
             .as_mut()
             .ok_or(Error::UninitializedStatus)?;
 
-        Self::decode_forward_from_status(status, length, phoneme_size, f0, phoneme, speaker_id)
-    }
-
-    fn decode_forward_from_status(
-        status: &mut Status,
-        length: usize,
-        phoneme_size: usize,
-        f0: &[f32],
-        phoneme: &[f32],
-        speaker_id: usize,
-    ) -> Result<Vec<f32>> {
         if !status.validate_speaker_id(speaker_id) {
             return Err(Error::InvalidSpeakerId { speaker_id });
         }


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

以下の部分をちゃんと動くようにし、`use_gpu=true, load_all_models=true`で`initialize`を呼んでも動作するようにしました。

https://github.com/VOICEVOX/voicevox_core/blob/18dc02d0efd94b5076d494677b714565662b6c98/crates/voicevox_core/src/internal.rs#L203-L211

```console
❯ cd ./example/cpp/unix
❯ sed -i 's/\(initialize(\)false/\1true/' ./simple_tts.cpp
❯ cmake --build ./build && ORT_USE_CORE=1 cargo build && cp ../../../target/debug/libcore.so ./ && ./build/simple_tts あ
[ 50%] Building CXX object CMakeFiles/simple_tts.dir/simple_tts.cpp.o
[100%] Linking CXX executable simple_tts
[100%] Built target simple_tts
   Compiling voicevox_core v0.1.0 (/home/ryo/src/github.com/VOICEVOX/voicevox_core/crates/voicevox_core)
    Finished dev [unoptimized + debuginfo] target(s) in 3.63s
coreの初期化中...
openjtalk辞書の読み込み中...
音声生成中...
音声ファイル保存中...
音声ファイル保存完了 (audio.wav)
❯ echo "$?"
0
```

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

Closes #230.

## その他
