### PR TITLE
actions-rs/toolchainからdtolnay/rust-toolchainに切り替える

### DIFF
--- a/.github/actions/rust-toolchain-from-file/action.yml
+++ b/.github/actions/rust-toolchain-from-file/action.yml
@@ -1,0 +1,17 @@
+inputs:
+  targets:
+    required: false
+  components:
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - id: read-rust-toolchain
+      shell: bash
+      run: echo "toolchain=$(cat ./rust-toolchain)" >> "$GITHUB_OUTPUT"
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ steps.read-rust-toolchain.outputs.toolchain }}
+        targets: ${{ inputs.targets }}
+        components: ${{ inputs.components }}

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -78,10 +78,10 @@ jobs:
         with:
           python-version: "3.8"
           architecture: ${{ contains(matrix.artifact_name,'x86') && 'x86' || 'x64' }}
-      - uses: actions-rs/toolchain@v1
+      - name: set up ${{ matrix.target }}
+        uses: ./.github/actions/rust-toolchain-from-file
         with:
-          target: ${{ matrix.target }}
-          default: true
+          targets: ${{ matrix.target }}
       - uses: actions-rs/install@v0.1
         if: ${{ env.VERSION != 'DEBUG' }}
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Set up Rust
+        uses: ./.github/actions/rust-toolchain-from-file
         with:
           components: clippy,rustfmt
       - name: Set up Python 3.8
@@ -50,7 +51,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3.8"
-      - uses: actions-rs/toolchain@v1
+      - name: Set up Rust
+        uses: ./.github/actions/rust-toolchain-from-file
       - uses: Swatinem/rust-cache@v1
         with:
           # cargoのキャッシュが原因でテストが失敗する場合はバージョン部分をカウントアップすること
@@ -63,7 +65,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - name: Set up Rust
+        uses: ./.github/actions/rust-toolchain-from-file
       - name: Install cargo-binstall
         uses: taiki-e/install-action@cargo-binstall
       - name: Install cbindgen
@@ -87,7 +90,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - name: Set up Rust
+        uses: ./.github/actions/rust-toolchain-from-file
       - name: Install cargo-binstall
         uses: taiki-e/install-action@cargo-binstall
       - name: Install cbindgen
@@ -133,7 +137,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3.8"
-      - uses: actions-rs/toolchain@v1
+      - name: Set up Rust
+        uses: ./.github/actions/rust-toolchain-from-file
       - name: venv作成
         shell: bash
         run: |

--- a/.github/workflows/update_rust_toolchain.yml
+++ b/.github/workflows/update_rust_toolchain.yml
@@ -10,9 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - name: set up stable rust
+        uses: dtolnay/rust-toolchain@stable
       - name: update rust toolchain
         shell: bash
         run: |


### PR DESCRIPTION
## 内容

このリポジトリで使っているactions-rs/toolchainをdtolnay/rust-toolchainに置き換えます。

## 関連 Issue

Resolves #312.

## その他
