### PR TITLE
download.ps1にCPUarch判定処理を追加

### DIFF
--- a/scripts/downloads/download.ps1
+++ b/scripts/downloads/download.ps1
@@ -79,8 +79,11 @@ Function Target-Os(){
 }
 
 Function Target-Arch(){
-	# TODO: cpu architectureの判定を実装する
-	"x64"
+	if ( $env:PROCESSOR_ARCHITECTURE -eq "x86" ){
+		"x86"
+	} else {
+		"x64"
+	}
 }
 
 Function Download-and-Extract($Target,$Url,$ExtractDir,$ArchiveFormat){

--- a/scripts/downloads/download.ps1
+++ b/scripts/downloads/download.ps1
@@ -79,10 +79,10 @@ Function Target-Os(){
 }
 
 Function Target-Arch(){
-	if ( $env:PROCESSOR_ARCHITECTURE -eq "x86" ){
-		"x86"
-	} else {
+	if ( [Environment]::Is64BitProcess ){
 		"x64"
+	} else {
+		"x86"
 	}
 }
 


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

#339 の対応です。
Target-Arch関数に、CPUアーキテクチャを判定する処理を書きました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

close #339

## その他
正確には、実行されているPCの物理CPUアーキテクチャでは無く、実行プロセスが64bitかどうかを判定しています。