### PR TITLE
Hotfix: C++版のLinux armhf向けコアを製品版でビルドできるようにする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,7 @@ jobs:
             cc_version: "8"
             cxx_version: "8"
             arch: arm-linux-gnueabihf
+            cmake_additional_options: -DARMHF=ON
 
           - os: ubuntu-18.04
             device: cpu-arm64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,12 @@ if(DIRECTML)
   determine_target_architecture(DML_ARCH)
 endif()
 
+option(ARMHF "Enables building for ARMHF" OFF)
+if(ARMHF)
+  # https://github.com/VOICEVOX/voicevox_core/issues/132
+  add_link_options("-Xlinker" "--long-plt")
+endif()
+
 add_subdirectory(core)
 add_subdirectory(open_jtalk/src)
 


### PR DESCRIPTION
## 内容

#132 の影響で、0.12.1より新しいバージョンでLinux  armhf向けの製品版リリースがされておらず、以降にリリースされたキャラクターやスタイルをarmhf環境で利用できない状態にあったので、0.13.x向けのHotfixとしてPRを出します。

armhf向けのビルドの場合、リンカに`--long-plt`オプションを追加することで、製品版0.12.3以降のように埋め込みファイルが多い場合でもビルドできるようにしました。

以下のDocker BuildKit/QEMUを使ったarmhf (armv7l)エミュレーション環境で、デモモデル（`model/`のonnxモデル）によってexampleの`simple_tts`で正常に音声が生成されることを確認しました（ただし埋め込みファイル全体が正常なことをテストしているわけではない）。

- <https://github.com/aoirint/vvcore_simple_tts_armhf-docker/tree/68abca1141839bbfc52d210c0901f8e8f005f552>
    - CMake 3.16以降を使用するためにUbuntu 20.04環境
    - エミュレーションとCMake 3.16の相性のためか、1回目の`cmake -S . -B build`実行に失敗することのWorkaround入り
- デモモデルを使ったビルド成果物: <https://github.com/aoirint/voicevox_core/releases/tag/0.13.0-aoirint-1>

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

- close #132 

## その他
