### PR TITLE
`AudioQueryModel`のser/deを修正

### DIFF
--- a/crates/voicevox_core/src/engine/model.rs
+++ b/crates/voicevox_core/src/engine/model.rs
@@ -34,13 +34,21 @@ impl AccentPhraseModel {
 #[derive(Clone, new, Getters, Deserialize, Serialize)]
 pub struct AudioQueryModel {
     accent_phrases: Vec<AccentPhraseModel>,
+    #[serde(rename = "speedScale")]
     speed_scale: f32,
+    #[serde(rename = "pitchScale")]
     pitch_scale: f32,
+    #[serde(rename = "intonationScale")]
     intonation_scale: f32,
+    #[serde(rename = "volumeScale")]
     volume_scale: f32,
+    #[serde(rename = "prePhonemeLength")]
     pre_phoneme_length: f32,
+    #[serde(rename = "postPhonemeLength")]
     post_phoneme_length: f32,
+    #[serde(rename = "outputSamplingRate")]
     output_sampling_rate: u32,
+    #[serde(rename = "outputStereo")]
     output_stereo: bool,
     #[allow(dead_code)]
     kana: String,


### PR DESCRIPTION
## 内容

#244 にて`AudioQueryModel`に`serde`をimplした際snake\_caseのフィールド名がすべてそのままだったため、エンジンが入出力するものとは異なる形式のJSONを入出力している状態になっています。

`accent_phrases`以外をlowerCamelCaseにリネームすることでエンジン側に合わせました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他
