### PR TITLE
`PartialEq`はマクロで実装する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2180,6 +2180,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+
+[[package]]
 name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3578,6 +3584,7 @@ dependencies = [
  "once_cell",
  "onnxruntime",
  "open_jtalk",
+ "paste",
  "pretty_assertions",
  "process_path",
  "regex",

--- a/crates/voicevox_core/Cargo.toml
+++ b/crates/voicevox_core/Cargo.toml
@@ -18,6 +18,7 @@ easy-ext.workspace = true
 fs-err.workspace = true
 once_cell.workspace = true
 onnxruntime = { git = "https://github.com/VOICEVOX/onnxruntime-rs.git", rev="405f62fb53df1b59b0e69adafbd1c28e4d5c2787" }
+paste = "1.0.12"
 process_path = "0.1.4"
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/voicevox_core/src/engine/open_jtalk.rs
+++ b/crates/voicevox_core/src/engine/open_jtalk.rs
@@ -2,6 +2,8 @@ use std::path::{Path, PathBuf};
 
 use ::open_jtalk::*;
 
+use crate::macros::partialeq;
+
 #[derive(thiserror::Error, Debug)]
 pub enum OpenJtalkError {
     #[error("open_jtalk load error")]
@@ -14,33 +16,14 @@ pub enum OpenJtalkError {
     },
 }
 
-impl PartialEq for OpenJtalkError {
-    fn eq(&self, other: &Self) -> bool {
-        return match (self, other) {
-            (
-                Self::Load {
-                    mecab_dict_dir: mecab_dict_dir1,
-                },
-                Self::Load {
-                    mecab_dict_dir: mecab_dict_dir2,
-                },
-            ) => mecab_dict_dir1 == mecab_dict_dir2,
-            (
-                Self::ExtractFullContext {
-                    text: text1,
-                    source: source1,
-                },
-                Self::ExtractFullContext {
-                    text: text2,
-                    source: source2,
-                },
-            ) => (text1, by_display(source1)) == (text2, by_display(source2)),
-            _ => false,
-        };
-
-        fn by_display(source: &Option<anyhow::Error>) -> impl PartialEq {
-            source.as_ref().map(|e| e.to_string())
-        }
+partialeq! {
+    for OpenJtalkError {
+        unit: {},
+        unnamed: {},
+        named: {
+            Load { mecab_dict_dir },
+            ExtractFullContext { text, #[stringify] source },
+        },
     }
 }
 

--- a/crates/voicevox_core/src/error.rs
+++ b/crates/voicevox_core/src/error.rs
@@ -2,6 +2,7 @@ use self::engine::{FullContextLabelError, KanaParseError};
 use self::result_code::VoicevoxResultCode::{self, *};
 use super::*;
 //use engine::
+use crate::macros::partialeq;
 use std::path::PathBuf;
 use thiserror::Error;
 
@@ -68,47 +69,25 @@ pub enum Error {
     ParseKana(#[from] KanaParseError),
 }
 
-impl PartialEq for Error {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::NotLoadedOpenjtalkDict, Self::NotLoadedOpenjtalkDict)
-            | (Self::GpuSupport, Self::GpuSupport)
-            | (Self::UninitializedStatus, Self::UninitializedStatus)
-            | (Self::InferenceFailed, Self::InferenceFailed) => true,
-            (
-                Self::LoadModel {
-                    path: path1,
-                    source: source1,
-                },
-                Self::LoadModel {
-                    path: path2,
-                    source: source2,
-                },
-            ) => (path1, source1.to_string()) == (path2, source2.to_string()),
-            (Self::LoadMetas(e1), Self::LoadMetas(e2))
-            | (Self::GetSupportedDevices(e1), Self::GetSupportedDevices(e2)) => {
-                e1.to_string() == e2.to_string()
-            }
-            (
-                Self::InvalidSpeakerId {
-                    speaker_id: speaker_id1,
-                },
-                Self::InvalidSpeakerId {
-                    speaker_id: speaker_id2,
-                },
-            ) => speaker_id1 == speaker_id2,
-            (
-                Self::InvalidModelIndex {
-                    model_index: model_index1,
-                },
-                Self::InvalidModelIndex {
-                    model_index: model_index2,
-                },
-            ) => model_index1 == model_index2,
-            (Self::ExtractFullContextLabel(e1), Self::ExtractFullContextLabel(e2)) => e1 == e2,
-            (Self::ParseKana(e1), Self::ParseKana(e2)) => e1 == e2,
-            _ => false,
-        }
+partialeq! {
+    for Error {
+        unit: {
+            NotLoadedOpenjtalkDict,
+            GpuSupport,
+            UninitializedStatus,
+            InferenceFailed,
+        },
+        unnamed: {
+            LoadMetas(#[stringify] source),
+            GetSupportedDevices(#[stringify] source),
+            ExtractFullContextLabel(err),
+            ParseKana(err),
+        },
+        named: {
+            LoadModel { path, #[stringify] source },
+            InvalidSpeakerId { speaker_id },
+            InvalidModelIndex { model_index },
+        },
     }
 }
 

--- a/crates/voicevox_core/src/lib.rs
+++ b/crates/voicevox_core/src/lib.rs
@@ -3,6 +3,7 @@
 /// cbindgen:ignore
 mod engine;
 mod error;
+mod macros;
 mod numerics;
 mod publish;
 mod result;

--- a/crates/voicevox_core/src/macros.rs
+++ b/crates/voicevox_core/src/macros.rs
@@ -1,0 +1,102 @@
+macro_rules! partialeq {
+    (
+        for $ty:ty {
+            unit: {
+                $(
+                    $unit_variant_ident:ident
+                ),*
+                $(,)?
+            },
+            unnamed: {
+                $(
+                    $unnamed_variant_ident:ident(
+                        $($unnamed_field:ident),*
+                        $($(,)? #[stringify] $unnamed_source:ident)?
+                        $(,)?
+                    )
+                ),*
+                $(,)?
+            },
+            named: {
+                $(
+                    $named_variant_ident:ident {
+                        $($named_field:ident),*
+                        $($(,)? #[stringify] $named_source:ident)?
+                        $(,)?
+                    }
+                ),*
+                $(,)?
+            },
+        }
+    ) => {
+        impl PartialEq for $ty {
+            fn eq(&self, __other: &Self) -> bool {
+                return match (self, __other) {
+                    $(
+                        (
+                            Self::$unit_variant_ident,
+                            Self::$unit_variant_ident,
+                        ) => true,
+                    )*
+                    $(
+                        (
+                            Self::$unnamed_variant_ident($(::paste::paste!([<$unnamed_field _1>]),)* $(::paste::paste!([<$unnamed_source _1>]))*),
+                            Self::$unnamed_variant_ident($(::paste::paste!([<$unnamed_field _2>]),)* $(::paste::paste!([<$unnamed_source _2>]))*),
+                        ) => true
+                            $(
+                                && ::paste::paste!([<$unnamed_field _1>])
+                                    == ::paste::paste!([<$unnamed_field _2>])
+                            )*
+                            $(
+                                && __OptionalAnyhowError::to_option_string(::paste::paste!([<$unnamed_source _1>]))
+                                    == __OptionalAnyhowError::to_option_string(::paste::paste!([<$unnamed_source _2>]))
+                            )*,
+                    )*
+                    $(
+                        (
+                            Self::$named_variant_ident { $($named_field: ::paste::paste!([<$named_field _1>]),)* $($named_source: ::paste::paste!([<$named_source _1>]))* },
+                            Self::$named_variant_ident { $($named_field: ::paste::paste!([<$named_field _2>]),)* $($named_source: ::paste::paste!([<$named_source _2>]))* },
+                        ) => true
+                            $(
+                                && ::paste::paste!([<$named_field _1>])
+                                    == ::paste::paste!([<$named_field _2>])
+                            )*
+                            $(
+                                && __OptionalAnyhowError::to_option_string(::paste::paste!([<$named_source _1>]))
+                                    == __OptionalAnyhowError::to_option_string(::paste::paste!([<$named_source _2>]))
+                            )*,
+                    )*
+                    _ => false,
+                };
+
+                /// バリアントがすべて網羅されていることをチェック
+                const _: fn(&$ty) = |err| {
+                    type This = $ty;
+
+                    match err {
+                        $(| This::$unit_variant_ident)*
+                        $(| This::$unnamed_variant_ident(..))*
+                        $(| This::$named_variant_ident { .. })* => {}
+                    }
+                };
+
+                trait __OptionalAnyhowError {
+                    fn to_option_string(&self) -> Option<String>;
+                }
+
+                impl __OptionalAnyhowError for anyhow::Error {
+                    fn to_option_string(&self) -> Option<String> {
+                        Some(self.to_string())
+                    }
+                }
+
+                impl __OptionalAnyhowError for Option<anyhow::Error> {
+                    fn to_option_string(&self) -> Option<String> {
+                        self.as_ref().map(|e| e.to_string())
+                    }
+                }
+            }
+        }
+    };
+}
+pub(crate) use partialeq;

--- a/crates/voicevox_core/src/macros.rs
+++ b/crates/voicevox_core/src/macros.rs
@@ -48,8 +48,8 @@ macro_rules! partialeq {
                                     == ::paste::paste!([<$unnamed_field _2>])
                             )*
                             $(
-                                && __OptionalAnyhowError::to_option_string(::paste::paste!([<$unnamed_source _1>]))
-                                    == __OptionalAnyhowError::to_option_string(::paste::paste!([<$unnamed_source _2>]))
+                                && crate::macros::OptionalAnyhowError::to_option_string(::paste::paste!([<$unnamed_source _1>]))
+                                    == crate::macros::OptionalAnyhowError::to_option_string(::paste::paste!([<$unnamed_source _2>]))
                             )*,
                     )*
                     $(
@@ -62,8 +62,8 @@ macro_rules! partialeq {
                                     == ::paste::paste!([<$named_field _2>])
                             )*
                             $(
-                                && __OptionalAnyhowError::to_option_string(::paste::paste!([<$named_source _1>]))
-                                    == __OptionalAnyhowError::to_option_string(::paste::paste!([<$named_source _2>]))
+                                && crate::macros::OptionalAnyhowError::to_option_string(::paste::paste!([<$named_source _1>]))
+                                    == crate::macros::OptionalAnyhowError::to_option_string(::paste::paste!([<$named_source _2>]))
                             )*,
                     )*
                     _ => false,
@@ -79,24 +79,24 @@ macro_rules! partialeq {
                         $(| This::$named_variant_ident { .. })* => {}
                     }
                 };
-
-                trait __OptionalAnyhowError {
-                    fn to_option_string(&self) -> Option<String>;
-                }
-
-                impl __OptionalAnyhowError for anyhow::Error {
-                    fn to_option_string(&self) -> Option<String> {
-                        Some(self.to_string())
-                    }
-                }
-
-                impl __OptionalAnyhowError for Option<anyhow::Error> {
-                    fn to_option_string(&self) -> Option<String> {
-                        self.as_ref().map(|e| e.to_string())
-                    }
-                }
             }
         }
     };
 }
 pub(crate) use partialeq;
+
+pub(crate) trait OptionalAnyhowError {
+    fn to_option_string(&self) -> Option<String>;
+}
+
+impl OptionalAnyhowError for anyhow::Error {
+    fn to_option_string(&self) -> Option<String> {
+        Some(self.to_string())
+    }
+}
+
+impl OptionalAnyhowError for Option<anyhow::Error> {
+    fn to_option_string(&self) -> Option<String> {
+        self.as_ref().map(|e| e.to_string())
+    }
+}


### PR DESCRIPTION
## 内容

エラー型に対する`PartialEq`はマクロで実装するようにします。

#298 で`PartialEq`を手動で実装するようになりましたが、<https://github.com/VOICEVOX/voicevox_core/pull/370#discussion_r1134444417>のような漏れが発生しうります。
この漏れを撲滅するのが目的です。

## 関連 Issue

- #298

(追記)
Closes #441.
Closes #443.

## その他

丁度よいproc-macroのライブラリがあればよかったのですが、無さそうだったのでマクロは手作りしました。

マクロは次の形で展開されることを確認しています。

crates/voicevox\_core/src/error.rs:

```rust
impl PartialEq for Error {
    fn eq(&self, __other: &Self) -> bool {
        return match (self, __other) {
            (Self::NotLoadedOpenjtalkDict, Self::NotLoadedOpenjtalkDict) => true,
            (Self::GpuSupport, Self::GpuSupport) => true,
            (Self::UninitializedStatus, Self::UninitializedStatus) => true,
            (Self::InferenceFailed, Self::InferenceFailed) => true,
            (Self::LoadMetas(source_1), Self::LoadMetas(source_2)) => {
                true
                    && crate::macros::OptionalAnyhowError::to_option_string(source_1)
                        == crate::macros::OptionalAnyhowError::to_option_string(
                            source_2,
                        )
            }
            (
                Self::GetSupportedDevices(source_1),
                Self::GetSupportedDevices(source_2),
            ) => {
                true
                    && crate::macros::OptionalAnyhowError::to_option_string(source_1)
                        == crate::macros::OptionalAnyhowError::to_option_string(
                            source_2,
                        )
            }
            (
                Self::ExtractFullContextLabel(err_1),
                Self::ExtractFullContextLabel(err_2),
            ) => true && err_1 == err_2,
            (Self::ParseKana(err_1), Self::ParseKana(err_2)) => {
                true && err_1 == err_2
            }
            (
                Self::LoadModel { path: path_1, source: source_1 },
                Self::LoadModel { path: path_2, source: source_2 },
            ) => {
                true && path_1 == path_2
                    && crate::macros::OptionalAnyhowError::to_option_string(source_1)
                        == crate::macros::OptionalAnyhowError::to_option_string(
                            source_2,
                        )
            }
            (
                Self::InvalidSpeakerId { speaker_id: speaker_id_1 },
                Self::InvalidSpeakerId { speaker_id: speaker_id_2 },
            ) => true && speaker_id_1 == speaker_id_2,
            (
                Self::InvalidModelIndex { model_index: model_index_1 },
                Self::InvalidModelIndex { model_index: model_index_2 },
            ) => true && model_index_1 == model_index_2,
            _ => false,
        };
        /// バリアントがすべて網羅されていることをチェック
        const _: fn(&Error) = |err| {
            type This = Error;
            match err {
                This::NotLoadedOpenjtalkDict
                | This::GpuSupport
                | This::UninitializedStatus
                | This::InferenceFailed
                | This::LoadMetas(..)
                | This::GetSupportedDevices(..)
                | This::ExtractFullContextLabel(..)
                | This::ParseKana(..)
                | This::LoadModel { .. }
                | This::InvalidSpeakerId { .. }
                | This::InvalidModelIndex { .. } => {}
            }
        };
    }
}
```

crates/voicevox\_core/src/engine/open\_jtalk.rs:

```rust
impl PartialEq for OpenJtalkError {
    fn eq(&self, __other: &Self) -> bool {
        return match (self, __other) {
            (
                Self::Load { mecab_dict_dir: mecab_dict_dir_1 },
                Self::Load { mecab_dict_dir: mecab_dict_dir_2 },
            ) => true && mecab_dict_dir_1 == mecab_dict_dir_2,
            (
                Self::ExtractFullContext { text: text_1, source: source_1 },
                Self::ExtractFullContext { text: text_2, source: source_2 },
            ) => {
                true && text_1 == text_2
                    && crate::macros::OptionalAnyhowError::to_option_string(
                        source_1,
                    )
                        == crate::macros::OptionalAnyhowError::to_option_string(
                            source_2,
                        )
            }
            _ => false,
        };
        /// バリアントがすべて網羅されていることをチェック
        const _: fn(&OpenJtalkError) = |err| {
            type This = OpenJtalkError;
            match err {
                This::Load { .. } | This::ExtractFullContext { .. } => {}
            }
        };
    }
}
```
