### PR TITLE
cbindgenのインストール時にcargo-quickinstallのリポジトリを明示的に指定する

### DIFF
--- a/.github/actions/cargo-binstall-cbindgen/action.yml
+++ b/.github/actions/cargo-binstall-cbindgen/action.yml
@@ -1,0 +1,24 @@
+inputs:
+  version:
+    required: true
+    default: ^0.23
+
+runs:
+  using: composite
+  steps:
+    - name: Install cbindgen
+      shell: bash
+      run: |
+        case "$OS" in
+          Windows)
+            cargo install cbindgen --version ${{ inputs.version }};;
+          macOS | Linux )
+            cargo binstall \
+              cbindgen@${{ inputs.version }} \
+              --pkg-url 'https://github.com/alsuren/cargo-quickinstall/releases/download/{ name }-{ version }-{ target }/{ name }-{ version }-{ target }.tar.gz' \
+              --pkg-fmt tgz \
+              --bin-dir '{ bin }{ binary-ext }' \
+              --no-confirm \
+              --log-level debug;;
+        esac
+

--- a/.github/actions/cargo-binstall-cbindgen/action.yml
+++ b/.github/actions/cargo-binstall-cbindgen/action.yml
@@ -1,7 +1,7 @@
 inputs:
   version:
     required: true
-    default: ^0.23
+    default: ^0.24
 
 runs:
   using: composite

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Install cargo-binstall
         uses: taiki-e/install-action@cargo-binstall
       - name: Install cbindgen
-        run: cargo binstall cbindgen@^0.24 --no-confirm
+        uses: ./.github/actions/cargo-binstall-cbindgen
       - name: set cargo version
         if: ${{ env.VERSION != 'DEBUG' }}
         shell: bash

--- a/.github/workflows/generate_document.yml
+++ b/.github/workflows/generate_document.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install cargo-binstall
         uses: taiki-e/install-action@cargo-binstall
       - name: Install cbindgen
-        run: cargo binstall cbindgen@^0.24 --no-confirm
+        uses: ./.github/actions/cargo-binstall-cbindgen
       - name: Generate C header file
         run: cbindgen --crate voicevox_core_c_api -o ./docs/apis/c_api/doxygen/voicevox_core.h
       - name: mkdir public

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install cargo-binstall
         uses: taiki-e/install-action@cargo-binstall
       - name: Install cbindgen
-        run: cargo binstall cbindgen@^0.24 --no-confirm
+        uses: ./.github/actions/cargo-binstall-cbindgen
       - name: Generate voicevox_core_1.h
         run: cbindgen --crate voicevox_core_c_api -o ./voicevox_core_1.h
       - name: Generate voicevox_core_2.h
@@ -91,7 +91,7 @@ jobs:
       - name: Install cargo-binstall
         uses: taiki-e/install-action@cargo-binstall
       - name: Install cbindgen
-        run: cargo binstall cbindgen@^0.24 --no-confirm
+        uses: ./.github/actions/cargo-binstall-cbindgen
       - name: build voicevox_core_c_api
         run: cargo build -p voicevox_core_c_api
       - name: voicevox_core.hを生成


### PR DESCRIPTION
## 内容

cargo-binstallでcbindgenをインストールする際、cargo-quickinstallでの再配布を明示的にダウンロード対象にすることでCIを直します。

## 関連 Issue

## その他
