### PR TITLE
linux-arm64-cpu用ビルドの追加

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,3 +7,6 @@ CARGO_WORKSPACE_DIR = { value = "", relative = true }
 # Windows環境でテストエラーになるのを防ぐために設定するworkaround
 # https://github.com/VOICEVOX/onnxruntime-rs/issues/3#issuecomment-1207381367
 ORT_OUT_DIR = { value = "target/debug/deps", relative = true }
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -66,6 +66,12 @@ jobs:
             artifact_name: linux-x64-gpu
             whl_local_version: cuda
             use_cuda: true
+          - os: ubuntu-20.04
+            features: ""
+            target: aarch64-unknown-linux-gnu
+            artifact_name: linux-arm64-cpu
+            whl_local_version: cpu
+            use_cuda: false
           - os: macos-11
             features: ""
             target: aarch64-apple-darwin
@@ -90,6 +96,12 @@ jobs:
         uses: ./.github/actions/rust-toolchain-from-file
         with:
           targets: ${{ matrix.target }}
+      - name: Install cross compiler for aarch64-unknown-linux-gnu
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        shell: bash
+        run: |
+          sudo apt update
+          sudo apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
       - name: Install cargo-binstall
         uses: taiki-e/install-action@cargo-binstall
       - name: Install cbindgen

--- a/crates/voicevox_core/Cargo.toml
+++ b/crates/voicevox_core/Cargo.toml
@@ -15,11 +15,11 @@ cfg-if = "1.0.0"
 derive-getters = "0.2.0"
 derive-new = "0.5.9"
 once_cell.workspace = true
-onnxruntime = { git = "https://github.com/VOICEVOX/onnxruntime-rs.git", rev="bee215aaf6d5e346d96e0724acd02a51f612a72e" }
+onnxruntime = { git = "https://github.com/VOICEVOX/onnxruntime-rs.git", rev="ddcdc56a5fc0b6cf38faf8b5349c44fbf5a2ca8c" }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-open_jtalk = { git = "https://github.com/VOICEVOX/open_jtalk-rs.git", rev="c77112b470874a6a963426ed6c2fb21f12394a78" }
+open_jtalk = { git = "https://github.com/VOICEVOX/open_jtalk-rs.git", rev="9edab53f0bfa877dbb37224d17fd0f3efbe32abd" }
 regex = "1.6.0"
 
 [dev-dependencies]


### PR DESCRIPTION
## 内容
Linux arm64用のビルドを作成します．

変更点
* 依存モジュールを更新
* CI設定を変更
* ```aarch64-unknown-linux-gnu```用にリンカ設定を追加

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他
[手元のCI](https://github.com/haru3me/voicevox_core/actions)ではビルドが通りました．

よろしくお願いします．