### PR TITLE
不要になったCIステップを削除

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,15 +41,6 @@ jobs:
             additional-features: ""
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Install LLVM and Clang # required for bindgen to work, see https://github.com/rust-lang/rust-bindgen/issues/1797
-        uses: KyleMayes/install-llvm-action@32c4866ebb71e0949e8833eb49beeebed48532bd
-        if: matrix.os == 'windows-2019'
-        with:
-          version: "11.0"
-          directory: ${{ runner.temp }}/llvm
-      - name: Set LIBCLANG_PATH
-        run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
-        if: matrix.os == 'windows-2019'
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
       - uses: Swatinem/rust-cache@v1


### PR DESCRIPTION

## 内容
ビルド時にClangでbindコードを自動生成してたころの名残があったので消した
現在ではClangはビルド時には行っておらずテストを遅くするだけなので不要



