### PR TITLE
Windows上ではGPUの情報を出すようにする

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,6 +1157,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "humansize"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e682e2bd70ecbcce5209f11a992a4ba001fea8e60acf7860ce007629e6d2756"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1292,6 +1301,12 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "libnghttp2-sys"
@@ -2761,6 +2776,7 @@ dependencies = [
  "derive-new",
  "flate2",
  "heck",
+ "humansize",
  "once_cell",
  "onnxruntime",
  "open_jtalk",
@@ -2772,6 +2788,8 @@ dependencies = [
  "surf",
  "tar",
  "thiserror",
+ "tracing",
+ "windows",
 ]
 
 [[package]]
@@ -2969,17 +2987,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04662ed0e3e5630dfa9b26e4cb823b817f1a9addda855d973a9458c236556244"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2988,10 +3027,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3000,16 +3051,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "xattr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ once_cell = "1.15.0"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.85"
 thiserror = "1.0.37"
+tracing = { version = "0.1.37", features = ["log"] }
 voicevox_core = { path = "crates/voicevox_core" }
 
 # min-sized-rustを元にrelease buildのサイズが小さくなるようにした

--- a/crates/voicevox_core/Cargo.toml
+++ b/crates/voicevox_core/Cargo.toml
@@ -30,3 +30,8 @@ surf = "2.3.2"
 flate2 = "1.0.24"
 tar = "0.4.38"
 heck = "0.4.0"
+
+[target."cfg(windows)".dependencies]
+humansize = "2.1.2"
+tracing.workspace = true
+windows = { version = "0.43.0", features = ["Win32_Foundation", "Win32_Graphics_Dxgi"] }

--- a/crates/voicevox_core/src/publish.rs
+++ b/crates/voicevox_core/src/publish.rs
@@ -620,7 +620,7 @@ fn list_windows_video_cards() {
         CreateDXGIFactory, IDXGIFactory, DXGI_ADAPTER_DESC, DXGI_ERROR_NOT_FOUND,
     };
 
-    info!("Video cards:");
+    info!("利用可能なGPU (DirectMLには1番目のGPUが使われます):");
     match list_windows_video_cards() {
         Ok(descs) => {
             for desc in descs {

--- a/crates/voicevox_core/src/publish.rs
+++ b/crates/voicevox_core/src/publish.rs
@@ -620,7 +620,7 @@ fn list_windows_video_cards() {
         CreateDXGIFactory, IDXGIFactory, DXGI_ADAPTER_DESC, DXGI_ERROR_NOT_FOUND,
     };
 
-    info!("利用可能なGPU (DirectMLには1番目のGPUが使われます):");
+    info!("検出されたGPU (DirectMLには1番目のGPUが使われます):");
     match list_windows_video_cards() {
         Ok(descs) => {
             for desc in descs {

--- a/crates/voicevox_core_python_api/Cargo.toml
+++ b/crates/voicevox_core_python_api/Cargo.toml
@@ -22,5 +22,5 @@ pyo3 = { version = "0.17.2", features = ["abi3-py38", "extension-module"] }
 pyo3-log = "0.7.0"
 serde.workspace = true
 serde_json.workspace = true
-tracing = { version = "0.1.37", features = ["log"] }
+tracing.workspace = true
 voicevox_core.workspace = true


### PR DESCRIPTION
## 内容

Windows上でのみ、GPUの情報を`INFO`のレベルで流すようにします。

```console
> cargo run -q -- .\voicevox_core.dll
[src\main.rs:28] NvOptimusEnablement = 0
2022-12-30T19:45:58.937549Z  INFO voicevox_core::publish: 利用可能なGPU (DirectMLには1番目のGPUが使われます):
2022-12-30T19:45:58.945828Z  INFO voicevox_core::publish:   - "AMD Radeon(TM) Graphics" (495.77 MiB)
2022-12-30T19:45:58.945901Z  INFO voicevox_core::publish:   - "NVIDIA GeForce RTX 3070 Laptop GPU" (7.86 GiB)
2022-12-30T19:45:58.945940Z  INFO voicevox_core::publish:   - "Microsoft Basic Render Driver" (0 B)
```

```console
> cargo run -q --features optimus-enablement -- .\voicevox_core.dll
[src\main.rs:28] NvOptimusEnablement = 1
2022-12-30T19:46:16.355579Z  INFO voicevox_core::publish: 利用可能なGPU (DirectMLには1番目のGPUが使われます):
2022-12-30T19:46:16.363935Z  INFO voicevox_core::publish:   - "NVIDIA GeForce RTX 3070 Laptop GPU" (7.86 GiB)
2022-12-30T19:46:16.364008Z  INFO voicevox_core::publish:   - "AMD Radeon(TM) Graphics" (495.77 MiB)
2022-12-30T19:46:16.364047Z  INFO voicevox_core::publish:   - "Microsoft Basic Render Driver" (0 B)
```

<details>
<summary>コード</summary>

```rust
use std::{ffi::c_char, path::PathBuf};

use clap::Parser as _;
use duplicate::duplicate;
use libloading::Library;
use winapi::shared::minwindef::DWORD;

#[derive(clap::Parser)]
struct Args {
    dll: PathBuf,
}

fn main() -> eyre::Result<()> {
    let Args { dll } = Args::parse();

    unsafe {
        let dll = Library::new(dll)?;

        duplicate! {
            [
                symbol_name                                  T;
                [ voicevox_make_default_initialize_options ] [ unsafe extern "C" fn() -> VoicevoxInitializeOptions                   ];
                [ voicevox_initialize                      ] [ unsafe extern "C" fn(VoicevoxInitializeOptions) -> VoicevoxResultCode ];
            ]
            let symbol_name = dll.get::<T>(stringify!(symbol_name).as_ref())?;
        }

        dbg!(NvOptimusEnablement);
        voicevox_initialize(voicevox_make_default_initialize_options());
        Ok(())
    }
}

#[repr(C)]
struct VoicevoxInitializeOptions {
    acceleration_mode: VoicevoxAccelerationMode,
    cpu_num_threads: u16,
    load_all_models: bool,
    open_jtalk_dict_dir: *const c_char,
}

type VoicevoxAccelerationMode = i32;
type VoicevoxResultCode = i32;

#[allow(non_upper_case_globals)]
#[no_mangle]
pub static NvOptimusEnablement: DWORD = cfg!(feature = "optimus-enablement") as _;
```

```rust
// build.rs

fn main() {
    println!("cargo:rustc-link-arg=/EXPORT:NvOptimusEnablement");
}
```

```toml
[features]
optimus-enablement = []

[dependencies]
clap = { version = "4.0.32", features = ["derive"] }
duplicate = "0.4.1"
eyre = "0.6.8"
libloading = "0.7.4"
winapi = "0.3.9"
```

</details>


(追記) メッセージを変更しました。

## 関連 Issue

Resolves #336.

## その他
