### PR TITLE
`psscriptanalyzer`の起動条件にworkflow file自体の変更を加える

### DIFF
--- a/.github/workflows/psscriptanalyzer.yml
+++ b/.github/workflows/psscriptanalyzer.yml
@@ -5,6 +5,7 @@ on:
       - main
     paths:
       - '**.ps1'
+      - '.github/workflows/psscriptanalyzer.yml'
 jobs:
   psscriptanalyzer:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## 内容

~~#334~~ #343 でこれを忘れていたため、`main`ブランチでworkflowが作動していません。
(それでもdownload.ps1を更新すれば動くと思いますが)

## 関連 Issue

~~#334~~ #343

## その他
