### PR TITLE
`latest`を指定するのをやめる

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -30,49 +30,49 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-latest
+          - os: windows-2019
             features: ""
             target: x86_64-pc-windows-msvc
             artifact_name: windows-x64-cpu
             whl_local_version: cpu
             use_cuda: false
-          - os: windows-latest
+          - os: windows-2019
             features: directml
             target: x86_64-pc-windows-msvc
             artifact_name: windows-x64-directml
             whl_local_version: directml
             use_cuda: false
-          - os: windows-latest
+          - os: windows-2019
             features: ""
             target: x86_64-pc-windows-msvc
             artifact_name: windows-x64-cuda
             whl_local_version: cuda
             use_cuda: true
-          - os: windows-latest
+          - os: windows-2019
             features: ""
             target: i686-pc-windows-msvc
             artifact_name: windows-x86-cpu
             whl_local_version: cpu
             use_cuda: false
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             features: ""
             target: x86_64-unknown-linux-gnu
             artifact_name: linux-x64-cpu
             whl_local_version: cpu
             use_cuda: false
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             features: ""
             target: x86_64-unknown-linux-gnu
             artifact_name: linux-x64-gpu
             whl_local_version: cuda
             use_cuda: true
-          - os: macos-latest
+          - os: macos-11
             features: ""
             target: aarch64-apple-darwin
             artifact_name: osx-aarch64-cpu
             whl_local_version: cpu
             use_cuda: false
-          - os: macos-latest
+          - os: macos-11
             features: ""
             target: x86_64-apple-darwin
             artifact_name: osx-x64-cpu


### PR DESCRIPTION
## 内容

build_and_deploy.ymlにある`-latest`の指定を以下の通りに変更します。

- `windows-latest` → `windows-2019`
- `macos-latest` → `macos-11`
- `ubuntu-latest` → `ubuntu-20.04`

## 関連 Issue

https://github.com/VOICEVOX/voicevox_engine/pull/510

## その他
