### PR TITLE
bashで-vの使い方を間違えていたので修正

### DIFF
--- a/build_util/codesign.bash
+++ b/build_util/codesign.bash
@@ -3,11 +3,11 @@
 
 set -eu
 
-if [ -v "${CERT_BASE64}" ]; then
+if [ ! -v CERT_BASE64 ]; then
     echo "CERT_BASE64が未定義です"
     exit 1
 fi
-if [ -v "${CERT_PASSWORD}" ]; then
+if [ ! -v CERT_PASSWORD ]; then
     echo "CERT_PASSWORDが未定義です"
     exit 1
 fi


### PR DESCRIPTION
## 内容

`-v`は後ろで指定した変数名の変数が定義されているかどうか判別するもので、「`-v "${CERT_BASE64}"`は`$CERT_BASE64`の中身の値と同じ名前の変数名が定義されてるか」という意味になっていました。

上の`set -e`で「未定義の変数を使ったときはエラー」になっていたので、偶然止まっている感じでした。
