### PR TITLE
`NvOptimusEnablement`と`AmdPowerXpressRequestHighPerformance`を宣言

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2720,6 +2720,7 @@ dependencies = [
  "surf",
  "tar",
  "thiserror",
+ "winapi",
 ]
 
 [[package]]

--- a/crates/voicevox_core/Cargo.toml
+++ b/crates/voicevox_core/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [features]
 default = []
-directml = ["onnxruntime/directml"]
+directml = ["dep:winapi", "onnxruntime/directml"]
 
 
 [dependencies]
@@ -20,6 +20,7 @@ serde_json = "1.0.85"
 thiserror = "1.0.37"
 open_jtalk = { git = "https://github.com/VOICEVOX/open_jtalk-rs.git", rev="c77112b470874a6a963426ed6c2fb21f12394a78" }
 regex = "1.6.0"
+winapi = { version = "0.3.9", optional = true }
 
 [dev-dependencies]
 rstest = "0.15.0"

--- a/crates/voicevox_core/src/publish.rs
+++ b/crates/voicevox_core/src/publish.rs
@@ -13,6 +13,18 @@ use std::{collections::BTreeMap, path::PathBuf};
 use status::*;
 use std::ffi::CString;
 
+#[cfg(feature = "directml")]
+#[allow(non_upper_case_globals)]
+const _: () = {
+    use winapi::shared::minwindef::DWORD;
+
+    #[no_mangle]
+    pub static NvOptimusEnablement: DWORD = 0x00000001;
+
+    #[no_mangle]
+    pub static AmdPowerXpressRequestHighPerformance: DWORD = 0x00000001;
+};
+
 const PHONEME_LENGTH_MINIMAL: f32 = 0.01;
 
 static SPEAKER_ID_MAP: Lazy<BTreeMap<u32, (usize, u32)>> =

--- a/crates/voicevox_core/src/publish.rs
+++ b/crates/voicevox_core/src/publish.rs
@@ -14,7 +14,7 @@ use status::*;
 use std::ffi::CString;
 
 #[cfg(feature = "directml")]
-#[allow(non_upper_case_globals)]
+#[allow(non_upper_case_globals, unsafe_code)]
 const _: () = {
     use winapi::shared::minwindef::DWORD;
 

--- a/crates/voicevox_core_c_api/build.rs
+++ b/crates/voicevox_core_c_api/build.rs
@@ -1,4 +1,10 @@
 fn main() {
+    #[cfg(feature = "directml")]
+    {
+        println!("cargo:rustc-link-arg=/EXPORT:NvOptimusEnablement");
+        println!("cargo:rustc-link-arg=/EXPORT:AmdPowerXpressRequestHighPerformance");
+    }
+
     #[cfg(target_os = "linux")]
     println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN");
 

--- a/crates/voicevox_core_python_api/build.rs
+++ b/crates/voicevox_core_python_api/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    if cfg!(feature = "directml") {
+        println!("cargo:rustc-link-arg=/EXPORT:NvOptimusEnablement");
+        println!("cargo:rustc-link-arg=/EXPORT:AmdPowerXpressRequestHighPerformance");
+    }
+}


### PR DESCRIPTION
## 内容

`NvOptimusEnablement`と`AmdPowerXpressRequestHighPerformance`を宣言し、DirectMLで良い方のGPUが使われるようにします。

## 関連 Issue

Fixes #309.

## その他

Optimusの環境はおろか、まだ通常のWindowsの環境でも実際に動かしてません。そのためdraftとします。
