### PR TITLE
ログの時刻をマイクロ秒単位に揃える

### DIFF
--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -2,6 +2,7 @@
 mod compatible_engine;
 mod helpers;
 use self::helpers::*;
+use chrono::SecondsFormat;
 use is_terminal::IsTerminal;
 use libc::c_void;
 use once_cell::sync::Lazy;
@@ -41,7 +42,8 @@ static INTERNAL: Lazy<Mutex<Internal>> = Lazy::new(|| {
     }
 
     fn local_time(wtr: &mut Writer<'_>) -> fmt::Result {
-        wtr.write_str(&chrono::Local::now().to_rfc3339())
+        // https://github.com/tokio-rs/tracing/blob/tracing-subscriber-0.3.16/tracing-subscriber/src/fmt/time/datetime.rs#L235-L241
+        wtr.write_str(&chrono::Local::now().to_rfc3339_opts(SecondsFormat::Micros, false))
     }
 
     fn out() -> impl IsTerminal + Write {


### PR DESCRIPTION
## 内容

https://github.com/VOICEVOX/voicevox_core/pull/425#issuecomment-1455184365

## 関連 Issue

- #400

## その他

実際どうなのか手元で試してないためdraftです。
