### PR TITLE
Python APIだけlocal version segmentsを付ける

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -34,49 +34,49 @@ jobs:
             features: ""
             target: x86_64-pc-windows-msvc
             artifact_name: windows-x64-cpu
-            whl_package_name: voicevox-core-cpu
+            whl_package_name: voicevox_core-cpu
             use_cuda: false
           - os: windows-latest
             features: directml
             target: x86_64-pc-windows-msvc
             artifact_name: windows-x64-directml
-            whl_package_name: voicevox-core-directml
+            whl_package_name: voicevox_core-directml
             use_cuda: false
           - os: windows-latest
             features: ""
             target: x86_64-pc-windows-msvc
             artifact_name: windows-x64-cuda
-            whl_package_name: voicevox-core-cuda
+            whl_package_name: voicevox_core-cuda
             use_cuda: true
           - os: windows-latest
             features: ""
             target: i686-pc-windows-msvc
             artifact_name: windows-x86-cpu
-            whl_package_name: voicevox-core-cpu
+            whl_package_name: voicevox_core-cpu
             use_cuda: false
           - os: ubuntu-latest
             features: ""
             target: x86_64-unknown-linux-gnu
             artifact_name: linux-x64-cpu
-            whl_package_name: voicevox-core-cpu
+            whl_package_name: voicevox_core-cpu
             use_cuda: false
           - os: ubuntu-latest
             features: ""
             target: x86_64-unknown-linux-gnu
             artifact_name: linux-x64-gpu
-            whl_package_name: voicevox-core-cuda
+            whl_package_name: voicevox_core-cuda
             use_cuda: true
           - os: macos-latest
             features: ""
             target: aarch64-apple-darwin
             artifact_name: osx-aarch64-cpu
-            whl_package_name: voicevox-core-cpu
+            whl_package_name: voicevox_core-cpu
             use_cuda: false
           - os: macos-latest
             features: ""
             target: x86_64-apple-darwin
             artifact_name: osx-x64-cpu
-            whl_package_name: voicevox-core-cpu
+            whl_package_name: voicevox_core-cpu
             use_cuda: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -64,7 +64,7 @@ jobs:
             features: ""
             target: x86_64-unknown-linux-gnu
             artifact_name: linux-x64-gpu
-            whl_package_name: voicevox-core-gpu
+            whl_package_name: voicevox-core-cuda
             use_cuda: true
           - os: macos-latest
             features: ""

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -34,49 +34,49 @@ jobs:
             features: ""
             target: x86_64-pc-windows-msvc
             artifact_name: windows-x64-cpu
-            whl_version_local: cpu
+            whl_local_version: cpu
             use_cuda: false
           - os: windows-latest
             features: directml
             target: x86_64-pc-windows-msvc
             artifact_name: windows-x64-directml
-            whl_version_local: directml
+            whl_local_version: directml
             use_cuda: false
           - os: windows-latest
             features: ""
             target: x86_64-pc-windows-msvc
             artifact_name: windows-x64-cuda
-            whl_version_local: cuda
+            whl_local_version: cuda
             use_cuda: true
           - os: windows-latest
             features: ""
             target: i686-pc-windows-msvc
             artifact_name: windows-x86-cpu
-            whl_version_local: cpu
+            whl_local_version: cpu
             use_cuda: false
           - os: ubuntu-latest
             features: ""
             target: x86_64-unknown-linux-gnu
             artifact_name: linux-x64-cpu
-            whl_version_local: cpu
+            whl_local_version: cpu
             use_cuda: false
           - os: ubuntu-latest
             features: ""
             target: x86_64-unknown-linux-gnu
             artifact_name: linux-x64-gpu
-            whl_version_local: cuda
+            whl_local_version: cuda
             use_cuda: true
           - os: macos-latest
             features: ""
             target: aarch64-apple-darwin
             artifact_name: osx-aarch64-cpu
-            whl_version_local: cpu
+            whl_local_version: cpu
             use_cuda: false
           - os: macos-latest
             features: ""
             target: x86_64-apple-darwin
             artifact_name: osx-x64-cpu
-            whl_version_local: cpu
+            whl_local_version: cpu
             use_cuda: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -105,7 +105,7 @@ jobs:
         run: |
           for cargo_toml in $( echo ./crates/voicevox_core_*/Cargo.toml ); do
             if [[ "$cargo_toml" =~ voicevox_core_python_api ]]; then
-              version="$VERSION+"${{ matrix.whl_version_local }}
+              version="$VERSION+"${{ matrix.whl_local_version }}
             else
               version="$VERSION"
             fi

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -34,41 +34,49 @@ jobs:
             features: ""
             target: x86_64-pc-windows-msvc
             artifact_name: windows-x64-cpu
+            whl_package_name: voicevox-core-cpu
             use_cuda: false
           - os: windows-latest
             features: directml
             target: x86_64-pc-windows-msvc
             artifact_name: windows-x64-directml
+            whl_package_name: voicevox-core-directml
             use_cuda: false
           - os: windows-latest
             features: ""
             target: x86_64-pc-windows-msvc
             artifact_name: windows-x64-cuda
+            whl_package_name: voicevox-core-cuda
             use_cuda: true
           - os: windows-latest
             features: ""
             target: i686-pc-windows-msvc
             artifact_name: windows-x86-cpu
+            whl_package_name: voicevox-core-cpu
             use_cuda: false
           - os: ubuntu-latest
             features: ""
             target: x86_64-unknown-linux-gnu
             artifact_name: linux-x64-cpu
+            whl_package_name: voicevox-core-cpu
             use_cuda: false
           - os: ubuntu-latest
             features: ""
             target: x86_64-unknown-linux-gnu
             artifact_name: linux-x64-gpu
+            whl_package_name: voicevox-core-gpu
             use_cuda: true
           - os: macos-latest
             features: ""
             target: aarch64-apple-darwin
             artifact_name: osx-aarch64-cpu
+            whl_package_name: voicevox-core-cpu
             use_cuda: false
           - os: macos-latest
             features: ""
             target: x86_64-apple-darwin
             artifact_name: osx-x64-cpu
+            whl_package_name: voicevox-core-cpu
             use_cuda: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -111,7 +119,10 @@ jobs:
         run: |
           pip install -r ./crates/voicevox_core_python_api/requirements.txt
           maturin build --manifest-path ./crates/voicevox_core_python_api/Cargo.toml --features ${{ matrix.features }}, --target ${{ matrix.target }} --release
-          printf '::set-output name=whl::%s\n' "$(find ./target/wheels -type f)"
+          from="$(find ./target/wheels -type f)"
+          to="$(sed 's/voicevox_core/${{ matrix.whl_package_name }}/' <<<"$from")"
+          mv "$from" "$to"
+          printf '::set-output name=whl::%s\n' "$to"
         env:
           ORT_USE_CUDA: ${{ matrix.use_cuda }}
       - name: Set ASSET_NAME env var

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -34,49 +34,49 @@ jobs:
             features: ""
             target: x86_64-pc-windows-msvc
             artifact_name: windows-x64-cpu
-            whl_package_name: voicevox_core_cpu
+            whl_version_local: cpu
             use_cuda: false
           - os: windows-latest
             features: directml
             target: x86_64-pc-windows-msvc
             artifact_name: windows-x64-directml
-            whl_package_name: voicevox_core_directml
+            whl_version_local: directml
             use_cuda: false
           - os: windows-latest
             features: ""
             target: x86_64-pc-windows-msvc
             artifact_name: windows-x64-cuda
-            whl_package_name: voicevox_core_cuda
+            whl_version_local: cuda
             use_cuda: true
           - os: windows-latest
             features: ""
             target: i686-pc-windows-msvc
             artifact_name: windows-x86-cpu
-            whl_package_name: voicevox_core_cpu
+            whl_version_local: cpu
             use_cuda: false
           - os: ubuntu-latest
             features: ""
             target: x86_64-unknown-linux-gnu
             artifact_name: linux-x64-cpu
-            whl_package_name: voicevox_core_cpu
+            whl_version_local: cpu
             use_cuda: false
           - os: ubuntu-latest
             features: ""
             target: x86_64-unknown-linux-gnu
             artifact_name: linux-x64-gpu
-            whl_package_name: voicevox_core_cuda
+            whl_version_local: cuda
             use_cuda: true
           - os: macos-latest
             features: ""
             target: aarch64-apple-darwin
             artifact_name: osx-aarch64-cpu
-            whl_package_name: voicevox_core_cpu
+            whl_version_local: cpu
             use_cuda: false
           - os: macos-latest
             features: ""
             target: x86_64-apple-darwin
             artifact_name: osx-x64-cpu
-            whl_package_name: voicevox_core_cpu
+            whl_version_local: cpu
             use_cuda: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -104,17 +104,13 @@ jobs:
         shell: bash
         run: |
           for cargo_toml in $( echo ./crates/voicevox_core_*/Cargo.toml ); do
-            set-cargo-version $cargo_toml ${{ env.VERSION }}
+            if [[ "$cargo_toml" =~ voicevox_core_python_api ]]; then
+              version="$VERSION+"${{ matrix.whl_version_local }}
+            else
+              version="$VERSION"
+            fi
+            set-cargo-version $cargo_toml "$version"
           done
-      - name: set `project.name` for voicevox_core_python_api
-        shell: bash
-        run: |
-          if [ "$RUNNER_OS" = macOS ]; then
-            sed_i='sed -i ""'
-          else
-            sed_i='sed -i'
-          fi
-          $sed_i 's/voicevox_core/${{ matrix.whl_package_name }}/' ./crates/voicevox_core_python_api/pyproject.toml
       - name: generate voicevox_core.h
         shell: bash
         run: cbindgen --crate voicevox_core_c_api -o ./voicevox_core.h

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -106,6 +106,9 @@ jobs:
           for cargo_toml in $( echo ./crates/voicevox_core_*/Cargo.toml ); do
             set-cargo-version $cargo_toml ${{ env.VERSION }}
           done
+      - name: set `project.name` for voicevox_core_python_api
+        shell: bash
+        run: sed -i 's/voicevox_core/${{ matrix.whl_package_name }}/' ./crates/voicevox_core_python_api/pyproject.toml
       - name: generate voicevox_core.h
         shell: bash
         run: cbindgen --crate voicevox_core_c_api -o ./voicevox_core.h
@@ -119,10 +122,7 @@ jobs:
         run: |
           pip install -r ./crates/voicevox_core_python_api/requirements.txt
           maturin build --manifest-path ./crates/voicevox_core_python_api/Cargo.toml --features ${{ matrix.features }}, --target ${{ matrix.target }} --release
-          from="$(find ./target/wheels -type f)"
-          to="$(sed 's/voicevox_core/${{ matrix.whl_package_name }}/' <<<"$from")"
-          mv "$from" "$to"
-          printf '::set-output name=whl::%s\n' "$to"
+          printf '::set-output name=whl::%s\n' "$(find ./target/wheels -type f)"
         env:
           ORT_USE_CUDA: ${{ matrix.use_cuda }}
       - name: Set ASSET_NAME env var

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -34,49 +34,49 @@ jobs:
             features: ""
             target: x86_64-pc-windows-msvc
             artifact_name: windows-x64-cpu
-            whl_package_name: voicevox_core-cpu
+            whl_package_name: voicevox_core_cpu
             use_cuda: false
           - os: windows-latest
             features: directml
             target: x86_64-pc-windows-msvc
             artifact_name: windows-x64-directml
-            whl_package_name: voicevox_core-directml
+            whl_package_name: voicevox_core_directml
             use_cuda: false
           - os: windows-latest
             features: ""
             target: x86_64-pc-windows-msvc
             artifact_name: windows-x64-cuda
-            whl_package_name: voicevox_core-cuda
+            whl_package_name: voicevox_core_cuda
             use_cuda: true
           - os: windows-latest
             features: ""
             target: i686-pc-windows-msvc
             artifact_name: windows-x86-cpu
-            whl_package_name: voicevox_core-cpu
+            whl_package_name: voicevox_core_cpu
             use_cuda: false
           - os: ubuntu-latest
             features: ""
             target: x86_64-unknown-linux-gnu
             artifact_name: linux-x64-cpu
-            whl_package_name: voicevox_core-cpu
+            whl_package_name: voicevox_core_cpu
             use_cuda: false
           - os: ubuntu-latest
             features: ""
             target: x86_64-unknown-linux-gnu
             artifact_name: linux-x64-gpu
-            whl_package_name: voicevox_core-cuda
+            whl_package_name: voicevox_core_cuda
             use_cuda: true
           - os: macos-latest
             features: ""
             target: aarch64-apple-darwin
             artifact_name: osx-aarch64-cpu
-            whl_package_name: voicevox_core-cpu
+            whl_package_name: voicevox_core_cpu
             use_cuda: false
           - os: macos-latest
             features: ""
             target: x86_64-apple-darwin
             artifact_name: osx-x64-cpu
-            whl_package_name: voicevox_core-cpu
+            whl_package_name: voicevox_core_cpu
             use_cuda: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -110,11 +110,11 @@ jobs:
         shell: bash
         run: |
           if [ "$RUNNER_OS" = macOS ]; then
-            gsed=gsed
+            sed_i='sed -i ""'
           else
-            gsed=sed
+            sed_i='sed -i'
           fi
-          "$gsed" -i 's/voicevox_core/${{ matrix.whl_package_name }}/' ./crates/voicevox_core_python_api/pyproject.toml
+          $sed_i 's/voicevox_core/${{ matrix.whl_package_name }}/' ./crates/voicevox_core_python_api/pyproject.toml
       - name: generate voicevox_core.h
         shell: bash
         run: cbindgen --crate voicevox_core_c_api -o ./voicevox_core.h

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -108,7 +108,13 @@ jobs:
           done
       - name: set `project.name` for voicevox_core_python_api
         shell: bash
-        run: sed -i 's/voicevox_core/${{ matrix.whl_package_name }}/' ./crates/voicevox_core_python_api/pyproject.toml
+        run: |
+          if [ "$RUNNER_OS" = macOS ]; then
+            gsed=gsed
+          else
+            gsed=sed
+          fi
+          "$gsed" -i 's/voicevox_core/${{ matrix.whl_package_name }}/' ./crates/voicevox_core_python_api/pyproject.toml
       - name: generate voicevox_core.h
         shell: bash
         run: cbindgen --crate voicevox_core_c_api -o ./voicevox_core.h


### PR DESCRIPTION
## 内容

リリース時にwhlの名前をリネームします。

Maturin側でwhlの名付けをコントロールするのは面倒そうなので、whlの生成後にリネームするようにしました。

## 関連 Issue

Fixes #304.

## その他
