### PR TITLE
`set-output`から`>> "$GITHUB_OUTPUT"`に切り替える

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -124,7 +124,7 @@ jobs:
         run: |
           pip install -r ./crates/voicevox_core_python_api/requirements.txt
           maturin build --manifest-path ./crates/voicevox_core_python_api/Cargo.toml --features ${{ matrix.features }}, --target ${{ matrix.target }} --release
-          printf '::set-output name=whl::%s\n' "$(find ./target/wheels -type f)"
+          echo "whl=$(find ./target/wheels -type f)" >> "$GITHUB_OUTPUT"
         env:
           ORT_USE_CUDA: ${{ matrix.use_cuda }}
       - name: Set ASSET_NAME env var


### PR DESCRIPTION
## 内容

`echo "::set-output name={key}::{value}"`というやりかたが[deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)になっており、Actionsの画面で警告も出ているため新しい方法に切り替えます。

## 関連 Issue

## その他
