### PR TITLE
Deno版ダウンローダーを追加

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -197,3 +197,30 @@ jobs:
           files: |-
             scripts/downloads/*
           target_commitish: ${{ github.sha }}
+  deploy_precompiled_downloader:
+    strategy:
+      matrix:
+        include:
+          - os: windows-2019
+            name: download.exe
+          - os: ubuntu-20.04
+            name: download-linux
+          - os: macos-11
+            name: download-macos
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+      - name: Compile download.ts
+        run: deno compile --allow-net --allow-read --allow-write -o ${{ matrix.name }} ./scripts/downloads/download.ts
+      - name: Upload to Release
+        if: env.VERSION != 'DEBUG' && env.SKIP_UPLOADING_RELEASE_ASSET == '0'
+        uses: softprops/action-gh-release@v1
+        with:
+          prerelease: true
+          tag_name: ${{ env.VERSION }}
+          files: ${{ matrix.name }}
+          target_commitish: ${{ github.sha }}

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -215,7 +215,7 @@ jobs:
         with:
           deno-version: v1.x
       - name: Compile download.ts
-        run: deno compile --allow-net --allow-read --allow-write -o ${{ matrix.name }} ./scripts/downloads/download.ts
+        run: deno compile --allow-env --allow-net --allow-read --allow-write -o ${{ matrix.name }} ./scripts/downloads/download.ts
       - name: Upload to Release
         if: env.VERSION != 'DEBUG' && env.SKIP_UPLOADING_RELEASE_ASSET == '0'
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/download_test.yml
+++ b/.github/workflows/download_test.yml
@@ -427,7 +427,7 @@ jobs:
       - name: Execute download command
         run: ${{ matrix.download_command }}
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Get latest version
         if: ${{ env.EXPECTED_VOICEVOX_CORE_VERSION == 'latest' }}
         shell: bash

--- a/.github/workflows/download_test.yml
+++ b/.github/workflows/download_test.yml
@@ -32,7 +32,7 @@ jobs:
               *curand*
           - name: 通常ダウンロード (Deno)
             os: windows-latest
-            download_command: deno run --allow-net --allow-read --allow-write ./scripts/downloads/download.ts
+            download_command: deno run --allow-env --allow-net --allow-read --allow-write ./scripts/downloads/download.ts
             download_dir: voicevox_core
             check_items: |
               core.dll
@@ -66,7 +66,7 @@ jobs:
               *curand*
           - name: CpuArch指定 (Deno)
             os: windows-latest
-            download_command: deno run --allow-net --allow-read --allow-write ./scripts/downloads/download.ts --cpu-arch x86
+            download_command: deno run --allow-env --allow-net --allow-read --allow-write ./scripts/downloads/download.ts --cpu-arch x86
             download_dir: voicevox_core
             check_items: |
               core.dll
@@ -100,7 +100,7 @@ jobs:
               *curand*
           - name: output先指定ダウンロード (Deno)
             os: windows-latest
-            download_command: deno run --allow-net --allow-read --allow-write ./scripts/downloads/download.ts --output other_output
+            download_command: deno run --allow-env --allow-net --allow-read --allow-write ./scripts/downloads/download.ts --output other_output
             download_dir: other_output
             check_items: |
               core.dll
@@ -134,7 +134,7 @@ jobs:
               open_jtalk_dic_utf_8-1.11
           - name: Min option確認 (Deno)
             os: windows-latest
-            download_command: deno run --allow-net --allow-read --allow-write ./scripts/downloads/download.ts --min
+            download_command: deno run --allow-env --allow-net --allow-read --allow-write ./scripts/downloads/download.ts --min
             download_dir: voicevox_core
             check_items: |
               core.dll
@@ -169,7 +169,7 @@ jobs:
               *curand*
           - name: DirectML option確認 (Deno)
             os: windows-latest
-            download_command: deno run --allow-net --allow-read --allow-write ./scripts/downloads/download.ts --accelerator directml
+            download_command: deno run --allow-env --allow-net --allow-read --allow-write ./scripts/downloads/download.ts --accelerator directml
             download_dir: voicevox_core
             check_items: |
               core.dll
@@ -204,7 +204,7 @@ jobs:
               open_jtalk_dic_utf_8-1.11
           - name: DirectMLかつMin option確認 (Deno)
             os: windows-latest
-            download_command: deno run --allow-net --allow-read --allow-write ./scripts/downloads/download.ts --accelerator directml --min
+            download_command: deno run --allow-env --allow-net --allow-read --allow-write ./scripts/downloads/download.ts --accelerator directml --min
             download_dir: voicevox_core
             check_items: |
               core.dll
@@ -242,7 +242,7 @@ jobs:
               *directml*
           - name: cuda option確認 (Deno)
             os: windows-latest
-            download_command: deno run --allow-net --allow-read --allow-write ./scripts/downloads/download.ts --accelerator cuda
+            download_command: deno run --allow-env --allow-net --allow-read --allow-write ./scripts/downloads/download.ts --accelerator cuda
             download_dir: voicevox_core
             check_items: |
               core.dll
@@ -284,7 +284,7 @@ jobs:
               open_jtalk_dic_utf_8-1.11
           - name: cudaかつmin option確認 (Deno)
             os: windows-latest
-            download_command: deno run --allow-net --allow-read --allow-write ./scripts/downloads/download.ts --accelerator cuda --min
+            download_command: deno run --allow-env --allow-net --allow-read --allow-write ./scripts/downloads/download.ts --accelerator cuda --min
             download_dir: voicevox_core
             check_items: |
               core.dll
@@ -426,6 +426,8 @@ jobs:
           deno-version: v1.x
       - name: Execute download command
         run: ${{ matrix.download_command }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
       - name: Get latest version
         if: ${{ env.EXPECTED_VOICEVOX_CORE_VERSION == 'latest' }}
         shell: bash

--- a/.github/workflows/download_test.yml
+++ b/.github/workflows/download_test.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: 通常ダウンロード
+          - name: 通常ダウンロード (PowerShell)
             os: windows-latest
             download_command: ./scripts/downloads/Download.ps1
             download_dir: voicevox_core
@@ -30,7 +30,24 @@ jobs:
               *nvidia*
               *cufft*
               *curand*
-          - name: CpuArch指定
+          - name: 通常ダウンロード (Deno)
+            os: windows-latest
+            download_command: deno run --allow-net --allow-read --allow-write ./scripts/downloads/download.ts
+            download_dir: voicevox_core
+            check_items: |
+              core.dll
+              open_jtalk_dic_utf_8-1.11
+              README.txt
+            check_not_exists_items: |
+              *directml*
+              *cuda*
+              *cudnn*
+              *onnxruntime*providers*
+              *eula*
+              *nvidia*
+              *cufft*
+              *curand*
+          - name: CpuArch指定 (PowerShell)
             os: windows-latest
             download_command: ./scripts/downloads/Download.ps1 -CpuArch x86
             download_dir: voicevox_core
@@ -47,7 +64,24 @@ jobs:
               *nvidia*
               *cufft*
               *curand*
-          - name: output先指定ダウンロード
+          - name: CpuArch指定 (Deno)
+            os: windows-latest
+            download_command: deno run --allow-net --allow-read --allow-write ./scripts/downloads/download.ts --cpu-arch x86
+            download_dir: voicevox_core
+            check_items: |
+              core.dll
+              open_jtalk_dic_utf_8-1.11
+              README.txt
+            check_not_exists_items: |
+              *directml*
+              *cuda*
+              *cudnn*
+              *onnxruntime*providers*
+              *eula*
+              *nvidia*
+              *cufft*
+              *curand*
+          - name: output先指定ダウンロード (PowerShell)
             os: windows-latest
             download_command: ./scripts/downloads/Download.ps1 -Output other_output
             download_dir: other_output
@@ -64,7 +98,24 @@ jobs:
               *nvidia*
               *cufft*
               *curand*
-          - name: Min option確認
+          - name: output先指定ダウンロード (Deno)
+            os: windows-latest
+            download_command: deno run --allow-net --allow-read --allow-write ./scripts/downloads/download.ts --output other_output
+            download_dir: other_output
+            check_items: |
+              core.dll
+              open_jtalk_dic_utf_8-1.11
+              README.txt
+            check_not_exists_items: |
+              *directml*
+              *cuda*
+              *cudnn*
+              *onnxruntime*providers*
+              *eula*
+              *nvidia*
+              *cufft*
+              *curand*
+          - name: Min option確認 (PowerShell)
             os: windows-latest
             download_command: ./scripts/downloads/Download.ps1 -Min $True
             download_dir: voicevox_core
@@ -81,7 +132,24 @@ jobs:
               *cufft*
               *curand*
               open_jtalk_dic_utf_8-1.11
-          - name: DirectML option確認
+          - name: Min option確認 (Deno)
+            os: windows-latest
+            download_command: deno run --allow-net --allow-read --allow-write ./scripts/downloads/download.ts --min
+            download_dir: voicevox_core
+            check_items: |
+              core.dll
+              README.txt
+            check_not_exists_items: |
+              *directml*
+              *cuda*
+              *cudnn*
+              *onnxruntime*providers*
+              *eula*
+              *nvidia*
+              *cufft*
+              *curand*
+              open_jtalk_dic_utf_8-1.11
+          - name: DirectML option確認 (PowerShell)
             os: windows-latest
             download_command: ./scripts/downloads/Download.ps1 -Accelerator directml
             download_dir: voicevox_core
@@ -99,7 +167,25 @@ jobs:
               *nvidia*
               *cufft*
               *curand*
-          - name: DirectMLかつMin option確認
+          - name: DirectML option確認 (Deno)
+            os: windows-latest
+            download_command: deno run --allow-net --allow-read --allow-write ./scripts/downloads/download.ts --accelerator directml
+            download_dir: voicevox_core
+            check_items: |
+              core.dll
+              open_jtalk_dic_utf_8-1.11
+              README.txt
+              DirectML.dll
+              DirectML_LICENSE.txt
+            check_not_exists_items: |
+              *directml*
+              *cuda*
+              *cudnn*
+              *eula*
+              *nvidia*
+              *cufft*
+              *curand*
+          - name: DirectMLかつMin option確認 (PowerShell)
             os: windows-latest
             download_command: ./scripts/downloads/Download.ps1 -Accelerator directml -Min $true
             download_dir: voicevox_core
@@ -116,7 +202,24 @@ jobs:
               Directml.dll
               DirectML_LICENSE.txt
               open_jtalk_dic_utf_8-1.11
-          - name: cuda option確認
+          - name: DirectMLかつMin option確認 (Deno)
+            os: windows-latest
+            download_command: deno run --allow-net --allow-read --allow-write ./scripts/downloads/download.ts --accelerator directml --min
+            download_dir: voicevox_core
+            check_items: |
+              core.dll
+              README.txt
+            check_not_exists_items: |
+              *cuda*
+              *cudnn*
+              *eula*
+              *nvidia*
+              *cufft*
+              *curand*
+              Directml.dll
+              DirectML_LICENSE.txt
+              open_jtalk_dic_utf_8-1.11
+          - name: cuda option確認 (PowerShell)
             os: windows-latest
             download_command: ./scripts/downloads/Download.ps1 -Accelerator cuda
             download_dir: voicevox_core
@@ -137,9 +240,51 @@ jobs:
               curand64_*.dll
             check_not_exists_items: |
               *directml*
-          - name: cudaかつmin option確認
+          - name: cuda option確認 (Deno)
+            os: windows-latest
+            download_command: deno run --allow-net --allow-read --allow-write ./scripts/downloads/download.ts --accelerator cuda
+            download_dir: voicevox_core
+            check_items: |
+              core.dll
+              open_jtalk_dic_utf_8-1.11
+              README.txt
+              EULA.txt
+              NVIDIA_SLA_cuDNN_Support.txt
+              cublas64_*.dll
+              cublasLt64_*.dll
+              cudart64_*.dll
+              cudnn64_*.dll
+              cudnn_adv_infer64_*.dll
+              cudnn_cnn_infer64_*.dll
+              cudnn_ops_infer64_*.dll
+              cufft64_*.dll
+              curand64_*.dll
+            check_not_exists_items: |
+              *directml*
+          - name: cudaかつmin option確認 (PowerShell)
             os: windows-latest
             download_command: ./scripts/downloads/Download.ps1 -Accelerator cuda -Min $true
+            download_dir: voicevox_core
+            check_items: |
+              core.dll
+              README.txt
+            check_not_exists_items: |
+              *directml*
+              EULA.txt
+              NVIDIA_SLA_cuDNN_Support.txt
+              cublas64_*.dll
+              cublasLt64_*.dll
+              cudart64_*.dll
+              cudnn64_*.dll
+              cudnn_adv_infer64_*.dll
+              cudnn_cnn_infer64_*.dll
+              cudnn_ops_infer64_*.dll
+              cufft64_*.dll
+              curand64_*.dll
+              open_jtalk_dic_utf_8-1.11
+          - name: cudaかつmin option確認 (Deno)
+            os: windows-latest
+            download_command: deno run --allow-net --allow-read --allow-write ./scripts/downloads/download.ts --accelerator cuda --min
             download_dir: voicevox_core
             check_items: |
               core.dll
@@ -274,6 +419,11 @@ jobs:
       #EXPECTED_VOICEVOX_CORE_VERSION: ${{ matrix.expected_version || 'latest' }}
     steps:
       - uses: actions/checkout@v3
+      - name: Set up Deno
+        if: ${{ startsWith(matrix.download_command, 'deno ') }}
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
       - name: Execute download command
         run: ${{ matrix.download_command }}
       - name: Get latest version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,19 @@ jobs:
       - name: ShellCheck
         run: git ls-files | grep -E '\.(ba)?sh' | xargs shellcheck
 
+  deno-lint:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+      - name: deno-fmt
+        run: git ls-files | grep '\.ts$' | xargs deno fmt --check
+      - name: deno-lint
+        run: git ls-files | grep '\.ts$' | xargs deno lint
+
   actionlint:
     runs-on: ubuntu-22.04
     steps:

--- a/scripts/downloads/download.ts
+++ b/scripts/downloads/download.ts
@@ -1,0 +1,249 @@
+#!/usr/bin/env -S deno run --allow-net --allow-read --allow-write
+
+import {
+  Command,
+  EnumType,
+} from "https://deno.land/x/cliffy@v0.25.7/command/mod.ts";
+import { tgz } from "https://deno.land/x/compress@v0.4.5/mod.ts";
+import { Octokit } from "https://cdn.skypack.dev/@octokit/rest?dts";
+import { basename, join } from "https://deno.land/std@0.171.0/path/mod.ts";
+import { arch } from "https://deno.land/std@0.170.0/node/process.ts";
+import {
+  Uint8ArrayReader,
+  Uint8ArrayWriter,
+  ZipReader,
+} from "https://deno.land/x/zipjs@v2.6.61/index.js";
+
+const DEFAULT_OUTPUT = "./voicevox_core";
+
+const ORGANIZATION_NAME = "VOICEVOX";
+
+const CORE_DISPLAY_NAME = "voicevox_core";
+const CORE_REPO_NAME = "voicevox_core";
+
+const ADDITIONAL_LIBRARIES_DISPLAY_NAME = "voicevox_additional_libraries";
+const ADDITIONAL_LIBRARIES_REPO_NAME = "voicevox_additional_libraries";
+
+const OPEN_JTALK_DIC_DISPLAY_NAME = "open_jtalk_dic";
+const OPEN_JTALK_DIC_URL = new URL(
+  "https://jaist.dl.sourceforge.net/project/open-jtalk/Dictionary/open_jtalk_dic-1.11/open_jtalk_dic_utf_8-1.11.tar.gz",
+);
+
+async function main(): Promise<void> {
+  // CliffyはASCII文字のことしか考えていないらしく、全角文字を入れると
+  // helpの表示が崩れる
+  const { options } = await new Command()
+    .name("download")
+    .description(`Download ${CORE_DISPLAY_NAME} and other libraries.`)
+    .type("accelerator", new EnumType(["cpu", "cuda", "directml"]))
+    .type("cpu-arch", new EnumType(["x64", "aarch64"]))
+    .type("os", new EnumType(["windows", "linux", "osx"]))
+    .option("--min", `Only Download ${CORE_DISPLAY_NAME}.`)
+    .option("-o, --output <output>", "Output to the directory.", {
+      default: DEFAULT_OUTPUT,
+    })
+    .option(
+      "-v, --version <tag-or-latest>",
+      `Version of ${CORE_DISPLAY_NAME}.`,
+      { default: "latest" },
+    )
+    .option(
+      "--additional-libraries-version <tag-or-latest>",
+      "Version of the additional libraries.",
+      { default: "latest" },
+    )
+    .option(
+      "--accelerator <accelerator:accelerator>",
+      "Accelerator. (cuda is only available on Linux)",
+      { default: "cpu" },
+    )
+    .option(
+      "--cpu-arch <cpu-arch:cpu-arch>",
+      "CPU Architecture. Defaults to the current one.",
+      { default: defaultArch() },
+    )
+    .option(
+      "--os <os:os>",
+      "OS. Defaults to the current one.",
+      { default: defaultOS() },
+    )
+    .parse(Deno.args);
+
+  if (!options.cpuArch) {
+    throw new Error(`${arch}はサポートされていない環境です`);
+  }
+
+  const { output, version, additionalLibrariesVersion } = options;
+  const min = !!options.min;
+  const accelerator = options.accelerator as "cpu" | "cuda" | "directml";
+  const cpuArch = options.cpuArch as "x64" | "aarch64";
+  const os = options.os as "windows" | "linux" | "osx";
+
+  const octokit = new Octokit();
+
+  const coreAsset = await findRelease(
+    octokit,
+    CORE_REPO_NAME,
+    version,
+    (tag) => {
+      const cpuArchRename = os == "linux" && cpuArch == "aarch64"
+        ? "arm64"
+        : cpuArch;
+      const acceleratorRename = os == "linux" && accelerator == "cuda"
+        ? "gpu"
+        : accelerator;
+      return `${CORE_DISPLAY_NAME}-${os}-${cpuArchRename}-` +
+        `${acceleratorRename}-${tag}.zip`;
+    },
+  );
+
+  const additionalLibrariesAsset = accelerator == "cpu"
+    ? undefined
+    : await findRelease(
+      octokit,
+      ADDITIONAL_LIBRARIES_REPO_NAME,
+      additionalLibrariesVersion,
+      (_) => {
+        const acceleratorRename = accelerator == "cuda" ? "CUDA" : "DirectML";
+        return `${acceleratorRename}-${os}-${cpuArch}.zip`;
+      },
+    );
+
+  info(`対象OS: ${os}`);
+  info(`対象CPUアーキテクチャ: ${cpuArch}`);
+  info(`ダウンロードアーティファクトタイプ: ${accelerator}`);
+  info(`ダウンロード${CORE_DISPLAY_NAME}バージョン: ${coreAsset.releaseTag}`);
+  if (additionalLibrariesAsset) {
+    info(
+      `ダウンロード追加ライブラリバージョン: ` +
+        `${additionalLibrariesAsset.releaseTag}`,
+    );
+  }
+
+  const promises = [
+    download(CORE_DISPLAY_NAME, coreAsset.url, "unzip-j", output),
+  ];
+
+  if (!min) {
+    promises.push(
+      download(
+        OPEN_JTALK_DIC_DISPLAY_NAME,
+        OPEN_JTALK_DIC_URL,
+        "tar-x",
+        output,
+      ),
+    );
+
+    if (additionalLibrariesAsset) {
+      promises.push(download(
+        ADDITIONAL_LIBRARIES_DISPLAY_NAME,
+        additionalLibrariesAsset.url,
+        "unzip-j",
+        output,
+      ));
+    }
+  }
+
+  await Promise.all(promises);
+
+  success("全ての必要なファイルダウンロードが完了しました");
+}
+
+function defaultArch(): "x64" | "aarch64" | undefined {
+  return arch == "x64" ? "x64" : arch == "arm64" ? "aarch64" : undefined;
+}
+
+function defaultOS(): "windows" | "linux" | "osx" {
+  if (Deno.build.os == "darwin") {
+    return "osx";
+  }
+  return Deno.build.os;
+}
+
+async function findRelease(
+  octokit: Octokit,
+  repo: string,
+  tagOrLatest: string,
+  assetName: (tag: string) => string,
+): Promise<{ releaseTag: string; url: URL }> {
+  // FIXME: どうにかして型付けできないか?
+  const endpoint = tagOrLatest == "latest"
+    ? `GET /repos/${ORGANIZATION_NAME}/${repo}/releases/latest`
+    : `GET /repos/${ORGANIZATION_NAME}/${repo}/releases/tags/${tagOrLatest}`;
+  const { data: { html_url, tag_name, assets } } = await octokit.request(
+    endpoint,
+  );
+  const targetAssetName = assetName(tag_name);
+  const asset = assets.find((a: { name: string }) => a.name == targetAssetName);
+  if (!asset) {
+    throw new Error(`Could not find ${targetAssetName} in ${html_url}`);
+  }
+  return { releaseTag: tag_name, url: new URL(asset.url) };
+}
+
+async function download(
+  displayName: string,
+  url: URL,
+  extractionMethod: "unzip-j" | "tar-x",
+  output: string,
+): Promise<void> {
+  status(`${displayName}をダウンロード`);
+
+  const res = await fetch(url, {
+    headers: { "Accept": "application/octet-stream" },
+  });
+  if (res.status != 200) throw new Error(`Got ${res.status}: ${url}`);
+  const archiveData = new Uint8Array(await res.arrayBuffer());
+
+  status(`${displayName}をダウンロード: 解凍中`);
+
+  if (extractionMethod == "unzip-j") {
+    await extractZIPWithJunkPaths(archiveData, output);
+  } else {
+    await extractTGZ(archiveData, output);
+  }
+
+  success(`${displayName}をダウンロード: 完了`);
+}
+
+async function extractZIPWithJunkPaths(
+  archiveData: Uint8Array,
+  output: string,
+): Promise<void> {
+  const zip = new ZipReader(new Uint8ArrayReader(archiveData));
+  const entries = await zip.getEntries();
+
+  await Deno.mkdir(output, { recursive: true });
+
+  for (const entry of entries) {
+    if (entry.directory) continue;
+    const path = join(output, basename(entry.filename));
+    const content = await entry.getData(new Uint8ArrayWriter());
+    await Deno.writeFile(path, content);
+  }
+}
+
+async function extractTGZ(
+  archiveData: Uint8Array,
+  output: string,
+): Promise<void> {
+  const tempdir = await Deno.makeTempDir({ prefix: "download-" });
+  const src = join(tempdir, "asset.tar.gz");
+  await Deno.writeFile(src, archiveData);
+  await tgz.uncompress(src, output);
+}
+
+function info(msg: string): void {
+  console.error(`[%c*%c] %s`, "color: blue; font-weight: bold", "", msg);
+}
+
+function status(msg: string): void {
+  console.error(`[%cx%c] %s`, "color: purple", "", msg);
+}
+
+function success(msg: string): void {
+  console.error(`[%c+%c] %s`, "color: green; font-weight: bold", "", msg);
+}
+
+await main();
+Deno.exit(0); // https://github.com/octokit/octokit.js/issues/2079

--- a/scripts/downloads/download.ts
+++ b/scripts/downloads/download.ts
@@ -232,11 +232,15 @@ async function extractZIP(
 
   for (const entry of entries) {
     if (entry.directory) continue;
-    const path = join(output, stripFirstDir(entry.filename));
+    const path = join(output, stripFirstDir(fixZipEntryPath(entry.filename)));
     const content = await entry.getData(new Uint8ArrayWriter());
     await Deno.mkdir(dirname(path), { recursive: true });
     await Deno.writeFile(path, content);
   }
+}
+
+function fixZipEntryPath(possiblyIllegalZipEntryPath: string): string {
+  return possiblyIllegalZipEntryPath.replaceAll("\\", "/");
 }
 
 function stripFirstDir(posixPath: string): string {

--- a/scripts/downloads/download.ts
+++ b/scripts/downloads/download.ts
@@ -36,7 +36,7 @@ async function main(): Promise<void> {
     .name("download")
     .description(`Download ${CORE_DISPLAY_NAME} and other libraries.`)
     .type("accelerator", new EnumType(["cpu", "cuda", "directml"]))
-    .type("cpu-arch", new EnumType(["x64", "aarch64"]))
+    .type("cpu-arch", new EnumType(["x86", "x64", "aarch64"]))
     .type("os", new EnumType(["windows", "linux", "osx"]))
     .option("--min", `Only Download ${CORE_DISPLAY_NAME}.`)
     .option(
@@ -78,7 +78,7 @@ async function main(): Promise<void> {
   const { output, version, additionalLibrariesVersion } = options;
   const min = !!options.min;
   const accelerator = options.accelerator as "cpu" | "cuda" | "directml";
-  const cpuArch = options.cpuArch as "x64" | "aarch64";
+  const cpuArch = options.cpuArch as "x86" | "x64" | "aarch64";
   const os = options.os as "windows" | "linux" | "osx";
 
   const octokit = new Octokit();
@@ -156,8 +156,10 @@ async function main(): Promise<void> {
   success("全ての必要なファイルダウンロードが完了しました");
 }
 
-function defaultArch(): "x64" | "aarch64" | undefined {
+function defaultArch(): "x86" | "x64" | "aarch64" | undefined {
   switch (arch) {
+    case "x32":
+      return "x86";
     case "x64":
       return "x64";
     case "arm64":

--- a/scripts/downloads/download.ts
+++ b/scripts/downloads/download.ts
@@ -62,7 +62,7 @@ async function main(): Promise<void> {
     .option(
       "--cpu-arch <cpu-arch:cpu-arch>",
       "CPU Architecture. Defaults to the current one.",
-      { default: defaultArch() },
+      { default: defaultCPUArch() },
     )
     .option(
       "--os <os:os>",
@@ -154,7 +154,7 @@ async function main(): Promise<void> {
   success("全ての必要なファイルダウンロードが完了しました");
 }
 
-function defaultArch(): "x86" | "x64" | "aarch64" | undefined {
+function defaultCPUArch(): "x86" | "x64" | "aarch64" | undefined {
   switch (process.arch) {
     case "x32":
       return "x86";
@@ -198,7 +198,7 @@ async function findGHAsset(
 async function downloadAndExtract(
   displayName: string,
   target:
-    | { octokit: Octokit; repo: string; tag: string; assetID: number }
+    | { octokit: Octokit; repo: string; assetID: number }
     | URL,
   extraction:
     | { format: "zip"; stripFirstDir: true }

--- a/scripts/downloads/download.ts
+++ b/scripts/downloads/download.ts
@@ -225,12 +225,12 @@ async function downloadAndExtract(
 async function downloadArchiveFromGH(
   target: { octokit: Octokit; repo: string; assetID: number },
 ): Promise<ArrayBuffer> {
-  return await target.octokit.rest.repos.getReleaseAsset({
+  return (await target.octokit.rest.repos.getReleaseAsset({
     owner: ORGANIZATION_NAME,
     repo: target.repo,
     asset_id: target.assetID,
     headers: { "Accept": "application/octet-stream" },
-  });
+  })).data;
 }
 
 async function downloadArchiveFromURL(target: URL): Promise<ArrayBuffer> {

--- a/scripts/downloads/download.ts
+++ b/scripts/downloads/download.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run --allow-net --allow-read --allow-write
+#!/usr/bin/env -S deno run --allow-env --allow-net --allow-read --allow-write
 
 import {
   Command,
@@ -7,7 +7,7 @@ import {
 import { tgz } from "https://deno.land/x/compress@v0.4.5/mod.ts";
 import { Octokit } from "https://cdn.skypack.dev/@octokit/rest?dts";
 import { dirname, join } from "https://deno.land/std@0.171.0/path/mod.ts";
-import { arch } from "https://deno.land/std@0.170.0/node/process.ts";
+import { arch, env } from "https://deno.land/std@0.170.0/node/process.ts";
 import {
   Uint8ArrayReader,
   Uint8ArrayWriter,
@@ -81,7 +81,7 @@ async function main(): Promise<void> {
   const cpuArch = options.cpuArch as "x86" | "x64" | "aarch64";
   const os = options.os as "windows" | "linux" | "osx";
 
-  const octokit = new Octokit();
+  const octokit = new Octokit({ auth: env["GITHUB_TOKEN"] });
 
   const coreAsset = await findGHAsset(
     octokit,

--- a/scripts/downloads/download.ts
+++ b/scripts/downloads/download.ts
@@ -6,7 +6,7 @@ import {
 } from "https://deno.land/x/cliffy@v0.25.7/command/mod.ts";
 import { tgz } from "https://deno.land/x/compress@v0.4.5/mod.ts";
 import { Octokit } from "https://cdn.skypack.dev/@octokit/rest?dts";
-import { basename, join } from "https://deno.land/std@0.171.0/path/mod.ts";
+import { dirname, join } from "https://deno.land/std@0.171.0/path/mod.ts";
 import { arch } from "https://deno.land/std@0.170.0/node/process.ts";
 import {
   Uint8ArrayReader,
@@ -228,12 +228,11 @@ async function extractZIP(
   const zip = new ZipReader(new Uint8ArrayReader(archiveData));
   const entries = await zip.getEntries();
 
-  await Deno.mkdir(output, { recursive: true });
-
   for (const entry of entries) {
     if (entry.directory) continue;
     const path = join(output, stripFirstDir(entry.filename));
     const content = await entry.getData(new Uint8ArrayWriter());
+    await Deno.mkdir(dirname(path), { recursive: true });
     await Deno.writeFile(path, content);
   }
 }

--- a/scripts/downloads/download.ts
+++ b/scripts/downloads/download.ts
@@ -39,9 +39,11 @@ async function main(): Promise<void> {
     .type("cpu-arch", new EnumType(["x64", "aarch64"]))
     .type("os", new EnumType(["windows", "linux", "osx"]))
     .option("--min", `Only Download ${CORE_DISPLAY_NAME}.`)
-    .option("-o, --output <output>", "Output to the directory.", {
-      default: DEFAULT_OUTPUT,
-    })
+    .option(
+      "-o, --output <output>",
+      "Output to the directory.",
+      { default: DEFAULT_OUTPUT },
+    )
     .option(
       "-v, --version <tag-or-latest>",
       `Version of ${CORE_DISPLAY_NAME}.`,
@@ -125,14 +127,12 @@ async function main(): Promise<void> {
   ];
 
   if (!min) {
-    promises.push(
-      download(
-        OPEN_JTALK_DIC_DISPLAY_NAME,
-        OPEN_JTALK_DIC_URL,
-        "tar-x",
-        output,
-      ),
-    );
+    promises.push(download(
+      OPEN_JTALK_DIC_DISPLAY_NAME,
+      OPEN_JTALK_DIC_URL,
+      "tar-x",
+      output,
+    ));
 
     if (additionalLibrariesAsset) {
       promises.push(download(
@@ -150,7 +150,14 @@ async function main(): Promise<void> {
 }
 
 function defaultArch(): "x64" | "aarch64" | undefined {
-  return arch == "x64" ? "x64" : arch == "arm64" ? "aarch64" : undefined;
+  switch (arch) {
+    case "x64":
+      return "x64";
+    case "arm64":
+      return "aarch64";
+    default:
+      return undefined;
+  }
 }
 
 function defaultOS(): "windows" | "linux" | "osx" {

--- a/scripts/downloads/download.ts
+++ b/scripts/downloads/download.ts
@@ -251,7 +251,7 @@ async function extractZIP(
     if (entry.directory) continue;
     const dst = path.join(
       output,
-      stripFirstDir(fixZipEntryFilename(entry.filename)),
+      stripFirstDir(fixZIPEntryFilename(entry.filename)),
     );
     const content = await entry.getData(new Uint8ArrayWriter());
     await Deno.mkdir(path.dirname(dst), { recursive: true });
@@ -259,7 +259,7 @@ async function extractZIP(
   }
 }
 
-function fixZipEntryFilename(possiblyIllegalFilename: string): string {
+function fixZIPEntryFilename(possiblyIllegalFilename: string): string {
   return possiblyIllegalFilename.replaceAll("\\", "/");
 }
 

--- a/scripts/downloads/download.ts
+++ b/scripts/downloads/download.ts
@@ -81,7 +81,7 @@ async function main(): Promise<void> {
   const cpuArch = options.cpuArch as "x86" | "x64" | "aarch64";
   const os = options.os as "windows" | "linux" | "osx";
 
-  const octokit = new Octokit({ auth: process.env["GITHUB_TOKEN"] });
+  const octokit = new Octokit({ auth: Deno.env.get("GITHUB_TOKEN") });
 
   const coreAsset = await findGHAsset(
     octokit,


### PR DESCRIPTION
## 内容

TypeScriptの練習がてら、Deno版のダウンローダーを書いてみたのでここにぶら下げておきます。

PowerShell版のダウンローダーのメンテが厳しいのではないかという話がDiscordであったと思うのですが、Deno版ダウンローダーはそれに対する解決策の一つになると思います。利点としては次の4点でしょうか。

1. コマンド一発でEXEにコンパイルして配布できる
2. 言語自体はTypeScriptなので読み書きできる人が多そう
3. (Bashと比べて) エラーのときにちゃんとメッセージを出して停止することが保証しやすい
4. (主にBashと比べて) 単一ファイルのまま外部ライブラリを気軽に導入できる
    - 標準ライブラリに何でも入っているPythonやPowerShell (Core)はともかく、Bashだと例えばjqを気軽に要求できないためにJSONを扱えなかったりします。

## 関連 Issue

## その他

![image](https://user-images.githubusercontent.com/14125495/211035781-3b3df787-1187-43cd-802f-b92ad2f561a5.png)

![image](https://user-images.githubusercontent.com/14125495/211049145-49c27fb1-725c-485e-8740-a61979b5da9e.png)

```console
❯ tree ./voicevox_core
./voicevox_core
├── EULA.txt
├── libcublasLt.so.11
├── libcublas.so.11
├── libcudnn_adv_infer.so.8
├── libcudnn_cnn_infer.so.8
├── libcudnn_ops_infer.so.8
├── libcudnn.so.8
├── libcufft.so.10
├── libcurand.so.10
├── libonnxruntime_providers_cuda.so
├── libonnxruntime_providers_shared.so
├── libonnxruntime_providers_tensorrt.so
├── libonnxruntime.so.1.11.1
├── libvoicevox_core.so
├── NVIDIA_SLA_cuDNN_Support.txt
├── open_jtalk_dic_utf_8-1.11
│   ├── char.bin
│   ├── COPYING
│   ├── left-id.def
│   ├── matrix.bin
│   ├── pos-id.def
│   ├── rewrite.def
│   ├── right-id.def
│   ├── sys.dic
│   └── unk.dic
├── README.txt
├── VERSION
└── voicevox_core.h

2 directories, 27 files
```