### PR TITLE
directmlでGPUが使えなかったことに対する対処

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
       - published
 jobs:
   rust-lint:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/crates/voicevox_core/Cargo.toml
+++ b/crates/voicevox_core/Cargo.toml
@@ -19,7 +19,7 @@ derive-getters = "0.2.0"
 derive-new = "0.5.9"
 libc = "0.2.131"
 once_cell = "1.10.0"
-onnxruntime = { git = "https://github.com/VOICEVOX/onnxruntime-rs.git", version = "0.0.30" }
+onnxruntime = { git = "https://github.com/VOICEVOX/onnxruntime-rs.git", version = "0.1.0" }
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.83"
 thiserror = "1.0.32"

--- a/crates/voicevox_core/src/status.rs
+++ b/crates/voicevox_core/src/status.rs
@@ -181,6 +181,7 @@ impl Status {
                     session_builder
                         .with_disable_mem_pattern()?
                         .with_execution_mode(onnxruntime::ExecutionMode::ORT_SEQUENTIAL)?
+                        .with_append_execution_provider_directml(0)?
                 } else {
                     let options = CudaProviderOptions::default();
                     session_builder.with_append_execution_provider_cuda(options)?


### PR DESCRIPTION
## 内容
`with_append_execution_provider_directml` の呼び出しが行われていなかったのが原因であると思われるため、呼び出しを行うようにした


## 関連 Issue
~~https://github.com/VOICEVOX/onnxruntime-rs/pull/6 がmergeされないとreviewできない~~
できるようになった！
#213


## その他
