### PR TITLE
Markdownドキュメントにある`curl`に`-f`を付ける

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Invoke-WebRequest https://github.com/VOICEVOX/voicevox_core/releases/latest/down
 ### Linux/macOS の場合
 
 ```bash
-curl -sSL https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.sh | bash -s
+curl-sSfL https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.sh | bash -s
 ```
 
 詳細な Downloader の使い方については [こちら](./docs/downloads/download.md) を参照してください

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Invoke-WebRequest https://github.com/VOICEVOX/voicevox_core/releases/latest/down
 ### Linux/macOS の場合
 
 ```bash
-curl-sSfL https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.sh | bash -s
+curl -sSfL https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.sh | bash -s
 ```
 
 詳細な Downloader の使い方については [こちら](./docs/downloads/download.md) を参照してください

--- a/docs/downloads/download.md
+++ b/docs/downloads/download.md
@@ -17,7 +17,7 @@ Invoke-WebRequest https://github.com/VOICEVOX/voicevox_core/releases/latest/down
 ### Linux/macOS の場合
 
 ```bash
-curl-sSfL https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.sh | bash -s
+curl -sSfL https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.sh | bash -s
 ```
 
 <a id="directml"></a>
@@ -43,7 +43,7 @@ Invoke-WebRequest https://github.com/VOICEVOX/voicevox_core/releases/latest/down
 ### Linux の場合
 
 ```bash
-curl-sSfL https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.sh | bash -s -- --accelerator cuda
+curl -sSfL https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.sh | bash -s -- --accelerator cuda
 ```
 
 <a id="help"></a>
@@ -63,5 +63,5 @@ Get-Help ./download.ps1 -full
 ### Linux/macOS の場合
 
 ```bash
-curl-sSfL https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.sh | bash -s -- --help
+curl -sSfL https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.sh | bash -s -- --help
 ```

--- a/docs/downloads/download.md
+++ b/docs/downloads/download.md
@@ -17,7 +17,7 @@ Invoke-WebRequest https://github.com/VOICEVOX/voicevox_core/releases/latest/down
 ### Linux/macOS の場合
 
 ```bash
-curl -sSL https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.sh | bash -s
+curl-sSfL https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.sh | bash -s
 ```
 
 <a id="directml"></a>
@@ -43,7 +43,7 @@ Invoke-WebRequest https://github.com/VOICEVOX/voicevox_core/releases/latest/down
 ### Linux の場合
 
 ```bash
-curl -sSL https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.sh | bash -s -- --accelerator cuda
+curl-sSfL https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.sh | bash -s -- --accelerator cuda
 ```
 
 <a id="help"></a>
@@ -63,5 +63,5 @@ Get-Help ./download.ps1 -full
 ### Linux/macOS の場合
 
 ```bash
-curl -sSL https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.sh | bash -s -- --help
+curl-sSfL https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.sh | bash -s -- --help
 ```


### PR DESCRIPTION
## 内容

~~`find -name '*.md' -exec sed -i 's/curl -sSL/curl-sSfL/' {} +`~~
`find -name '*.md' | xargs sed -i 's/curl -sSL/curl -sSfL/'`します。 (スペース入れ忘れてました)

before:

```console
❯ curl -sSL https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.sh
Not Found%
❯ echo "$?"
0
```

after:

```console
❯ curl -sSfL https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.sh
curl: (22) The requested URL returned error: 404
❯ echo "$?"
22
```

## 関連 Issue

https://github.com/VOICEVOX/voicevox_core/issues/330

## その他

ダウンロードスクリプトとかには既にちゃんと`-f`が付いていました。
