### PR TITLE
ダウンローダーをスクリプト版からrust版を使うよう案内

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,32 @@
 ## 環境構築
 
 Downloader を用いて環境構築を行う場合
-
 ### Windows の場合
 
 PowerShell で下記コマンドを実行してください
 
 ```PowerShell
-Invoke-WebRequest https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.ps1 -OutFile ./download.ps1
-./download.ps1
+Invoke-WebRequest https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download-windows-x64.exe -OutFile ./download.exe
+./download.exe
 ```
 
 ### Linux/macOS の場合
 
+[最新のリリース](https://github.com/VOICEVOX/voicevox_core/releases/latest)から環境に合わせてダウンローダーのバイナリをダウンロードしてください。
+現在利用可能なのは以下の4つです。
+
+* download-linux-arm64
+* download-linux-x64
+* download-osx-arm64
+* download-osx-x64
+
+以下はLinuxのx64での実行例です。
+
 ```bash
-curl -sSfL https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.sh | bash -s
+binary=download-linux-x64
+curl -sSfL https://github.com/VOICEVOX/voicevox_core/releases/latest/download/${binary} -o download
+chmod +x download
+./download
 ```
 
 詳細な Downloader の使い方については [こちら](./docs/downloads/download.md) を参照してください

--- a/docs/downloads/download.md
+++ b/docs/downloads/download.md
@@ -1,49 +1,69 @@
 # VOICEVOX CORE Downloader
+VOICEVOX COREの実行にはモデルやOpen JTalkなどの外部ライブラリのダウンロードが必要になります。
+VOICEVOX CORE Downloaderは環境に合わせてそれらをダウンロードします。
 
-<a id="default"></a>
-<a id="cpu"></a>
 
-## デフォルト(CPU 版)をダウンロードする場合
+# ダウンローダーの入手
 
 ### Windows の場合
 
 PowerShell で下記コマンドを実行してください
 
 ```PowerShell
-Invoke-WebRequest https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.ps1 -OutFile ./download.ps1
-./download.ps1
+Invoke-WebRequest https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download-windows-x64.exe -OutFile ./download.exe
 ```
 
 ### Linux/macOS の場合
 
+[最新のリリース](https://github.com/VOICEVOX/voicevox_core/releases/latest)から環境に合わせてダウンローダーのバイナリをダウンロードしてください。
+現在利用可能なのは以下の4つです。
+
+* download-linux-arm64
+* download-linux-x64
+* download-osx-arm64
+* download-osx-x64
+
+以下はLinuxのx64での実行例です。
+
 ```bash
-curl -sSfL https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.sh | bash -s
+binary=download-linux-x64
+curl -sSfL https://github.com/VOICEVOX/voicevox_core/releases/latest/download/${binary} -o download
+chmod +x download
+```
+
+# ダウンローダーの使い方
+
+
+<a id="default"></a>
+<a id="cpu"></a>
+
+## デフォルト(CPU 版)をダウンロードする場合
+
+
+```
+download
+```
+
+または
+
+```
+download --device cpu
 ```
 
 <a id="directml"></a>
 
 ## DirectML 版をダウンロードする場合
 
-```PowerShell
-Invoke-WebRequest https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.ps1 -OutFile ./download.ps1
-./download.ps1 -Device directml
+```
+download --device directml
 ```
 
 <a id="cuda"></a>
 
 ## CUDA 版をダウンロードする場合
 
-### Windows の場合
-
-```PowerShell
-Invoke-WebRequest https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.ps1 -OutFile ./download.ps1
-./download.ps1 -Device cuda
 ```
-
-### Linux の場合
-
-```bash
-curl -sSfL https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.sh | bash -s -- --device cuda
+download --device cuda
 ```
 
 <a id="help"></a>
@@ -53,15 +73,6 @@ curl -sSfL https://github.com/VOICEVOX/voicevox_core/releases/latest/download/do
 スクリプトにヘルプ表示機能があります。
 以下のようにしてヘルプを表示できます。
 
-### Windows の場合
-
-```PowerShell
-Invoke-WebRequest https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.ps1 -OutFile ./download.ps1
-Get-Help ./download.ps1 -full
 ```
-
-### Linux/macOS の場合
-
-```bash
-curl -sSfL https://github.com/VOICEVOX/voicevox_core/releases/latest/download/download.sh | bash -s -- --help
+download --help
 ```


### PR DESCRIPTION
## 内容

ダウンローダーをスクリプト版からrust版を使うようドキュメントを変更しました。
linux/macではどれ使うという問題は残っていますが…

## 関連 Issue

ref #433
