### PR TITLE
fix: Python API の共有ライブラリが C API の配布物に含まれないようにする

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -135,7 +135,7 @@ jobs:
         run: |
           mkdir -p "artifact/${{ env.ASSET_NAME }}"
           cp -v voicevox_core.h "artifact/${{ env.ASSET_NAME }}"
-          cp -v target/${{ matrix.target }}/release/*.{dll,so,dylib} "artifact/${{ env.ASSET_NAME }}" || true
+          cp -v target/${{ matrix.target }}/release/*voicevox_core.{dll,so,dylib} "artifact/${{ env.ASSET_NAME }}" || true
           cp -v target/${{ matrix.target }}/release/voicevox_core.dll.lib "artifact/${{ env.ASSET_NAME }}/voicevox_core.lib" || true
           cp -v -n target/${{ matrix.target }}/release/build/onnxruntime-sys-*/out/onnxruntime_*/onnxruntime-*/lib/*.{dll,so.*,so,dylib} "artifact/${{ env.ASSET_NAME }}" || true
           # libonnxruntimeについてはバージョン付のshared libraryを使用するためバージョンがついてないものを削除する


### PR DESCRIPTION
## 内容

C API の配布物内に Python API 向けの共有ライブラリ（例えば Linux では `libvoicevox_core_python_api.so`）が含まれてしまっていました（ #315 のテストリリース https://github.com/aoirint/voicevox_core/releases/tag/0.13.0-aoirint.8 の結果を見て気づきました。Python API 向けの共有ライブラリができている理由は、`voicevox_core_python_api` クレートの crate-type が cdylib だからと考えられます）。

```
voicevox_core-linux-x64-cpu-0.13.0-aoirint.8 $ ls
README.txt			libonnxruntime.so.1.11.1	libvoicevox_core_python_api.so <- これです
VERSION				libvoicevox_core.so		voicevox_core.h
```

これは意図的な同梱ではないはずなので、C API の共有ライブラリ（Linux の場合 `libvoicevox_core.so`）のみをコピーするように修正しました。

## 関連 PR

ref #315 
