### PR TITLE
macOS の dylib 向けに rpath を追加

### DIFF
--- a/crates/voicevox_core_c_api/build.rs
+++ b/crates/voicevox_core_c_api/build.rs
@@ -6,9 +6,10 @@ fn main() {
     println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN");
 
     #[cfg(target_os = "macos")]
-    println!("cargo:rustc-link-arg=-Wl,-rpath,@loader_path/");
-    #[cfg(target_os = "macos")]
-    println!("cargo:rustc-link-arg=-Wl,-install_name,@rpath/libcore.dylib");
+    {
+        println!("cargo:rustc-link-arg=-Wl,-rpath,@loader_path/");
+        println!("cargo:rustc-link-arg=-Wl,-install_name,@rpath/libcore.dylib");
+    }
 }
 
 #[cfg(feature = "generate-c-header")]

--- a/crates/voicevox_core_c_api/build.rs
+++ b/crates/voicevox_core_c_api/build.rs
@@ -6,6 +6,8 @@ fn main() {
     println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN");
 
     #[cfg(target_os = "macos")]
+    println!("cargo:rustc-link-arg=-Wl,-rpath,@loader_path/");
+    #[cfg(target_os = "macos")]
     println!("cargo:rustc-link-arg=-Wl,-install_name,@rpath/libcore.dylib");
 }
 


### PR DESCRIPTION
## 内容

macOS の dylib に rpath として `@loader_path/` を追加しました。

以前のコメント https://github.com/VOICEVOX/voicevox_core/pull/203#discussion_r928189845 で、macOS の dylib について rpath の追加をしなくても良いということを言ったのですが、その後、ビルド済みのエンジンでは問題ないと思われるものの、ビルドしていない状態のエンジンで `--voicelib_dir` オプションでコアの場所を指定するユースケースでは特に rpath を追加した方が良いと感じました。

以前の CMake の設定を改めて確認すると `@loader_path/` を rpath として追加していたので、これと同様の設定を行いました。

https://github.com/VOICEVOX/voicevox_core/blob/7ff2e7f2ae7e635d2557e2a6114e31b8f8cf3ddd/core/CMakeLists.txt#L104-L109

## 関連 PR

ref #203 

## その他
