### PR TITLE
Add: 事例紹介にvoicevox.rbを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ cargo test
 ## 事例紹介
 
 **[voicevox.rb](https://github.com/sevenc-nanashi/voicevox.rb) [@sevenc-nanashi](https://github.com/sevenc-nanashi)** ･･･ VOICEVOX CORE の Ruby 向け FFI ラッパー  
-**[VOICEVOX ENGINE SHARP](https://github.com/yamachu/VoicevoxEngineSharp) [@yamachu](https://github.com/yamachu)** ･･･ VOICEVOX ENGINE の C# 実装  
 **[Node VOICEVOX Engine](https://github.com/y-chan/node-voicevox-engine) [@y-chan](https://github.com/y-chan)** ･･･ VOICEVOX ENGINE の Node.js/C++ 実装
+**[VOICEVOX ENGINE SHARP](https://github.com/yamachu/VoicevoxEngineSharp) [@yamachu](https://github.com/yamachu)** ･･･ VOICEVOX ENGINE の C# 実装  
 
 ## ライセンス
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ cargo test
 
 ## 事例紹介
 
+**[voicevox.rb](https://github.com/sevenc-nanashi/voicevox.rb) [@sevenc-nanashi](https://github.com/sevenc-nanashi)** ･･･ VOICEVOX CORE の Ruby 向け FFI ラッパー  
 **[VOICEVOX ENGINE SHARP](https://github.com/yamachu/VoicevoxEngineSharp) [@yamachu](https://github.com/yamachu)** ･･･ VOICEVOX ENGINE の C# 実装  
 **[Node VOICEVOX Engine](https://github.com/y-chan/node-voicevox-engine) [@y-chan](https://github.com/y-chan)** ･･･ VOICEVOX ENGINE の Node.js/C++ 実装
 


### PR DESCRIPTION
## 内容

タイトル通り。

## 関連 Issue

（なし）

## その他

サンプルと同じことをするコードを [sevenc-nanashi/voicevox.rb:examples/cli.rb](https://github.com/sevenc-nanashi/voicevox.rb/blob/main/examples/cli.rb) で実装しています。こちらも追記するべきでしょうか？