### PR TITLE
自動修正が必要なCargo.lockを弾く

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,15 @@ jobs:
           bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
           ./actionlint -color
 
+  validate-cargo-lock:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Rust
+        uses: ./.github/actions/rust-toolchain-from-file
+      - name: Validate Cargo.lock
+        run: cargo metadata --locked --format-version 1 > /dev/null
+
   rust-lint:
     runs-on: windows-latest
     steps:


### PR DESCRIPTION
## 内容

Cargo.lockの内容がCargo.tomlに合っていないとき、CargoはCargo.lockを可能な限り自動で修正します。例えばCargo.tomlのonnxruntime-rsやopen_jtalk-rsのバージョンだけ上げてCargo.lockを更新せずにPRを出したときCIは通るのですが、そのまま`main`にマージされてしまうと、手元で何かするたびにCargo.lockのdiffが発生することになります。

そこでそのような自動修正が必要なCargo.lockに対してエラーを発するようにします。実害は少ないとはいえ結構頻繁に発生しうると思ったので。

## 関連 Issue

## その他
