### PR TITLE
fix: `audio_query` 関数で `kana` オプションを `true` に設定したときに適切な `accent_phrases` を得られるようにする

### DIFF
--- a/crates/voicevox_core/src/publish.rs
+++ b/crates/voicevox_core/src/publish.rs
@@ -167,7 +167,8 @@ impl VoicevoxCore {
             return Err(Error::NotLoadedOpenjtalkDict);
         }
         let accent_phrases = if options.kana {
-            parse_kana(text)?
+            self.synthesis_engine
+                .replace_mora_data(&parse_kana(text)?, speaker_id)?
         } else {
             self.synthesis_engine
                 .create_accent_phrases(text, speaker_id)?

--- a/crates/voicevox_core/src/publish.rs
+++ b/crates/voicevox_core/src/publish.rs
@@ -896,8 +896,11 @@ mod tests {
         assert_eq!(result.unwrap().len(), F0_LENGTH * 256);
     }
 
+    type TextConsonantVowelData =
+        [(&'static [(&'static str, &'static str, &'static str)], usize)];
+
     // [([(テキスト, 母音, 子音), ...], アクセントの位置), ...] の形式
-    const TEXT_CONSONANT_VOWEL_DATA1: &[(&[(&str, &str, &str)], usize)] = &[
+    const TEXT_CONSONANT_VOWEL_DATA1: &TextConsonantVowelData = &[
         (&[("コ", "k", "o"), ("レ", "r", "e"), ("ワ", "w", "a")], 3),
         (
             &[
@@ -911,7 +914,7 @@ mod tests {
         ),
     ];
 
-    const TEXT_CONSONANT_VOWEL_DATA2: &[(&[(&str, &str, &str)], usize)] = &[
+    const TEXT_CONSONANT_VOWEL_DATA2: &TextConsonantVowelData = &[
         (&[("コ", "k", "o"), ("レ", "r", "e"), ("ワ", "w", "a")], 1),
         (
             &[
@@ -942,7 +945,7 @@ mod tests {
     async fn audio_query_works(
         #[case] input_text: &str,
         #[case] input_kana_option: bool,
-        #[case] expected_text_consonant_vowel_data: &[(&[(&str, &str, &str)], usize)],
+        #[case] expected_text_consonant_vowel_data: &TextConsonantVowelData,
         #[case] expected_kana_text: &str,
     ) {
         let open_jtalk_dic_dir = download_open_jtalk_dict_if_no_exists().await;
@@ -966,7 +969,6 @@ mod tests {
                 0,
                 AudioQueryOptions {
                     kana: input_kana_option,
-                    ..Default::default()
                 },
             )
             .unwrap();

--- a/crates/voicevox_core/src/publish.rs
+++ b/crates/voicevox_core/src/publish.rs
@@ -978,20 +978,17 @@ mod tests {
             expected_text_consonant_vowel_data.len()
         );
 
-        for (accent_phrase, (text_consonant_vowel_slice, accent_pos)) in query
-            .accent_phrases()
-            .iter()
-            .zip(expected_text_consonant_vowel_data)
+        for (accent_phrase, (text_consonant_vowel_slice, accent_pos)) in
+            std::iter::zip(query.accent_phrases(), expected_text_consonant_vowel_data)
         {
             assert_eq!(
                 accent_phrase.moras().len(),
                 text_consonant_vowel_slice.len()
             );
             assert_eq!(accent_phrase.accent(), accent_pos);
-            for (mora, (text, consonant, vowel)) in accent_phrase
-                .moras()
-                .iter()
-                .zip(*text_consonant_vowel_slice)
+
+            for (mora, (text, consonant, vowel)) in
+                std::iter::zip(accent_phrase.moras(), *text_consonant_vowel_slice)
             {
                 assert_eq!(mora.text(), text);
                 // NOTE: 子音の長さが必ず非ゼロになるテストケースを想定している


### PR DESCRIPTION
## 内容

`VoicevoxCore::audio_query` メソッドを `kana` オプションを `true` に設定した状態で使用すると、`parse_kana` 関数で生成された `accent_phrases` に対して `predict_duration` および `predict_intonataion` を用いないようになっており、子音・母音の長さ等が未設定のまま（デフォルト値の 0 等のまま）出力されていました。

（これにより、この `audio_query` メソッドを呼び出している `VoicevoxCore::tts` メソッドにも影響があり、無音の wav が生成される結果となっていました。）

エンジンの Python コードには以下のような部分があり、これを参考に、`SynthesisEngine::replace_mora_data` メソッドに `parse_kana` で生成された `accent_phrases` を適用して、推論結果が反映された適切な `accent_phrases` を得られるようにしました。

https://github.com/VOICEVOX/voicevox_engine/blob/2c4f52a9ec80cda5936edecccc4c2aabd14a78f7/run.py#L303-L315

## 関連 Issue

close #405 
