### PR TITLE
runner.osのUbuntu-18.04 がサポート切れていたので削除し、Ubuntu-22.04を新たに追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,9 +35,9 @@ jobs:
             additional-features: ""
           - os: macos-12
             additional-features: ""
-          - os: ubuntu-18.04
-            additional-features: ""
           - os: ubuntu-20.04
+            additional-features: ""
+          - os: ubuntu-22.04
             additional-features: ""
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## 内容

T/O

https://github.com/VOICEVOX/voicevox_core/pull/217#issuecomment-1222326918

