### PR TITLE
android版のビルドが通らない問題の解決（line 2: syntax error near unexpected token `;'）

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -131,7 +131,7 @@ jobs:
         shell: bash
         run: |
           cargo set-version "$VERSION" --exclude voicevox_core_python_api --exclude download --exclude xtask
-          if ${{ matrix.whl_local_version }}; then cargo set-version "$VERSION+"${{ matrix.whl_local_version }} -p voicevox_core_python_api; fi
+          if ${{ !!matrix.whl_local_version }}; then cargo set-version "$VERSION+"${{ matrix.whl_local_version }} -p voicevox_core_python_api; fi
       - name: generate voicevox_core.h
         shell: bash
         run: cbindgen --crate voicevox_core_c_api -o ./voicevox_core.h


### PR DESCRIPTION
## 内容

whl名が無いため`line 2: syntax error near unexpected token `;'`というエラーになります。
Android版はPython wheelが不要なので、通らないようにします。
