### PR TITLE
APIドキュメントのリンクを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ python run.py \
 
 ## API
 
-[Releases](https://github.com/VOICEVOX/voicevox_core/releases)にある zip ファイル内に core.h が入っているのでご確認ください
+[API ドキュメント](https://voicevox.github.io/voicevox_core/apis/c_api/globals_func.html)をご覧ください。
 
 ## コアライブラリのビルド
 


### PR DESCRIPTION
## 内容

READMEに追記しました。

## 関連issue

close #242 

## その他

ドキュメントのURLなのですが、とりあえず↓にしてみました。
https://voicevox.github.io/voicevox_core/apis/c_api/globals_func.html

よりわかりやすい一覧ページがあればそちらにしたほうが良いかもです。