### PR TITLE
CIを直すため`clippy::derive_partial_eq_without_eq`に従う

### DIFF
--- a/crates/voicevox_core/src/c_export.rs
+++ b/crates/voicevox_core/src/c_export.rs
@@ -19,7 +19,7 @@ fn lock_internal() -> MutexGuard<'static, Internal> {
  */
 
 #[repr(i32)]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
 pub enum VoicevoxResultCode {
     // C でのenum定義に合わせて大文字で定義している

--- a/crates/voicevox_core/src/engine/full_context_label.rs
+++ b/crates/voicevox_core/src/engine/full_context_label.rs
@@ -21,7 +21,7 @@ pub enum FullContextLabelError {
 
 type Result<T> = std::result::Result<T, FullContextLabelError>;
 
-#[derive(new, Getters, Clone, PartialEq, Debug)]
+#[derive(new, Getters, Clone, PartialEq, Eq, Debug)]
 pub struct Phoneme {
     contexts: HashMap<String, String>,
     label: String,
@@ -75,7 +75,7 @@ impl Phoneme {
     }
 }
 
-#[derive(new, Getters, Clone, PartialEq, Debug)]
+#[derive(new, Getters, Clone, PartialEq, Eq, Debug)]
 pub struct Mora {
     consonant: Option<Phoneme>,
     vowel: Phoneme,
@@ -108,7 +108,7 @@ impl Mora {
     }
 }
 
-#[derive(new, Getters, Clone, Debug, PartialEq)]
+#[derive(new, Getters, Clone, Debug, PartialEq, Eq)]
 pub struct AccentPhrase {
     moras: Vec<Mora>,
     accent: usize,
@@ -198,7 +198,7 @@ impl AccentPhrase {
     }
 }
 
-#[derive(new, Getters, Clone, PartialEq, Debug)]
+#[derive(new, Getters, Clone, PartialEq, Eq, Debug)]
 pub struct BreathGroup {
     accent_phrases: Vec<AccentPhrase>,
 }
@@ -245,7 +245,7 @@ impl BreathGroup {
     }
 }
 
-#[derive(new, Getters, Clone, PartialEq, Debug)]
+#[derive(new, Getters, Clone, PartialEq, Eq, Debug)]
 pub struct Utterance {
     breath_groups: Vec<BreathGroup>,
     pauses: Vec<Phoneme>,

--- a/crates/voicevox_core/src/engine/kana_parser.rs
+++ b/crates/voicevox_core/src/engine/kana_parser.rs
@@ -10,7 +10,7 @@ const PAUSE_DELIMITER: char = '、';
 const WIDE_INTERROGATION_MARK: char = '？';
 const LOOP_LIMIT: usize = 300;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct KanaParseError(String);
 
 impl std::fmt::Display for KanaParseError {


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

ついさっき[Rust 1.63がリリースされ](https://blog.rust-lang.org/2022/08/11/Rust-1.63.0.html)、Clippyに以下のlintが追加されたためにCIが落ちるようになってました。

- [`clippy::derive_partial_eq_without_eq`](https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq)

これに従いwarningが出る箇所に`#[derive(Eq)]`しました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他
