### PR TITLE
`osx-aarch64-cpu`を`osx-arm64-cpu`に改名する

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -75,7 +75,7 @@ jobs:
           - os: macos-11
             features: ""
             target: aarch64-apple-darwin
-            artifact_name: osx-aarch64-cpu
+            artifact_name: osx-arm64-cpu
             whl_local_version: cpu
             use_cuda: false
           - os: macos-11

--- a/scripts/downloads/download.sh
+++ b/scripts/downloads/download.sh
@@ -76,7 +76,7 @@ target_arch(){
   cpu_arch=$(uname -m)
   case "$cpu_arch" in
     "x86_64") echo "x64";;
-    "arm64") echo "aarch64";;
+    "arm64") echo "arm64";;
     *)
       echo "$cpu_archはサポートされていない環境です" >&2
       exit 1;;


### PR DESCRIPTION
## 内容

`osx-aarch64-cpu`を`osx-arm64-cpu`に改名します。

## 関連 Issue

Fixes #393.

## その他

Node.js的には`windows`も`win32`で`osx`も`darwin`なのでは?と思わなくもないですが、そこまでやる必要は無さそう?やるとしたら今をおいて他にないと思いますが...
