### PR TITLE
android向け動的ライブラリのzipファイル名をandroid用に変更する

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -75,7 +75,7 @@ jobs:
           - os: ubuntu-20.04
             features: ""
             target: aarch64-linux-android
-            artifact_name: linux-arm64-cpu
+            artifact_name: android-arm64-cpu
             use_cuda: false
           - os: macos-11
             features: ""


### PR DESCRIPTION
## 内容

https://github.com/VOICEVOX/voicevox_core/blob/20b45a16f4e2aa89fbda5f43a6ed25942e4dc58a/.github/workflows/build_and_deploy.yml#L71-L78

arm64版linuxと同じ artifact_name になっているため。ビルド時に生成されるzipファイルの名前衝突が起きている。
androidの artifact_name を `linux-arm64-cpu` → `android-arm64-cpu` に変更する。
## 関連 Issue

#449

## その他
