### PR TITLE
Hotfix: CI: 自動作成されるリリースのタグの場所を正しくする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -317,7 +317,7 @@ jobs:
 
       - name: Upload to Release
         if: env.VERSION != 'DEBUG' && env.SKIP_UPLOADING_RELEASE_ASSET == '0'
-        uses: svenstaro/upload-release-action@v2
+        uses: softprops/action-gh-release@v1
         with:
           prerelease: true
           tag_name: ${{ env.VERSION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -319,10 +319,11 @@ jobs:
         if: env.VERSION != 'DEBUG' && env.SKIP_UPLOADING_RELEASE_ASSET == '0'
         uses: svenstaro/upload-release-action@v2
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: true
-          tag: ${{ env.VERSION }}
-          file: ${{ env.ASSET_NAME }}.zip
+          tag_name: ${{ env.VERSION }}
+          files: |-
+            ${{ env.ASSET_NAME }}.zip
+          target_commitish: ${{ github.ref }}
 
   build-win-cpp-example:
     runs-on: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -323,7 +323,7 @@ jobs:
           tag_name: ${{ env.VERSION }}
           files: |-
             ${{ env.ASSET_NAME }}.zip
-          target_commitish: ${{ github.ref }}
+          target_commitish: ${{ github.sha }}
 
   build-win-cpp-example:
     runs-on: windows-latest


### PR DESCRIPTION
## 内容

`svenstaro/upload-release-action@v2`で自動作成されたリリースに紐づくtagが、メインブランチの最新コミットを指してしまう問題を修正し、CIが実行されたコミットを指すようにします。
tagのコミットIDを指定（`target_commitish: ${{ github.sha }}`）できる、`softprops/action-gh-release@v1`を使用するように変更しました。

既存の誤ったタグはPRでは張り替えられないと思うので、そちらはそのままになります（コード署名が導入されてからのリリースが該当）。

### 動作の確認

- [x] GitHub Releaseを手動で作成したときに、Releaseの上書きができないなどの原因でCIが落ちない
    - <https://github.com/aoirint/voicevox_core/actions/runs/3265943698> 
- [x] Run workflowボタンからCIを実行したときに、新規Releaseが自動で作成される
    - <https://github.com/aoirint/voicevox_core/actions/runs/3266032425>
    - デフォルトブランチに`workflow_dispatch`のWorkflowがないと、Run workflowボタンが現れないので、手元のforkでは一時的にデフォルトブランチをこのPRのブランチにしています
    - このPRのブランチから、1コミット追加した別のブランチを生やし、Run workflowボタンの`Use workflow from`で使用しています
    - 自動作成されたリリースは、デフォルトブランチの最新コミットではなく、1コミット進んだもの（CIが実行されたコミット）を指すように修正されていることが確認できます
        - https://github.com/aoirint/voicevox_core/releases/tag/0.13.0-aoirint.6

### Node 12の非推奨警告が出ます

GitHub Actionsでは、2022年4月にサポート終了したNode 12で動くActionの非推奨化が、2022年9月から始まっているようです。

- <https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/>

`softprops/actions-gh-release@v1`は、Node 12で動くようなので、CIの実行ログに非推奨警告が出ます。

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2***22-***9-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/setup-python, actions/cache, actions/upload-artifact, softprops/action-gh-release, actions/cache, actions/setup-python, actions/checkout

2023年夏にNode 12で動くよう指定されたActionは動かなくなるかもしれませんが、`softprops/actions-gh-release`ではすでにPRが出ているようなので、そちらのPRがマージされたあと、Actionのバージョンを上げれば警告は消えそうです。

- <https://github.com/softprops/action-gh-release/issues/263>
- <https://github.com/softprops/action-gh-release/pull/264>

Issue化しました（全リポジトリに関係するのでvoicevoxリポジトリにとりあえず）。

- <https://github.com/VOICEVOX/voicevox/issues/987>

### GITHUB_TOKENの明示的な指定を削除

リポジトリに対する限定的な権限を持つアクセストークンの`secrets.GITHUB_TOKEN`は、トークンのデフォルト値として使用されるので、別リポジトリにリリースを作りにいくのでなければ、明示的な指定は不要ということで、削除しました。

`svenstaro/upload-release-action`の以前のバージョンでは、このデフォルト値機能がなかったようなので、その名残りだと思われます・・・！

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

- ref <https://github.com/VOICEVOX/voicevox/issues/904>
- ref <https://github.com/VOICEVOX/voicevox_engine/pull/489>
- ref <https://github.com/VOICEVOX/voicevox/pull/985>
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他
