### PR TITLE
cargo-xtaskでvoicevox_core.hを生成する

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,6 @@
+[alias]
+xtask = "run -p xtask --"
+
 [env]
 CARGO_WORKSPACE_DIR = { value = "", relative = true }
 

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -87,6 +87,12 @@ jobs:
         with:
           crate: set-cargo-version
           version: latest
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@v1
+        with:
+          tool: cargo-binstall
+      - name: Install cbindgen
+        run: cargo binstall cbindgen --version ^0.24 --no-confirm
       - name: set cargo version
         if: ${{ env.VERSION != 'DEBUG' }}
         shell: bash
@@ -96,7 +102,7 @@ jobs:
           done
       - name: generate voicevox_core.h
         shell: bash
-        run: cargo xtask generate-c-header -o ./voicevox_core.h
+        run: cbindgen --crate voicevox_core_c_api -o ./voicevox_core.h
       - name: build voicevox_core_c_api
         run: cargo build -p voicevox_core_c_api --features ${{ matrix.features }}, --target ${{ matrix.target }} --release
         env:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -31,42 +31,42 @@ jobs:
       matrix:
         include:
           - os: windows-latest
-            additional-features: ""
+            features: ""
             target: x86_64-pc-windows-msvc
             artifact_name: windows-x64-cpu
             use_cuda: false
           - os: windows-latest
-            additional-features: directml
+            features: directml
             target: x86_64-pc-windows-msvc
             artifact_name: windows-x64-directml
             use_cuda: false
           - os: windows-latest
-            additional-features: ""
+            features: ""
             target: x86_64-pc-windows-msvc
             artifact_name: windows-x64-cuda
             use_cuda: true
           - os: windows-latest
-            additional-features: ""
+            features: ""
             target: i686-pc-windows-msvc
             artifact_name: windows-x86-cpu
             use_cuda: false
           - os: ubuntu-latest
-            additional-features: ""
+            features: ""
             target: x86_64-unknown-linux-gnu
             artifact_name: linux-x64-cpu
             use_cuda: false
           - os: ubuntu-latest
-            additional-features: ""
+            features: ""
             target: x86_64-unknown-linux-gnu
             artifact_name: linux-x64-gpu
             use_cuda: true
           - os: macos-latest
-            additional-features: ""
+            features: ""
             target: aarch64-apple-darwin
             artifact_name: osx-aarch64-cpu
             use_cuda: false
           - os: macos-latest
-            additional-features: ""
+            features: ""
             target: x86_64-apple-darwin
             artifact_name: osx-x64-cpu
             use_cuda: false
@@ -94,8 +94,11 @@ jobs:
           for cargo_toml in $( echo ./crates/voicevox_core_*/Cargo.toml ); do
             set-cargo-version $cargo_toml ${{ env.VERSION }}
           done
+      - name: generate voicevox_core.h
+        shell: bash
+        run: cargo xtask generate-c-header -o ./voicevox_core.h
       - name: build voicevox_core_c_api
-        run: cargo build -p voicevox_core_c_api --features generate-c-header,${{ matrix.additional-features }} --target ${{ matrix.target }} --release
+        run: cargo build -p voicevox_core_c_api --features ${{ matrix.features }}, --target ${{ matrix.target }} --release
         env:
           ORT_USE_CUDA: ${{ matrix.use_cuda }}
       - name: build voicevox_core_python_api
@@ -103,7 +106,7 @@ jobs:
         shell: bash
         run: |
           pip install -r ./crates/voicevox_core_python_api/requirements.txt
-          maturin build --manifest-path ./crates/voicevox_core_python_api/Cargo.toml --features ${{ matrix.additional-features }}, --target ${{ matrix.target }} --release
+          maturin build --manifest-path ./crates/voicevox_core_python_api/Cargo.toml --features ${{ matrix.features }}, --target ${{ matrix.target }} --release
           printf '::set-output name=whl::%s\n' "$(find ./target/wheels -type f)"
         env:
           ORT_USE_CUDA: ${{ matrix.use_cuda }}
@@ -114,7 +117,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p "artifact/${{ env.ASSET_NAME }}"
-          cp -v target/voicevox_core.h "artifact/${{ env.ASSET_NAME }}"
+          cp -v voicevox_core.h "artifact/${{ env.ASSET_NAME }}"
           cp -v target/${{ matrix.target }}/release/*.{dll,so,dylib} "artifact/${{ env.ASSET_NAME }}" || true
           cp -v target/${{ matrix.target }}/release/voicevox_core.dll.lib "artifact/${{ env.ASSET_NAME }}/voicevox_core.lib" || true
           cp -v -n target/${{ matrix.target }}/release/build/onnxruntime-sys-*/out/onnxruntime_*/onnxruntime-*/lib/*.{dll,so.*,so,dylib} "artifact/${{ env.ASSET_NAME }}" || true

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -88,11 +88,9 @@ jobs:
           crate: set-cargo-version
           version: latest
       - name: Install cargo-binstall
-        uses: taiki-e/install-action@v1
-        with:
-          tool: cargo-binstall
+        uses: taiki-e/install-action@cargo-binstall
       - name: Install cbindgen
-        run: cargo binstall cbindgen --version ^0.24 --no-confirm
+        run: cargo binstall cbindgen@^0.24 --no-confirm
       - name: set cargo version
         if: ${{ env.VERSION != 'DEBUG' }}
         shell: bash

--- a/.github/workflows/generate_document.yml
+++ b/.github/workflows/generate_document.yml
@@ -12,11 +12,9 @@ jobs:
         with:
           submodules: true
       - name: Install cargo-binstall
-        uses: taiki-e/install-action@v1
-        with:
-          tool: cargo-binstall
+        uses: taiki-e/install-action@cargo-binstall
       - name: Install cbindgen
-        run: cargo binstall cbindgen --version ^0.24 --no-confirm
+        run: cargo binstall cbindgen@^0.24 --no-confirm
       - name: Generate C header file
         run: cbindgen --crate voicevox_core_c_api -o ./docs/apis/c_api/doxygen/voicevox_core.h
       - name: mkdir public

--- a/.github/workflows/generate_document.yml
+++ b/.github/workflows/generate_document.yml
@@ -12,9 +12,7 @@ jobs:
         with:
           submodules: true
       - name: Generate C header file
-        run: cargo build -p voicevox_core_c_api --features generate-c-header
-      - name: Copy C header file
-        run: cp -v target/*.h ./docs/apis/c_api/doxygen/
+        run: cargo xtask generate-c-header -o ./docs/apis/c_api/doxygen/voicevox_core.h
       - name: mkdir public
         run: mkdir -p public/apis/c_api
       - name: Generate doxygen document

--- a/.github/workflows/generate_document.yml
+++ b/.github/workflows/generate_document.yml
@@ -11,8 +11,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@v1
+        with:
+          tool: cargo-binstall
+      - name: Install cbindgen
+        run: cargo binstall cbindgen --version ^0.24 --no-confirm
       - name: Generate C header file
-        run: cargo xtask generate-c-header -o ./docs/apis/c_api/doxygen/voicevox_core.h
+        run: cbindgen --crate voicevox_core_c_api -o ./docs/apis/c_api/doxygen/voicevox_core.h
       - name: mkdir public
         run: mkdir -p public/apis/c_api
       - name: Generate doxygen document

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,21 +28,21 @@ jobs:
       matrix:
         include:
           - os: windows-2019
-            additional-features: ""
+            features: ""
           - os: windows-2022
-            additional-features: ""
+            features: ""
           - os: windows-2019
-            additional-features: directml
+            features: directml
           - os: windows-2022
-            additional-features: directml
+            features: directml
           - os: macos-11
-            additional-features: ""
+            features: ""
           - os: macos-12
-            additional-features: ""
+            features: ""
           - os: ubuntu-20.04
-            additional-features: ""
+            features: ""
           - os: ubuntu-22.04
-            additional-features: ""
+            features: ""
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -54,10 +54,10 @@ jobs:
       - uses: Swatinem/rust-cache@v1
         with:
           # cargoのキャッシュが原因でテストが失敗する場合はバージョン部分をカウントアップすること
-          key: "v2-cargo-test-cache-${{ matrix.additional-features }}-${{ matrix.os }}"
+          key: "v2-cargo-test-cache-${{ matrix.features }}-${{ matrix.os }}"
       - name: Run cargo test
         shell: bash
-        run: cargo test --features generate-c-header,${{ matrix.additional-features }}
+        run: cargo test --features ,${{ matrix.features }}
 
   build-unix-cpp-example:
     strategy:
@@ -73,11 +73,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
       - name: build voicevox_core_c_api
-        run: cargo build -p voicevox_core_c_api --features generate-c-header
+        run: cargo build -p voicevox_core_c_api
+      - name: voicevox_core.hを生成
+        run: cargo xtask generate-c-header -o ./example/cpp/unix/voicevox_core/voicevox_core.h
       - name: 必要なfileをunix用exampleのディレクトリに移動させる
         run: |
           mkdir -p example/cpp/unix/voicevox_core/
-          cp -v target/voicevox_core.h example/cpp/unix/voicevox_core/
           cp -v target/debug/libvoicevox_core.{so,dylib} example/cpp/unix/voicevox_core/ || true
           cp -v target/debug/build/onnxruntime-sys-*/out/onnxruntime_*/onnxruntime-*/lib/libonnxruntime.so.* example/cpp/unix/voicevox_core/ || true
           cp -v target/debug/build/onnxruntime-sys-*/out/onnxruntime_*/onnxruntime-*/lib/libonnxruntime.*.dylib example/cpp/unix/voicevox_core/ || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,10 +72,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@v1
+        with:
+          tool: cargo-binstall
+      - name: Install cbindgen
+        run: cargo binstall cbindgen --version ^0.24 --no-confirm
       - name: build voicevox_core_c_api
         run: cargo build -p voicevox_core_c_api
       - name: voicevox_core.hを生成
-        run: cargo xtask generate-c-header -o ./example/cpp/unix/voicevox_core/voicevox_core.h
+        run: cbindgen --crate voicevox_core_c_api -o ./example/cpp/unix/voicevox_core/voicevox_core.h
       - name: 必要なfileをunix用exampleのディレクトリに移動させる
         run: |
           mkdir -p example/cpp/unix/voicevox_core/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,24 @@ jobs:
         shell: bash
         run: cargo test --features ,${{ matrix.features }}
 
+  xtask-generate-c-header:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@v1
+        with:
+          tool: cargo-binstall
+      - name: Install cbindgen
+        run: cargo binstall cbindgen --version ^0.24 --no-confirm
+      - name: Generate voicevox_core_1.h
+        run: cbindgen --crate voicevox_core_c_api -o ./voicevox_core_1.h
+      - name: Generate voicevox_core_2.h
+        run: cargo xtask generate-c-header -o ./voicevox_core_2.h
+      - name: Assert these header files are same
+        run: diff -u --color=always ./voicevox_core_{1,2}.h
+
   build-unix-cpp-example:
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,11 +65,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
       - name: Install cargo-binstall
-        uses: taiki-e/install-action@v1
-        with:
-          tool: cargo-binstall
+        uses: taiki-e/install-action@cargo-binstall
       - name: Install cbindgen
-        run: cargo binstall cbindgen --version ^0.24 --no-confirm
+        run: cargo binstall cbindgen@^0.24 --no-confirm
       - name: Generate voicevox_core_1.h
         run: cbindgen --crate voicevox_core_c_api -o ./voicevox_core_1.h
       - name: Generate voicevox_core_2.h
@@ -91,11 +89,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
       - name: Install cargo-binstall
-        uses: taiki-e/install-action@v1
-        with:
-          tool: cargo-binstall
+        uses: taiki-e/install-action@cargo-binstall
       - name: Install cbindgen
-        run: cargo binstall cbindgen --version ^0.24 --no-confirm
+        run: cargo binstall cbindgen@^0.24 --no-confirm
       - name: build voicevox_core_c_api
         run: cargo build -p voicevox_core_c_api
       - name: voicevox_core.hを生成

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,6 +271,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backtrace"
+version = "0.3.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "base-x"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,17 +495,32 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.17"
+version = "3.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
  "atty",
  "bitflags",
+ "clap_derive",
  "clap_lex",
  "indexmap",
+ "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -500,6 +539,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "color-eyre"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba75b3d9449ecdccb27ecbc479fdc0b87fa2dd43d2f8298f9bf0e59aacc8dce"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
 ]
 
 [[package]]
@@ -739,6 +805,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,6 +1025,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1079,6 +1161,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
@@ -1393,6 +1481,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1480,6 +1577,12 @@ checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "parking"
@@ -1623,6 +1726,30 @@ dependencies = [
  "ctor",
  "diff",
  "output_vt100",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -1873,6 +2000,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2063,6 +2196,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.3",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -2268,9 +2410,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"
@@ -2290,6 +2432,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -2403,6 +2554,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2413,6 +2575,17 @@ checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
  "pin-project",
  "tracing",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]
@@ -2502,6 +2675,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"
@@ -2791,6 +2970,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "xtask"
+version = "0.0.0"
+dependencies = [
+ "cbindgen",
+ "clap",
+ "color-eyre",
+ "eyre",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2733,7 +2733,6 @@ name = "voicevox_core_c_api"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "cbindgen",
  "libc",
  "once_cell",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "crates/voicevox_core",
   "crates/voicevox_core_c_api",
   "crates/voicevox_core_python_api",
+  "crates/xtask",
 ]
 
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,14 @@ sudo apt install libgomp1
 model フォルダにある onnx モデルはダミーのため、ノイズの混じった音声が出力されます
 
 ```bash
-cargo build --release
+# DLLをビルド
+cargo build --release -p voicevox_core_c_api
+```
+
+```bash
+# DLL用のヘッダファイルvoicevox_core.hを生成
+# cbindgenが手元にインストールされているのならそちらでも可
+cargo xtask generate-c-header 
 ```
 
 ## コアライブラリのテスト

--- a/crates/voicevox_core_c_api/Cargo.toml
+++ b/crates/voicevox_core_c_api/Cargo.toml
@@ -8,7 +8,6 @@ name = "voicevox_core"
 crate-type = ["cdylib"]
 
 [features]
-generate-c-header = ["dep:cbindgen"]
 directml = ["voicevox_core/directml"]
 
 [dependencies]
@@ -21,6 +20,3 @@ serde_json = "1.0.83"
 pretty_assertions = "1.2.1"
 anyhow = "1.0.61"
 rstest = "0.15.0"
-
-[build-dependencies]
-cbindgen = { version = "0.24.3", optional = true }

--- a/crates/voicevox_core_c_api/build.rs
+++ b/crates/voicevox_core_c_api/build.rs
@@ -1,7 +1,4 @@
 fn main() {
-    #[cfg(feature = "generate-c-header")]
-    generate_c_header();
-
     #[cfg(target_os = "linux")]
     println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN");
 
@@ -9,22 +6,5 @@ fn main() {
     {
         println!("cargo:rustc-link-arg=-Wl,-rpath,@loader_path/");
         println!("cargo:rustc-link-arg=-Wl,-install_name,@rpath/libvoicevox_core.dylib");
-    }
-}
-
-#[cfg(feature = "generate-c-header")]
-fn generate_c_header() {
-    use std::env;
-    use std::path::PathBuf;
-
-    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let output_file = target_dir().join("voicevox_core.h").display().to_string();
-
-    cbindgen::generate(&crate_dir)
-        .unwrap()
-        .write_to_file(&output_file);
-
-    fn target_dir() -> PathBuf {
-        PathBuf::from(env::var("CARGO_WORKSPACE_DIR").unwrap()).join("target")
     }
 }

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "xtask"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+cbindgen = "0.24.3"
+clap = { version = "3.2.22", features = ["derive"] }
+color-eyre = "0.6.2"
+eyre = "0.6.8"

--- a/crates/xtask/src/commands.rs
+++ b/crates/xtask/src/commands.rs
@@ -1,0 +1,1 @@
+pub(crate) mod generate_c_header;

--- a/crates/xtask/src/commands/generate_c_header.rs
+++ b/crates/xtask/src/commands/generate_c_header.rs
@@ -1,7 +1,4 @@
-use std::{
-    io,
-    path::{Path, PathBuf},
-};
+use std::{io, path::PathBuf};
 
 use eyre::ensure;
 
@@ -19,7 +16,7 @@ pub(crate) struct ArgsGenerateCHeader {
 pub(crate) fn run(ArgsGenerateCHeader { verify, output }: ArgsGenerateCHeader) -> eyre::Result<()> {
     let bindings = cbindgen::generate(CRATE_DIR)?;
 
-    if let Some(output) = output.filter(|output| output != Path::new("-")) {
+    if let Some(output) = output {
         let changed = bindings.write_to_file(&output);
         ensure!(
             !(verify && changed),

--- a/crates/xtask/src/commands/generate_c_header.rs
+++ b/crates/xtask/src/commands/generate_c_header.rs
@@ -1,0 +1,35 @@
+use std::{
+    io,
+    path::{Path, PathBuf},
+};
+
+use eyre::ensure;
+
+#[derive(clap::Parser)]
+pub(crate) struct ArgsGenerateCHeader {
+    /// Generate bindings and compare it to the existing bindings file and error if they are different
+    #[clap(long)]
+    verify: bool,
+
+    /// The file to output the bindings to
+    #[clap(short, long)]
+    output: Option<PathBuf>,
+}
+
+pub(crate) fn run(ArgsGenerateCHeader { verify, output }: ArgsGenerateCHeader) -> eyre::Result<()> {
+    let bindings = cbindgen::generate(CRATE_DIR)?;
+
+    if let Some(output) = output.filter(|output| output != Path::new("-")) {
+        let changed = bindings.write_to_file(&output);
+        ensure!(
+            !(verify && changed),
+            "Bindings changed: {}",
+            output.display(),
+        );
+    } else {
+        bindings.write(io::stdout());
+    }
+    return Ok(());
+
+    static CRATE_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../voicevox_core_c_api");
+}

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1,0 +1,20 @@
+mod commands;
+
+use clap::{AppSettings, Parser as _};
+
+use crate::commands::generate_c_header::ArgsGenerateCHeader;
+
+#[derive(clap::Parser)]
+#[clap(global_setting(AppSettings::DeriveDisplayOrder))]
+enum Args {
+    /// Generate voicevox_core.h
+    GenerateCHeader(ArgsGenerateCHeader),
+}
+
+fn main() -> eyre::Result<()> {
+    let args = Args::parse();
+    color_eyre::install()?;
+    match args {
+        Args::GenerateCHeader(args) => commands::generate_c_header::run(args),
+    }
+}


### PR DESCRIPTION
## 内容

`cargo xtask generate-c-header`でvoicevox\_core.hを生成できるようにし、`voicevox_core_c_api/generate-c-header`を削除します。

## 関連 Issue

Resolves #282.

## その他

- [x] #284 がマージされるまで待つ
- [x] cbindgenを起動できる`xtask`クレートを追加
- [x] `voicevox_core_c_api/generate-c-header`を削除
- [x] GitHub Actionsの更新
    - [x] `cargo build -p voicevox_core_c_api --features generate-c-header`を置き換える
    - [x] CLI版cbindgenと`cargo xtask`とで同じvoicevox\_core.hが生成されることをCIでテスト
    - [x] `build_and_deploy`や`generate_document`でCLI版cbindgenを使うことで時短 (やらなくてもよいかもしれない)
        `generate_document`については分単位の短縮になると考えられる
- [x] 今はまだ書かれていないvoicevox\_core.hの生成のことをドキュメントに書く 
