### PR TITLE
`voicevox_core::engine`下では偶数丸めで`round`するようにする

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2759,6 +2759,7 @@ dependencies = [
  "cfg-if",
  "derive-getters",
  "derive-new",
+ "easy-ext",
  "flate2",
  "heck",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 
 [workspace.dependencies]
 anyhow = "1.0.65"
+easy-ext = "1.0.1"
 once_cell = "1.15.0"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.85"

--- a/crates/voicevox_core/Cargo.toml
+++ b/crates/voicevox_core/Cargo.toml
@@ -14,6 +14,7 @@ anyhow.workspace = true
 cfg-if = "1.0.0"
 derive-getters = "0.2.0"
 derive-new = "0.5.9"
+easy-ext.workspace = true
 once_cell.workspace = true
 onnxruntime = { git = "https://github.com/VOICEVOX/onnxruntime-rs.git", rev="b27a4f57da23e17274ad43342b7af55f1c1e4094" }
 serde.workspace = true

--- a/crates/voicevox_core/src/engine/synthesis_engine.rs
+++ b/crates/voicevox_core/src/engine/synthesis_engine.rs
@@ -381,7 +381,7 @@ impl SynthesisEngine {
             let mut vowel_indexes_index = 0;
 
             for (i, phoneme_length) in phoneme_length_list.iter().enumerate() {
-                // VOICEVOX ENGINEと挙動を合わせるため、偶数丸めをする
+                // VOICEVOX ENGINEと挙動を合わせるため、四捨五入ではなく偶数丸めをする
                 //
                 // https://github.com/VOICEVOX/voicevox_engine/issues/552
                 let phoneme_length = ((*phoneme_length * RATE).round_ties_even_() / speed_scale)

--- a/crates/voicevox_core/src/engine/synthesis_engine.rs
+++ b/crates/voicevox_core/src/engine/synthesis_engine.rs
@@ -381,6 +381,9 @@ impl SynthesisEngine {
             let mut vowel_indexes_index = 0;
 
             for (i, phoneme_length) in phoneme_length_list.iter().enumerate() {
+                // VOICEVOX ENGINEと挙動を合わせるため、偶数丸めで`usize`に丸める
+                //
+                // https://github.com/VOICEVOX/voicevox_engine/issues/552
                 let phoneme_length = ((*phoneme_length * RATE).round_ties_even_() / speed_scale)
                     .round_ties_even_() as usize;
                 let phoneme_id = phoneme_data_list[i].phoneme_id();

--- a/crates/voicevox_core/src/engine/synthesis_engine.rs
+++ b/crates/voicevox_core/src/engine/synthesis_engine.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use super::full_context_label::Utterance;
 use super::open_jtalk::OpenJtalk;
 use super::*;
+use crate::numerics::F32Ext as _;
 use crate::InferenceCore;
 
 const UNVOICED_MORA_PHONEME_LIST: &[&str] = &["A", "I", "U", "E", "O", "cl", "pau"];
@@ -380,8 +381,8 @@ impl SynthesisEngine {
             let mut vowel_indexes_index = 0;
 
             for (i, phoneme_length) in phoneme_length_list.iter().enumerate() {
-                let phoneme_length =
-                    ((*phoneme_length * RATE).round() / speed_scale).round() as usize;
+                let phoneme_length = ((*phoneme_length * RATE).round_ties_even_() / speed_scale)
+                    .round_ties_even_() as usize;
                 let phoneme_id = phoneme_data_list[i].phoneme_id();
 
                 for _ in 0..phoneme_length {

--- a/crates/voicevox_core/src/engine/synthesis_engine.rs
+++ b/crates/voicevox_core/src/engine/synthesis_engine.rs
@@ -381,7 +381,7 @@ impl SynthesisEngine {
             let mut vowel_indexes_index = 0;
 
             for (i, phoneme_length) in phoneme_length_list.iter().enumerate() {
-                // VOICEVOX ENGINEと挙動を合わせるため、偶数丸めで`usize`に丸める
+                // VOICEVOX ENGINEと挙動を合わせるため、偶数丸めをする
                 //
                 // https://github.com/VOICEVOX/voicevox_engine/issues/552
                 let phoneme_length = ((*phoneme_length * RATE).round_ties_even_() / speed_scale)

--- a/crates/voicevox_core/src/lib.rs
+++ b/crates/voicevox_core/src/lib.rs
@@ -3,6 +3,7 @@
 /// cbindgen:ignore
 mod engine;
 mod error;
+mod numerics;
 mod publish;
 mod result;
 pub mod result_code;

--- a/crates/voicevox_core/src/numerics.rs
+++ b/crates/voicevox_core/src/numerics.rs
@@ -1,0 +1,17 @@
+use easy_ext::ext;
+
+#[ext(F32Ext)]
+pub(crate) impl f32 {
+    /// 偶数丸めを行う。
+    ///
+    /// [`round_ties_even` feature]で追加される予定の`f32::round_ties_even`の代用。
+    ///
+    /// [`round_ties_even` feature]: https://github.com/rust-lang/rust/pull/95317
+    fn round_ties_even_(self) -> f32 {
+        let mut rounded = self.round();
+        if (self - rounded).abs() == 0.5 {
+            rounded = 2. * (self / 2.).round();
+        }
+        rounded
+    }
+}

--- a/crates/voicevox_core_python_api/Cargo.toml
+++ b/crates/voicevox_core_python_api/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib"]
 directml = ["voicevox_core/directml"]
 
 [dependencies]
-easy-ext = "1.0.1"
+easy-ext.workspace = true
 log = "0.4.17"
 numpy = "0.17.2"
 pyo3 = { version = "0.17.2", features = ["abi3-py38", "extension-module"] }


### PR DESCRIPTION
## 内容

`voicevox_core::engine`下で`f32`を[四捨五入](https://doc.rust-lang.org/stable/std/primitive.f32.html#method.round)している箇所を、偶数丸めになるように修正します。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_engine/issues/552
- https://github.com/SHAREVOX/sharevox_core/commit/d647593df8a459a6579f731e89497ea774c157ac

## その他
