### PR TITLE
build.ymlでプルリク時にリリース以外のコードも通るようにする

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -18,8 +18,8 @@ on:
       - "*"
       - "**/*"
 env:
-  # releaseタグ名か、workflow_dispatchでのバージョン名か、DEBUGが入る
-  VERSION: ${{ github.event.release.tag_name || github.event.inputs.version || 'DEBUG' }}
+  # releaseタグ名か、workflow_dispatchでのバージョン名か、0.0.0が入る
+  VERSION: ${{ github.event.release.tag_name || github.event.inputs.version || '0.0.0' }}
 
   # Raw character weights are not public.
   # Skip uploading to GitHub Release on public repo.
@@ -123,11 +123,9 @@ jobs:
       - name: Install cbindgen
         uses: ./.github/actions/cargo-binstall-cbindgen
       - name: Install cargo-edit
-        if: ${{ env.VERSION != 'DEBUG' }}
         shell: bash
         run: cargo binstall cargo-edit@^0.11 --no-confirm --log-level debug
       - name: set cargo version
-        if: ${{ env.VERSION != 'DEBUG' }}
         shell: bash
         run: |
           cargo set-version "$VERSION" --exclude voicevox_core_python_api --exclude download --exclude xtask
@@ -179,7 +177,7 @@ jobs:
           cd artifact
           7z a "../${{ env.ASSET_NAME }}.zip" "${{ env.ASSET_NAME }}"
       - name: Upload to Release
-        if: env.VERSION != 'DEBUG' && env.SKIP_UPLOADING_RELEASE_ASSET == '0'
+        if: env.VERSION != '0.0.0' && env.SKIP_UPLOADING_RELEASE_ASSET == '0'
         uses: softprops/action-gh-release@v1
         with:
           prerelease: true
@@ -188,7 +186,7 @@ jobs:
             ${{ env.ASSET_NAME }}.zip
           target_commitish: ${{ github.sha }}
       - name: Upload Python whl to Release
-        if: env.VERSION != 'DEBUG' && env.SKIP_UPLOADING_RELEASE_ASSET == '0' && matrix.whl_local_version
+        if: env.VERSION != '0.0.0' && env.SKIP_UPLOADING_RELEASE_ASSET == '0' && matrix.whl_local_version
         uses: softprops/action-gh-release@v1
         with:
           prerelease: true
@@ -201,7 +199,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Upload to Release
-        if: env.VERSION != 'DEBUG' && env.SKIP_UPLOADING_RELEASE_ASSET == '0'
+        if: env.VERSION != '0.0.0' && env.SKIP_UPLOADING_RELEASE_ASSET == '0'
         uses: softprops/action-gh-release@v1
         with:
           prerelease: true
@@ -261,7 +259,7 @@ jobs:
           CERT_BASE64: ${{ secrets.CERT_BASE64 }}
           CERT_PASSWORD: ${{ secrets.CERT_PASSWORD }}
       - name: Upload to Release
-        if: env.VERSION != 'DEBUG' && env.SKIP_UPLOADING_RELEASE_ASSET == '0'
+        if: env.VERSION != '0.0.0' && env.SKIP_UPLOADING_RELEASE_ASSET == '0'
         uses: softprops/action-gh-release@v1
         with:
           prerelease: true


### PR DESCRIPTION
## 内容

build.ymlでプルリク時にリリース以外のコードも通るようにします。
（↓のようにすり抜ける時があったので）

- https://github.com/VOICEVOX/voicevox_core/pull/450



## その他
