### PR TITLE
CPUアーキテクチャを指定してダウンロードできるように修正

### DIFF
--- a/.github/workflows/download_test.yml
+++ b/.github/workflows/download_test.yml
@@ -175,6 +175,23 @@ jobs:
               *nvidia*
               *cufft*
               *curand*
+          - name: CPUArch指定
+            os: ubuntu-latest
+            download_command: ./scripts/downloads/download.sh --cpu-arch x64
+            download_dir: voicevox_core
+            check_items: |
+              libcore.so
+              open_jtalk_dic_utf_8-1.11
+              README.txt
+            check_not_exists_items: |
+              *directml*
+              *cuda*
+              *cudnn*
+              *onnxruntime*providers*
+              *eula*
+              *nvidia*
+              *cufft*
+              *curand*
           - name: output先指定ダウンロード
             os: ubuntu-latest
             download_command: ./scripts/downloads/download.sh --output other_output

--- a/.github/workflows/download_test.yml
+++ b/.github/workflows/download_test.yml
@@ -30,6 +30,23 @@ jobs:
               *nvidia*
               *cufft*
               *curand*
+          - name: CpuArch指定
+            os: windows-latest
+            download_command: ./scripts/downloads/Download.ps1 -CpuArch x86
+            download_dir: voicevox_core
+            check_items: |
+              core.dll
+              open_jtalk_dic_utf_8-1.11
+              README.txt
+            check_not_exists_items: |
+              *directml*
+              *cuda*
+              *cudnn*
+              *onnxruntime*providers*
+              *eula*
+              *nvidia*
+              *cufft*
+              *curand*
           - name: output先指定ダウンロード
             os: windows-latest
             download_command: ./scripts/downloads/Download.ps1 -Output other_output

--- a/scripts/downloads/download.ps1
+++ b/scripts/downloads/download.ps1
@@ -29,7 +29,7 @@ Param(
 	[Parameter()]
 	[bool]
 	# ダウンロードするライブラリを最小限にするように指定
-	$Min = $False
+	$Min = $False,
 
   [Parameter()]
   [ValidateSet("x86","x64")]

--- a/scripts/downloads/download.ps1
+++ b/scripts/downloads/download.ps1
@@ -32,6 +32,7 @@ Param(
 	$Min = $False
 
   [Parameter()]
+  [ValidateSet("x86","x64")]
   [String]
   # CPUアーキテクチャの指定
   $CpuArch

--- a/scripts/downloads/download.ps1
+++ b/scripts/downloads/download.ps1
@@ -30,12 +30,11 @@ Param(
 	[bool]
 	# ダウンロードするライブラリを最小限にするように指定
 	$Min = $False,
-
-  [Parameter()]
-  [ValidateSet("x86","x64")]
-  [String]
-  # CPUアーキテクチャの指定
-  $CpuArch = ""
+	[Parameter()]
+	[ValidateSet("x86","x64")]
+	[String]
+	# CPUアーキテクチャの指定
+	$CpuArch = ""
 )
 mkdir -p $Output
 If (-Not(Split-Path $Output -IsAbsolute)){

--- a/scripts/downloads/download.ps1
+++ b/scripts/downloads/download.ps1
@@ -30,6 +30,11 @@ Param(
 	[bool]
 	# ダウンロードするライブラリを最小限にするように指定
 	$Min = $False
+
+  [Parameter()]
+  [String]
+  # CPUアーキテクチャの指定
+  $CpuArch
 )
 mkdir -p $Output
 If (-Not(Split-Path $Output -IsAbsolute)){
@@ -111,8 +116,11 @@ Function Download-and-Extract($Target,$Url,$ExtractDir,$ArchiveFormat){
 }
 
 $Os=Target-Os
-$CpuArch=Target-Arch
 $OpenJtalkOutput= Join-Path $Output $OpenJtalkDictDirName
+
+If ( $CpuArch ){
+  $CpuArch=Target-Arch
+}
 
 If ( $Accelerator -eq "cpu" ){
 	$AdditionalLibrariesVersion=""

--- a/scripts/downloads/download.ps1
+++ b/scripts/downloads/download.ps1
@@ -35,7 +35,7 @@ Param(
   [ValidateSet("x86","x64")]
   [String]
   # CPUアーキテクチャの指定
-  $CpuArch
+  $CpuArch = ""
 )
 mkdir -p $Output
 If (-Not(Split-Path $Output -IsAbsolute)){
@@ -119,7 +119,7 @@ Function Download-and-Extract($Target,$Url,$ExtractDir,$ArchiveFormat){
 $Os=Target-Os
 $OpenJtalkOutput= Join-Path $Output $OpenJtalkDictDirName
 
-If ( $CpuArch ){
+If ( [string]::IsNullOrEmpty($CpuArch) ){
   $CpuArch=Target-Arch
 }
 

--- a/scripts/downloads/download.sh
+++ b/scripts/downloads/download.sh
@@ -8,6 +8,7 @@ help(){
     -v|--version \$version                     ダウンロードするvoicevox_coreのバージョンの指定(default latest)
     --additional-libraries-version \$version   追加でダウンロードするライブラリのバージョン
     --accelerator \$accelerator                ダウンロードするacceleratorを指定する(cpu,cudaを指定可能.cudaはlinuxのみ)
+    --cpu-arch \$cpu-arch                      ダウンロードするcpuのアーキテクチャを指定する
     --min                                     ダウンロードするライブラリを最小限にするように指定
 EOM
   exit 2
@@ -132,6 +133,9 @@ do
     --accelerator)
       accelerator="$2"
       shift;;
+    --cpu-arch)
+      cpu_arch="$2"
+      shift;;
     --min)
       min=true
       ;;
@@ -144,9 +148,11 @@ done
 
 
 os=$(target_os)
-cpu_arch=$(target_arch)
 open_jtalk_output="${output%/}/$open_jtalk_dict_dir_name"
 
+if [ -z "$cpu_arch" ];then
+  cpu_arch=$(target_arch)
+fi
 
 if [ "$accelerator" = "" ];then
   accelerator="cpu"

--- a/scripts/downloads/download.sh
+++ b/scripts/downloads/download.sh
@@ -8,7 +8,7 @@ help(){
     -v|--version \$version                     ダウンロードするvoicevox_coreのバージョンの指定(default latest)
     --additional-libraries-version \$version   追加でダウンロードするライブラリのバージョン
     --accelerator \$accelerator                ダウンロードするacceleratorを指定する(cpu,cudaを指定可能.cudaはlinuxのみ)
-    --cpu-arch \$cpu-arch                      ダウンロードするcpuのアーキテクチャを指定する
+    --cpu-arch \$cpu_arch                      ダウンロードするcpuのアーキテクチャを指定する
     --min                                     ダウンロードするライブラリを最小限にするように指定
 EOM
   exit 2

--- a/scripts/downloads/download.sh
+++ b/scripts/downloads/download.sh
@@ -108,6 +108,7 @@ download_and_extract(){
   echo "${target}のファイルを展開完了しました。後続のファイルダウンロード処理を待ってください"
 }
 
+cpu_arch=""
 version="latest"
 additional_libraries_version="latest"
 accelerator=""


### PR DESCRIPTION
## 内容

[エンジンデプロイ時にcoreのダウンロードスクリプトを使用するようにする](https://github.com/VOICEVOX/voicevox_engine/issues/514)  ためCPUアーキテクチャを指定してダウンロードスクリプトを実行できるように修正した

## 関連 Issue

refs https://github.com/VOICEVOX/voicevox_engine/issues/514

