### PR TITLE
7zコマンドが間違っていたので修正

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -158,14 +158,9 @@ jobs:
           CERT_PASSWORD: ${{ secrets.CERT_PASSWORD }}
       - name: Archive artifact
         shell: bash
-        if: (!contains(matrix.os , 'windows'))
         run: |
           cd artifact
-          zip -r "../${{ env.ASSET_NAME }}.zip" "${{ env.ASSET_NAME }}"
-      - name: Archive artifact (Windows)
-        if: contains(matrix.os, 'windows')
-        run: |
-          7z a "${{ env.ASSET_NAME }}.zip" "artifact/${{ env.ASSET_NAME }}"
+          7z a "../${{ env.ASSET_NAME }}.zip" "${{ env.ASSET_NAME }}"
       - name: Upload to Release
         if: env.VERSION != 'DEBUG' && env.SKIP_UPLOADING_RELEASE_ASSET == '0'
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## 内容

このままだとartifactディレクトリがrootになってしまうので修正。
ついでに7zコマンドはたしか全OSで使えるはずなので統一してみました。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_core/pull/372

## その他
