### PR TITLE
audio_query 関数の返すクエリの初期値に create_kana の結果を格納

### DIFF
--- a/crates/voicevox_core/src/engine/kana_parser.rs
+++ b/crates/voicevox_core/src/engine/kana_parser.rs
@@ -175,8 +175,7 @@ pub fn parse_kana(text: &str) -> KanaParseResult<Vec<AccentPhraseModel>> {
     Ok(parsed_result)
 }
 
-#[allow(dead_code)] // TODO: remove this feature
-fn create_kana(accent_phrases: &[AccentPhraseModel]) -> String {
+pub fn create_kana(accent_phrases: &[AccentPhraseModel]) -> String {
     let mut text = String::new();
     for phrase in accent_phrases {
         let moras = phrase.moras();

--- a/crates/voicevox_core/src/engine/model.rs
+++ b/crates/voicevox_core/src/engine/model.rs
@@ -50,6 +50,5 @@ pub struct AudioQueryModel {
     output_sampling_rate: u32,
     #[serde(rename = "outputStereo")]
     output_stereo: bool,
-    #[allow(dead_code)]
     kana: String,
 }

--- a/crates/voicevox_core/src/publish.rs
+++ b/crates/voicevox_core/src/publish.rs
@@ -157,6 +157,8 @@ impl VoicevoxCore {
                 .create_accent_phrases(text, speaker_id)?
         };
 
+        let kana = create_kana(&accent_phrases);
+
         Ok(AudioQueryModel::new(
             accent_phrases,
             1.,
@@ -167,7 +169,7 @@ impl VoicevoxCore {
             0.1,
             SynthesisEngine::DEFAULT_SAMPLING_RATE,
             false,
-            "".into(),
+            kana,
         ))
     }
 


### PR DESCRIPTION
## 内容

エンジンの `audio_query` の結果と比較して気づきましたが、コアの `VoicevoxCore::audio_query` 関数から返ってくる `AudioQuery` の `kana` フィールドが空文字列になっていました。エンジンでは `create_kana` で作られた AquesTalk 記法の文字列です。エンジンの以下の部分が対応するコードです。

https://github.com/VOICEVOX/voicevox_engine/blob/8057ee439767c9bfe14f323bb20f8391006d6bfd/run.py#L123-L146

エンジンと同じ挙動になるように変更を加えました。

## 関連 PR

ref #244 