### PR TITLE
null pointerの`open_jtalk_dict_dir`を`None`と解釈する

### DIFF
--- a/crates/voicevox_core_c_api/src/helpers.rs
+++ b/crates/voicevox_core_c_api/src/helpers.rs
@@ -197,12 +197,14 @@ impl Default for VoicevoxInitializeOptions {
 
 impl VoicevoxInitializeOptions {
     pub(crate) unsafe fn try_into_options(self) -> CApiResult<voicevox_core::InitializeOptions> {
-        let open_jtalk_dict_dir = ensure_utf8(CStr::from_ptr(self.open_jtalk_dict_dir))?;
+        let open_jtalk_dict_dir = (!self.open_jtalk_dict_dir.is_null())
+            .then(|| ensure_utf8(CStr::from_ptr(self.open_jtalk_dict_dir)).map(Into::into))
+            .transpose()?;
         Ok(voicevox_core::InitializeOptions {
             acceleration_mode: self.acceleration_mode.into(),
             cpu_num_threads: self.cpu_num_threads,
             load_all_models: self.load_all_models,
-            open_jtalk_dict_dir: Some(PathBuf::from(open_jtalk_dict_dir)),
+            open_jtalk_dict_dir,
         })
     }
 }

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -7,7 +7,6 @@ use once_cell::sync::Lazy;
 use std::ffi::{CStr, CString};
 use std::io;
 use std::os::raw::c_char;
-use std::path::PathBuf;
 use std::ptr::null;
 use std::sync::{Mutex, MutexGuard};
 use tracing_subscriber::EnvFilter;


### PR DESCRIPTION
## 内容

C APIにnull pointerの`open_jtalk_dict_dir`が与えられたとき、それをRustの`None::<PathBuf>`に変換します。

現在新C APIの`voicevox_initialize`を実行するとき、`VoicevoxInitializeOptions`がデフォルトのままだとnull pointer accessが起きます。
#217 のときからずっとこうだったようです。

<details>
<summary>再現コード</summary>

```rust
#!/usr/bin/env rust-script
//! ```cargo
//! [dependencies]
//! clap = { version = "4.0.32", features = ["derive"] }
//! duplicate = "0.4.1"
//! eyre = "0.6.8"
//! libloading = "0.7.4"
//! ```

use std::{ffi::c_char, path::PathBuf};

use clap::Parser as _;
use duplicate::duplicate;
use libloading::Library;

#[derive(clap::Parser)]
struct Args {
    dll: PathBuf,
}

fn main() -> eyre::Result<()> {
    let Args { dll } = Args::parse();

    unsafe {
        let dll = Library::new(dll)?;

        duplicate! {
            [
                symbol_name                                  T;
                [ voicevox_make_default_initialize_options ] [ unsafe extern "C" fn() -> VoicevoxInitializeOptions                   ];
                [ voicevox_initialize                      ] [ unsafe extern "C" fn(VoicevoxInitializeOptions) -> VoicevoxResultCode ];
            ]
            let symbol_name = dll.get::<T>(stringify!(symbol_name).as_ref())?;
        }

        voicevox_initialize(voicevox_make_default_initialize_options());
        Ok(())
    }
}

#[repr(C)]
struct VoicevoxInitializeOptions {
    acceleration_mode: VoicevoxAccelerationMode,
    cpu_num_threads: u16,
    load_all_models: bool,
    open_jtalk_dict_dir: *const c_char,
}

type VoicevoxAccelerationMode = i32;
type VoicevoxResultCode = i32;
```

</details>

```console
❯ cargo run -q -- ./libvoicevox_core.so
zsh: segmentation fault (core dumped)  cargo run -q -- ./libvoicevox_core.so
```

## 関連 Issue

#217

## その他

SHAREVOX#10 をやっているときに気付きました。