### PR TITLE
`anyhow::Error`を抱えたエラー型は`==`ではなく`assert_matches!`で比較する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "983cd8b9d4b02a6dc6ffa557262eb5858a27a0038ffffe21a0f133eaa819a164"
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-attributes"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3566,6 +3572,7 @@ name = "voicevox_core"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "async-std",
  "cfg-if",
  "derive-getters",

--- a/crates/voicevox_core/Cargo.toml
+++ b/crates/voicevox_core/Cargo.toml
@@ -27,6 +27,7 @@ open_jtalk = { git = "https://github.com/VOICEVOX/open_jtalk-rs.git", rev="9edab
 regex = "1.6.0"
 
 [dev-dependencies]
+assert_matches = "1.5.0"
 rstest = "0.15.0"
 pretty_assertions = "1.3.0"
 async-std = { version = "1.12.0", features = ["attributes"] }

--- a/crates/voicevox_core/src/engine/full_context_label.rs
+++ b/crates/voicevox_core/src/engine/full_context_label.rs
@@ -4,7 +4,7 @@ use super::*;
 use once_cell::sync::Lazy;
 use regex::Regex;
 
-#[derive(thiserror::Error, Debug, PartialEq)]
+#[derive(thiserror::Error, Debug)]
 pub enum FullContextLabelError {
     #[error("label parse error label:{label}")]
     LabelParse { label: String },

--- a/crates/voicevox_core/src/engine/synthesis_engine.rs
+++ b/crates/voicevox_core/src/engine/synthesis_engine.rs
@@ -644,6 +644,7 @@ fn make_interrogative_mora(last_mora: &MoraModel) -> MoraModel {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use assert_matches::assert_matches;
     use pretty_assertions::assert_eq;
 
     use crate::*;
@@ -656,10 +657,10 @@ mod tests {
         let open_jtalk_dic_dir = download_open_jtalk_dict_if_no_exists().await;
 
         let result = synthesis_engine.load_openjtalk_dict(&open_jtalk_dic_dir);
-        assert_eq!(result, Ok(()));
+        assert_matches!(result, Ok(()));
 
         let result = synthesis_engine.load_openjtalk_dict("");
-        assert_eq!(result, Err(Error::NotLoadedOpenjtalkDict));
+        assert_matches!(result, Err(Error::NotLoadedOpenjtalkDict));
     }
 
     #[rstest]

--- a/crates/voicevox_core/src/error.rs
+++ b/crates/voicevox_core/src/error.rs
@@ -68,50 +68,6 @@ pub enum Error {
     ParseKana(#[from] KanaParseError),
 }
 
-impl PartialEq for Error {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::NotLoadedOpenjtalkDict, Self::NotLoadedOpenjtalkDict)
-            | (Self::GpuSupport, Self::GpuSupport)
-            | (Self::UninitializedStatus, Self::UninitializedStatus)
-            | (Self::InferenceFailed, Self::InferenceFailed) => true,
-            (
-                Self::LoadModel {
-                    path: path1,
-                    source: source1,
-                },
-                Self::LoadModel {
-                    path: path2,
-                    source: source2,
-                },
-            ) => (path1, source1.to_string()) == (path2, source2.to_string()),
-            (Self::LoadMetas(e1), Self::LoadMetas(e2))
-            | (Self::GetSupportedDevices(e1), Self::GetSupportedDevices(e2)) => {
-                e1.to_string() == e2.to_string()
-            }
-            (
-                Self::InvalidSpeakerId {
-                    speaker_id: speaker_id1,
-                },
-                Self::InvalidSpeakerId {
-                    speaker_id: speaker_id2,
-                },
-            ) => speaker_id1 == speaker_id2,
-            (
-                Self::InvalidModelIndex {
-                    model_index: model_index1,
-                },
-                Self::InvalidModelIndex {
-                    model_index: model_index2,
-                },
-            ) => model_index1 == model_index2,
-            (Self::ExtractFullContextLabel(e1), Self::ExtractFullContextLabel(e2)) => e1 == e2,
-            (Self::ParseKana(e1), Self::ParseKana(e2)) => e1 == e2,
-            _ => false,
-        }
-    }
-}
-
 fn base_error_message(result_code: VoicevoxResultCode) -> &'static str {
     let c_message: &'static str = crate::error_result_to_message(result_code);
     &c_message[..(c_message.len() - 1)]

--- a/crates/voicevox_core/src/lib.rs
+++ b/crates/voicevox_core/src/lib.rs
@@ -3,6 +3,7 @@
 /// cbindgen:ignore
 mod engine;
 mod error;
+mod macros;
 mod numerics;
 mod publish;
 mod result;

--- a/crates/voicevox_core/src/macros.rs
+++ b/crates/voicevox_core/src/macros.rs
@@ -1,0 +1,9 @@
+#[cfg(test)]
+pub(crate) mod tests {
+    macro_rules! assert_result {
+        ($($arg:tt)*) => {
+            |__r| ::assert_matches::assert_matches!(__r, $($arg)*)
+        };
+    }
+    pub(crate) use assert_result;
+}

--- a/crates/voicevox_core/src/status.rs
+++ b/crates/voicevox_core/src/status.rs
@@ -359,6 +359,7 @@ impl Status {
 mod tests {
 
     use super::*;
+    use assert_matches::assert_matches;
     use pretty_assertions::assert_eq;
 
     #[rstest]
@@ -391,7 +392,7 @@ mod tests {
     fn status_load_metas_works() {
         let mut status = Status::new(true, 0);
         let result = status.load_metas();
-        assert_eq!(Ok(()), result);
+        assert_matches!(result, Ok(()));
         let expected = BTreeSet::from([0, 1, 2, 3]);
         assert_eq!(expected, status.supported_styles);
     }
@@ -407,7 +408,7 @@ mod tests {
     fn status_load_model_works() {
         let mut status = Status::new(false, 0);
         let result = status.load_model(0);
-        assert_eq!(Ok(()), result);
+        assert_matches!(result, Ok(()));
         assert_eq!(1, status.models.predict_duration.len());
         assert_eq!(1, status.models.predict_intonation.len());
         assert_eq!(1, status.models.decode.len());
@@ -422,7 +423,7 @@ mod tests {
             "model should  not be loaded"
         );
         let result = status.load_model(model_index);
-        assert_eq!(Ok(()), result);
+        assert_matches!(result, Ok(()));
         assert!(
             status.is_model_loaded(model_index),
             "model should be loaded"


### PR DESCRIPTION
## 内容

<https://github.com/VOICEVOX/voicevox_core/pull/440#issuecomment-1471561912>

#440 に対する第2の選択肢です。

## 関連 Issue

Closes #440.

(追記)
Closes #443.

## その他
