### PR TITLE
`SourceError`を廃止

### DIFF
--- a/crates/voicevox_core/src/engine/open_jtalk.rs
+++ b/crates/voicevox_core/src/engine/open_jtalk.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use ::open_jtalk::*;
 
-#[derive(thiserror::Error, Debug, PartialEq)]
+#[derive(thiserror::Error, Debug)]
 pub enum OpenJtalkError {
     #[error("open_jtalk load error")]
     Load { mecab_dict_dir: PathBuf },
@@ -10,8 +10,38 @@ pub enum OpenJtalkError {
     ExtractFullContext {
         text: String,
         #[source]
-        source: Option<crate::error::SourceError>,
+        source: Option<anyhow::Error>,
     },
+}
+
+impl PartialEq for OpenJtalkError {
+    fn eq(&self, other: &Self) -> bool {
+        return match (self, other) {
+            (
+                Self::Load {
+                    mecab_dict_dir: mecab_dict_dir1,
+                },
+                Self::Load {
+                    mecab_dict_dir: mecab_dict_dir2,
+                },
+            ) => mecab_dict_dir1 == mecab_dict_dir2,
+            (
+                Self::ExtractFullContext {
+                    text: text1,
+                    source: source1,
+                },
+                Self::ExtractFullContext {
+                    text: text2,
+                    source: source2,
+                },
+            ) => (text1, by_display(source1)) == (text2, by_display(source2)),
+            _ => false,
+        };
+
+        fn by_display(source: &Option<anyhow::Error>) -> impl PartialEq {
+            source.as_ref().map(|e| e.to_string())
+        }
+    }
 }
 
 pub type Result<T> = std::result::Result<T, OpenJtalkError>;

--- a/crates/voicevox_core/src/status.rs
+++ b/crates/voicevox_core/src/status.rs
@@ -174,7 +174,7 @@ impl Status {
         &self,
         model_bytes: B,
         session_options: &SessionOptions,
-    ) -> std::result::Result<Session<'static>, SourceError> {
+    ) -> anyhow::Result<Session<'static>> {
         let session_builder = ENVIRONMENT
             .new_session_builder()?
             .with_optimization_level(GraphOptimizationLevel::Basic)?

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -459,11 +459,11 @@ mod tests {
         VoicevoxResultCode::VOICEVOX_RESULT_NOT_LOADED_OPENJTALK_DICT_ERROR
     )]
     #[case(
-        Err(Error::LoadModel(voicevox_core::SourceError::new(anyhow!("some load model error")))),
+        Err(Error::LoadModel(anyhow!("some load model error"))),
         VoicevoxResultCode::VOICEVOX_RESULT_LOAD_MODEL_ERROR
     )]
     #[case(
-        Err(Error::GetSupportedDevices(voicevox_core::SourceError::new(anyhow!("some get supported devices error")))),
+        Err(Error::GetSupportedDevices(anyhow!("some get supported devices error"))),
         VoicevoxResultCode::VOICEVOX_RESULT_GET_SUPPORTED_DEVICES_ERROR
     )]
     fn into_result_code_with_error_works(


### PR DESCRIPTION
## 内容

`SourceError`を廃止し、`voicevox_core::Error`の`PartialEq`は手で実装します。

#297 における4.の選択肢を取りました。

## 関連 Issue

Fixes #297.

## その他
