### PR TITLE
`voicevox_core::Error`の`Display`実装を修正

### DIFF
--- a/crates/voicevox_core/src/error.rs
+++ b/crates/voicevox_core/src/error.rs
@@ -39,11 +39,14 @@ pub enum Error {
     #[error("{}", base_error_message(VOICEVOX_RESULT_UNINITIALIZED_STATUS_ERROR))]
     UninitializedStatus,
 
-    #[error("{},{0}", base_error_message(VOICEVOX_RESULT_INVALID_SPEAKER_ID_ERROR))]
+    #[error(
+        "{}: {speaker_id}",
+        base_error_message(VOICEVOX_RESULT_INVALID_SPEAKER_ID_ERROR)
+    )]
     InvalidSpeakerId { speaker_id: u32 },
 
     #[error(
-        "{},{0}",
+        "{}: {model_index}",
         base_error_message(VOICEVOX_RESULT_INVALID_MODEL_INDEX_ERROR)
     )]
     InvalidModelIndex { model_index: usize },


### PR DESCRIPTION
## 内容

`voicevox::Error::{InvalidSpeakerId, InvalidModelIndex}`の`Display`実装を変更しました。

```diff
 ========================================
-Display: 無効なspeaker_idです,無効なspeaker_idです
+Display: 無効なspeaker_idです: 999999
 Debug: InvalidSpeakerId {
     speaker_id: 999999,
 }
 ========================================
-Display: 無効なmodel_indexです,無効なmodel_indexです
+Display: 無効なmodel_indexです: 999999
 Debug: InvalidModelIndex {
     model_index: 999999,
 }
```

## 関連 Issue

Fixes #302.

## その他
