### PR TITLE
句読点の長さが適切に設定されていなかった問題を修正

### DIFF
--- a/crates/voicevox_core/src/engine/synthesis_engine.rs
+++ b/crates/voicevox_core/src/engine/synthesis_engine.rs
@@ -717,8 +717,8 @@ mod tests {
             "accent_phrases[4].pause_mora() is not None"
         );
 
-        for i in 0..4 {
-            let pause_mora = accent_phrases[i].pause_mora().clone().unwrap();
+        for accent_phrase in accent_phrases.iter().take(4) {
+            let pause_mora = accent_phrase.pause_mora().clone().unwrap();
             assert_eq!(pause_mora.text(), "、");
             assert_eq!(pause_mora.consonant(), &None);
             assert_eq!(pause_mora.consonant_length(), &None);

--- a/crates/voicevox_core/src/engine/synthesis_engine.rs
+++ b/crates/voicevox_core/src/engine/synthesis_engine.rs
@@ -166,12 +166,9 @@ impl SynthesisEngine {
                         let new_pause_mora = MoraModel::new(
                             pause_mora.text().clone(),
                             pause_mora.consonant().clone(),
-                            pause_mora
-                                .consonant()
-                                .as_ref()
-                                .map(|_| phoneme_length[vowel_indexes_data[index + 1] as usize]),
+                            *pause_mora.consonant_length(),
                             pause_mora.vowel().clone(),
-                            *pause_mora.vowel_length(),
+                            phoneme_length[vowel_indexes_data[index + 1] as usize],
                             *pause_mora.pitch(),
                         );
                         index += 1;


### PR DESCRIPTION
## 内容

https://github.com/VOICEVOX/voicevox_core/issues/213#issuecomment-1214026896 において句読点が無視されているように聞こえる問題が報告されていましたが、手元で確認したところ再現し、まだ直っていなかったことがわかりました。

原因を調査したところ、`pause_mora` の長さの設定でミスを犯していたことがわかりました（すみません……！）。本来は `vowel_length` を設定するべき数値を、`consonant_length` に設定していました（以下は C++ 版の同等の箇所。こちらの設定が正しいはずです）。

https://github.com/VOICEVOX/voicevox_core/blob/50082b69e535851a358647477bfc7b8512b43880/core/src/engine/synthesis_engine.cpp#L215-L220

これを修正したところ、句読点で音声が期待通りに区切れているように聞こえたので、修正されたと考えています。

## 関連 Issue

ref #213 

## その他
