### PR TITLE
CI: 自動作成されるリリースのタグの場所を正しくする

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -162,30 +162,32 @@ jobs:
           powershell Compress-Archive -Path "artifact/${{ env.ASSET_NAME }}" -DestinationPath "${{ env.ASSET_NAME }}.zip"
       - name: Upload to Release
         if: env.VERSION != 'DEBUG' && env.SKIP_UPLOADING_RELEASE_ASSET == '0'
-        uses: svenstaro/upload-release-action@v2
+        uses: softprops/action-gh-release@v1
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: true
-          tag: ${{ env.VERSION }}
-          file: ${{ env.ASSET_NAME }}.zip
+          tag_name: ${{ env.VERSION }}
+          files: |-
+            ${{ env.ASSET_NAME }}.zip
+          target_commitish: ${{ github.sha }}
       - name: Upload Python whl to Release
         if: env.VERSION != 'DEBUG' && env.SKIP_UPLOADING_RELEASE_ASSET == '0'
-        uses: svenstaro/upload-release-action@v2
+        uses: softprops/action-gh-release@v1
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: true
-          tag: ${{ env.VERSION }}
-          file: ${{ steps.build-voicevox-core-python-api.outputs.whl }}
+          tag_name: ${{ env.VERSION }}
+          files: |-
+            ${{ steps.build-voicevox-core-python-api.outputs.whl }}
+          target_commitish: ${{ github.sha }}
   deploy_downloader:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Upload to Release
         if: env.VERSION != 'DEBUG' && env.SKIP_UPLOADING_RELEASE_ASSET == '0'
-        uses: svenstaro/upload-release-action@v2
+        uses: softprops/action-gh-release@v1
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: true
-          file: scripts/downloads/*
-          file_glob: true
-          tag: ${{ env.VERSION }}
+          tag_name: ${{ env.VERSION }}
+          files: |-
+            scripts/downloads/*
+          target_commitish: ${{ github.sha }}


### PR DESCRIPTION
## 内容

mainブランチへのPRです（<https://github.com/VOICEVOX/voicevox_core/pull/311#pullrequestreview-1150911192>）。

`svenstaro/upload-release-action@v2`で自動作成されたリリースに紐づくtagが、メインブランチの最新コミットを指してしまう問題を修正し、CIが実行されたコミットを指すようにします。
tagのコミットIDを指定（`target_commitish: ${{ github.sha }}`）できる、`softprops/action-gh-release@v1`を使用するように変更しました。

- 動作確認: <https://github.com/aoirint/voicevox_core/actions/runs/3298041031>
    - 自動作成されたリリース: <https://github.com/aoirint/voicevox_core/releases/tag/0.13.0-aoirint.8>


## 関連 Issue

- ref <https://github.com/VOICEVOX/voicevox/issues/904>
- ref <https://github.com/VOICEVOX/voicevox_engine/pull/489>
- ref <https://github.com/VOICEVOX/voicevox/pull/985>
- ref <https://github.com/VOICEVOX/voicevox_core/pull/311>