### PR TITLE
不要な`unsafe impl`を削除

### DIFF
--- a/crates/voicevox_core/src/engine/synthesis_engine.rs
+++ b/crates/voicevox_core/src/engine/synthesis_engine.rs
@@ -21,8 +21,6 @@ pub struct SynthesisEngine {
 
 #[allow(unsafe_code)]
 unsafe impl Send for SynthesisEngine {}
-#[allow(unsafe_code)]
-unsafe impl Sync for SynthesisEngine {}
 
 impl SynthesisEngine {
     pub const DEFAULT_SAMPLING_RATE: u32 = 24000;

--- a/crates/voicevox_core/src/status.rs
+++ b/crates/voicevox_core/src/status.rs
@@ -99,8 +99,6 @@ impl SupportedDevices {
 
 #[allow(unsafe_code)]
 unsafe impl Send for Status {}
-#[allow(unsafe_code)]
-unsafe impl Sync for Status {}
 
 impl Status {
     const MODELS: &'static [Model] = &include!("include_models.rs");


### PR DESCRIPTION
## 内容

`SynthesisEngine`に対する不要な`unsafe impl Sync`を削除します ([`Sync`は`Mutex`が与えてくれる](https://doc.rust-lang.org/stable/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E)ため)。

## 関連 Issue

## その他
