### PR TITLE
`--accelerator`を`--device`に

### DIFF
--- a/.github/workflows/download_test.yml
+++ b/.github/workflows/download_test.yml
@@ -83,7 +83,7 @@ jobs:
               open_jtalk_dic_utf_8-1.11
           - name: DirectML option確認
             os: windows-latest
-            download_command: cargo run -vv -p download -- --accelerator directml
+            download_command: cargo run -vv -p download -- --device directml
             download_dir: voicevox_core
             check_items: |
               core.dll
@@ -101,7 +101,7 @@ jobs:
               *curand*
           - name: DirectMLかつMin option確認
             os: windows-latest
-            download_command: cargo run -vv -p download -- --accelerator directml --min
+            download_command: cargo run -vv -p download -- --device directml --min
             download_dir: voicevox_core
             check_items: |
               core.dll
@@ -118,7 +118,7 @@ jobs:
               open_jtalk_dic_utf_8-1.11
           - name: cuda option確認
             os: windows-latest
-            download_command: cargo run -vv -p download -- --accelerator cuda
+            download_command: cargo run -vv -p download -- --device cuda
             download_dir: voicevox_core
             check_items: |
               core.dll
@@ -139,7 +139,7 @@ jobs:
               *directml*
           - name: cudaかつmin option確認
             os: windows-latest
-            download_command: cargo run -vv -p download -- --accelerator cuda --min
+            download_command: cargo run -vv -p download -- --device cuda --min
             download_dir: voicevox_core
             check_items: |
               core.dll
@@ -228,7 +228,7 @@ jobs:
               open_jtalk_dic_utf_8-1.11
           - name: cuda option確認
             os: ubuntu-latest
-            download_command: ./scripts/downloads/download.sh --accelerator cuda
+            download_command: ./scripts/downloads/download.sh --device cuda
             download_dir: voicevox_core
             check_items: |
               libcore.so
@@ -248,7 +248,7 @@ jobs:
               *directml*
           - name: cudaかつmin option確認
             os: ubuntu-latest
-            download_command: ./scripts/downloads/download.sh --accelerator cuda --min
+            download_command: ./scripts/downloads/download.sh --device cuda --min
             download_dir: voicevox_core
             check_items: |
               libcore.so

--- a/crates/download/src/main.rs
+++ b/crates/download/src/main.rs
@@ -142,7 +142,7 @@ async fn main() -> anyhow::Result<()> {
     let core = find_gh_asset(octocrab, CORE_REPO_NAME, &version, |tag| {
         let device = match (os, device) {
             (Os::Linux, Device::Cuda) => "gpu",
-            (_, accelerator) => accelerator.into(),
+            (_, device) => device.into(),
         };
         format!("{CORE_REPO_NAME}-{os}-{cpu_arch}-{device}-{tag}.zip")
     })

--- a/docs/downloads/download.md
+++ b/docs/downloads/download.md
@@ -26,7 +26,7 @@ curl -sSfL https://github.com/VOICEVOX/voicevox_core/releases/latest/download/do
 
 ```PowerShell
 Invoke-WebRequest https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.ps1 -OutFile ./download.ps1
-./download.ps1 -Accelerator directml
+./download.ps1 -Device directml
 ```
 
 <a id="cuda"></a>
@@ -37,13 +37,13 @@ Invoke-WebRequest https://github.com/VOICEVOX/voicevox_core/releases/latest/down
 
 ```PowerShell
 Invoke-WebRequest https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.ps1 -OutFile ./download.ps1
-./download.ps1 -Accelerator cuda
+./download.ps1 -Device cuda
 ```
 
 ### Linux の場合
 
 ```bash
-curl -sSfL https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.sh | bash -s -- --accelerator cuda
+curl -sSfL https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.sh | bash -s -- --device cuda
 ```
 
 <a id="help"></a>

--- a/scripts/downloads/download.ps1
+++ b/scripts/downloads/download.ps1
@@ -24,8 +24,8 @@ Param(
 	[Parameter()]
 	[ValidateSet("cpu","cuda","directml")]
 	[string]
-	# ダウンロードするAcceleratorを指定する(cpu,cuda,directmlを指定可能)
-	$Accelerator = "cpu",
+	# ダウンロードするデバイスを指定する(cpu,cuda,directmlを指定可能)
+	$Device = "cpu",
 	[Parameter()]
 	[bool]
 	# ダウンロードするライブラリを最小限にするように指定
@@ -46,18 +46,18 @@ $VoicevoxAdditionalLibrariesBaseUrl="https://github.com/VOICEVOX/voicevox_additi
 $OpenJtalkDictUrl="https://jaist.dl.sourceforge.net/project/open-jtalk/Dictionary/open_jtalk_dic-1.11/open_jtalk_dic_utf_8-1.11.tar.gz"
 $OpenJtalkDictDirName="open_jtalk_dic_utf_8-1.11"
 
-Function Voicevox-Core-Releases-Url($Os,$CpuArch,$Accelerator,$Version){
-	"${VoicevoxCoreRepositoryBaseUrl}/releases/download/${Version}/voicevox_core-${Os}-${CpuArch}-${Accelerator}-${Version}.zip"
+Function Voicevox-Core-Releases-Url($Os,$CpuArch,$Device,$Version){
+	"${VoicevoxCoreRepositoryBaseUrl}/releases/download/${Version}/voicevox_core-${Os}-${CpuArch}-${Device}-${Version}.zip"
 }
 
-Function Voicevox-Additional-Libraries-Releases-Url($Os,$CpuArch,$Accelerator,$Version){
-	If ( $Accelerator -eq "cuda" ){
-		$Accelerator="CUDA"
-	} ElseIf ( $Accelerator -eq "directml" ){
-		$Accelerator="DirectML"
+Function Voicevox-Additional-Libraries-Releases-Url($Os,$CpuArch,$Device,$Version){
+	If ( $Device -eq "cuda" ){
+		$Device="CUDA"
+	} ElseIf ( $Device -eq "directml" ){
+		$Device="DirectML"
 	}
 
-	"${VoicevoxAdditionalLibrariesBaseUrl}/releases/download/${Version}/${Accelerator}-${Os}-${CpuArch}.zip"
+	"${VoicevoxAdditionalLibrariesBaseUrl}/releases/download/${Version}/${Device}-${Os}-${CpuArch}.zip"
 }
 
 Function Latest-Version($BaseUrl){
@@ -123,7 +123,7 @@ If ( [string]::IsNullOrEmpty($CpuArch) ){
   $CpuArch=Target-Arch
 }
 
-If ( $Accelerator -eq "cpu" ){
+If ( $Device -eq "cpu" ){
 	$AdditionalLibrariesVersion=""
 }
 
@@ -138,11 +138,11 @@ If ( $AdditionalLibrariesVersion -eq "latest" ){
 echo "対象OS:$Os"
 echo "対象CPUアーキテクチャ:$cpu_arch"
 echo "ダウンロードvoicevox_coreバージョン:$version"
-echo "ダウンロードアーティファクトタイプ:$Accelerator"
+echo "ダウンロードアーティファクトタイプ:$Device"
 echo "出力先:$Output"
 
-$VoicevoxCoreUrl=Voicevox-Core-Releases-Url "$Os" "$CpuArch" "$Accelerator" "$Version"
-$VoicevoxAdditionalLibrariesUrl=Voicevox-Additional-Libraries-Releases-Url "$Os" "$CpuArch" "$Accelerator" "$AdditionalLibrariesVersion"
+$VoicevoxCoreUrl=Voicevox-Core-Releases-Url "$Os" "$CpuArch" "$Device" "$Version"
+$VoicevoxAdditionalLibrariesUrl=Voicevox-Additional-Libraries-Releases-Url "$Os" "$CpuArch" "$Device" "$AdditionalLibrariesVersion"
 
 Download-and-Extract "voicevox_core" "$VoicevoxCoreUrl" "$Output"
 

--- a/scripts/downloads/download.sh
+++ b/scripts/downloads/download.sh
@@ -7,7 +7,7 @@ help(){
     -o|--output \$directory                    出力先の指定(default ./voicevox_core)
     -v|--version \$version                     ダウンロードするvoicevox_coreのバージョンの指定(default latest)
     --additional-libraries-version \$version   追加でダウンロードするライブラリのバージョン
-    --accelerator \$accelerator                ダウンロードするacceleratorを指定する(cpu,cudaを指定可能.cudaはlinuxのみ)
+    --device \$device                          ダウンロードするデバイスを指定する(cpu,cudaを指定可能.cudaはlinuxのみ)
     --cpu-arch \$cpu_arch                      ダウンロードするcpuのアーキテクチャを指定する
     --min                                     ダウンロードするライブラリを最小限にするように指定
     --os                                      ダウンロードする対象のOSを指定する
@@ -23,27 +23,27 @@ open_jtalk_dict_dir_name="open_jtalk_dic_utf_8-1.11"
 voicevox_core_releases_url(){
   os=$1
   cpu_arch=$2
-  accelerator=$3
+  device=$3
   version=$4
 
-  if [ "$os" = "linux" ] && [ "$accelerator" = "cuda" ];then
-    accelerator="gpu"
+  if [ "$os" = "linux" ] && [ "$device" = "cuda" ];then
+    device="gpu"
   fi
-  url="$voicevox_core_repository_base_url/releases/download/$version/voicevox_core-$os-$cpu_arch-$accelerator-$version.zip"
+  url="$voicevox_core_repository_base_url/releases/download/$version/voicevox_core-$os-$cpu_arch-$device-$version.zip"
   echo "$url"
 }
 
 voicevox_additional_libraries_url(){
   os=$1
   cpu_arch=$2
-  accelerator=$3
+  device=$3
   version=$4
-  if [ "$accelerator" = "cuda" ];then
-    accelerator="CUDA"
-  elif [ "$accelerator" = "directml" ];then
-    accelerator="DirectML"
+  if [ "$device" = "cuda" ];then
+    device="CUDA"
+  elif [ "$device" = "directml" ];then
+    device="DirectML"
   fi
-  url="${voicevox_additional_libraries_base_url}/releases/download/${version}/${accelerator}-${os}-${cpu_arch}.zip"
+  url="${voicevox_additional_libraries_base_url}/releases/download/${version}/${device}-${os}-${cpu_arch}.zip"
   echo "$url"
 }
 
@@ -116,7 +116,7 @@ os=""
 cpu_arch=""
 version="latest"
 additional_libraries_version="latest"
-accelerator=""
+device=""
 output="./voicevox_core"
 min=""
 
@@ -136,8 +136,8 @@ do
     --additional-libraries-version)
       additional_libraries_version="$2"
       shift;;
-    --accelerator)
-      accelerator="$2"
+    --device)
+      device="$2"
       shift;;
     --cpu-arch)
       cpu_arch="$2"
@@ -165,11 +165,11 @@ if [ -z "$cpu_arch" ];then
   cpu_arch=$(target_arch)
 fi
 
-if [ "$accelerator" = "" ];then
-  accelerator="cpu"
+if [ "$device" = "" ];then
+  device="cpu"
 fi
 
-if [ "$accelerator" = "cpu" ];then
+if [ "$device" = "cpu" ];then
   additional_libraries_version=""
 fi
 
@@ -185,15 +185,15 @@ fi
 echo "対象OS:$os"
 echo "対象CPUアーキテクチャ:$cpu_arch"
 echo "ダウンロードvoicevox_coreバージョン:$version"
-echo "ダウンロードアーティファクトタイプ:$accelerator"
+echo "ダウンロードデバイスタイプ:$device"
 
 if [ "$additional_libraries_version" != "" ];then
   echo "ダウンロード追加ライブラリバージョン:$additional_libraries_version"
 fi
 
 
-voicevox_core_url=$(voicevox_core_releases_url "$os" "$cpu_arch" "$accelerator" "$version")
-voicevox_additional_libraries_url=$(voicevox_additional_libraries_url "$os" "$cpu_arch" "$accelerator" "$additional_libraries_version")
+voicevox_core_url=$(voicevox_core_releases_url "$os" "$cpu_arch" "$device" "$version")
+voicevox_additional_libraries_url=$(voicevox_additional_libraries_url "$os" "$cpu_arch" "$device" "$additional_libraries_version")
 
 download_and_extract "voicevox_core" "$voicevox_core_url" "$output" &
 voicevox_core_download_task=$!


### PR DESCRIPTION
## 内容

```diff
 Usage: download [OPTIONS]

 Options:
       --min
           ダウンロードするライブラリを最小限にするように指定
   -o, --output <OUTPUT>
           出力先の指定 [default: ./voicevox_core]
   -v, --version <VERSION>
           ダウンロードするvoicevox_coreのバージョンの指定 [default: latest]
       --additional-libraries-version <ADDITIONAL_LIBRARIES_VERSION>
           追加でダウンロードするライブラリのバージョン [default: latest]
-      --accelerator <ACCELERATOR>
-          ダウンロードするacceleratorを指定する(cudaはlinuxのみ) [default: cpu] [possible values: cpu, cuda, directml]
+      --device <DEVICE>
+          ダウンロードするデバイスを指定する(cudaはlinuxのみ) [default: cpu] [possible values: cpu, cuda, directml]
       --cpu-arch <CPU_ARCH>
           ダウンロードするcpuのアーキテクチャを指定する [default: x64] [possible values: x86, x64, arm64]
       --os <OS>
           ダウンロードする対象のOSを指定する [default: linux] [possible values: windows, linux, osx]
   -h, --help
           Print help information
```

```diff
  INFO 対象OS: linux
  INFO 対象CPUアーキテクチャ: x64
- INFO ダウンロードアーティファクトタイプ: cuda
+ INFO ダウンロードデバイスタイプ: cuda
  INFO ダウンロードvoicevox_coreバージョン: 0.14.0-preview.4
  INFO ダウンロード追加ライブラリバージョン: 0.1.0
```

## 関連 Issue

- <https://github.com/VOICEVOX/voicevox_core/pull/375#discussion_r1089718923>

## その他
