### PR TITLE
C APIにおけるエラー表示を改善

### DIFF
--- a/crates/voicevox_core_c_api/src/helpers.rs
+++ b/crates/voicevox_core_c_api/src/helpers.rs
@@ -11,8 +11,8 @@ pub(crate) fn into_result_code_with_error(result: CApiResult<()>) -> VoicevoxRes
     return into_result_code(result);
 
     fn display_error(err: &CApiError) {
-        eprintln!("{err}");
-        dbg!(err);
+        eprintln!("Error(Display): {err}");
+        eprintln!("Error(Debug): {err:#?}");
     }
 
     fn into_result_code(result: CApiResult<()>) -> VoicevoxResultCode {


### PR DESCRIPTION
## 内容

C APIではエラーが発生した場合、以下のようにエラー内容をstderrに出力します。

https://github.com/VOICEVOX/voicevox_core/blob/01c837195882dc32932e101d3e8e9db27d01b1bc/crates/voicevox_core_c_api/src/helpers.rs#L13-L16

```console
OpenJTalkの辞書が読み込まれていません
[crates/voicevox_core_c_api/src/helpers.rs:15] err = RustApi(
    NotLoadedOpenjtalkDict,
)
```

これで十分な情報は出力されるのですが、`dbg!`はいわゆる「printデバッグ」に用いるものであり、ユーザーに向けたエラー表示に使うのは一般的ではないように思えます。
ref: [`clippy::dbg_macro`](https://rust-lang.github.io/rust-clippy/rust-1.64.0/index.html#dbg_macro)
(さらにこの`dbg!`で表示されるソースコード位置は`crates/voicevox_core_c_api/src/helpers.rs:15`で固定であり、役に立つ情報ではなくなっています)

このPRでは、エラーの出力を以下のような形式にします。

```console
Error(Display): OpenJTalkの辞書が読み込まれていません
Error(Debug): RustApi(
    NotLoadedOpenjtalkDict,
)
```

## 関連 Issue

## その他
