### PR TITLE
github/issue-labelerをv2.5に上げる

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,7 +7,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: github/issue-labeler@v2.0
+    - uses: github/issue-labeler@v2.5
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/labeler.yml


### PR DESCRIPTION
## 内容

- `node12`に関する警告が消える

- `enable-versioned-regex`が意味を成すようになる

    このパラメータは<https://github.com/VOICEVOX/voicevox/pull/584>で指定されるようになりましたが、バージョンがv2.0という当時でも古いバージョンだったため、意味をなさずに次の警告が今に至るまで出続けていました。

    > ```console
    > Warning: Unexpected input(s) 'enable-versioned-regex', valid inputs are ['repo-token', 'configuration-path']
    > ```

今現在エンジンとエディタの方もv2.0になっているので、このPRをマージ後に特に問題が起きなければ同様にPRを出していけばよいかと思います。

## 関連 Issue

-  <https://github.com/VOICEVOX/voicevox_core/pull/394#issuecomment-1405330292>
- <https://github.com/VOICEVOX/voicevox_core/pull/394#issuecomment-1405344666>

## その他
