### PR TITLE
`$RUST_LOG`がセットされていないときのデフォルト設定を用意する

### DIFF
--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -5,10 +5,10 @@ use self::helpers::*;
 use libc::c_void;
 use once_cell::sync::Lazy;
 use std::ffi::{CStr, CString};
-use std::io;
 use std::os::raw::c_char;
 use std::ptr::null;
 use std::sync::{Mutex, MutexGuard};
+use std::{env, io};
 use tracing_subscriber::EnvFilter;
 use voicevox_core::AudioQueryModel;
 use voicevox_core::Result;
@@ -21,7 +21,11 @@ type Internal = VoicevoxCore;
 
 static INTERNAL: Lazy<Mutex<Internal>> = Lazy::new(|| {
     let _ = tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
+        .with_env_filter(if env::var_os(EnvFilter::DEFAULT_ENV).is_some() {
+            EnvFilter::from_default_env()
+        } else {
+            "error,voicevox_core=info,voicevox_core_c_api=info,onnxruntime=info".into()
+        })
         .with_writer(io::stderr)
         .try_init();
 


### PR DESCRIPTION
## 内容

`$RUST_LOG`がセットされていないときに、適切なデフォルト設定を使うようにします。

#338 の時点ではエディタ側で`$RUST_LOG`を設定して運用する方針になると考えていたのですが、それだと面倒だと思いました。

この変更により`$RUST_LOG`は「ロガーのデフォルト設定を上書きする」という役割になります。ログを一切出したくないときは`RUST_LOG=off`とすればよいです (`RUST_LOG=''`だと`RUST_LOG=error`と同じになります)。

## 関連 Issue

## その他
