### PR TITLE
octocrabを更新

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,12 +299,6 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
-
-[[package]]
-name = "base64"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
@@ -1488,22 +1482,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyperx"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5617e92fc2f2501c3e2bc6ce547cad841adba2bae5b921c7e52510beca6d084c"
-dependencies = [
- "base64 0.13.0",
- "bytes 1.1.0",
- "http",
- "httpdate",
- "language-tags",
- "mime",
- "percent-encoding",
- "unicase",
-]
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,12 +1671,6 @@ checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
 dependencies = [
  "log",
 ]
-
-[[package]]
-name = "language-tags"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 
 [[package]]
 name = "lazy_static"
@@ -2014,19 +1986,19 @@ dependencies = [
 
 [[package]]
 name = "octocrab"
-version = "0.18.1"
-source = "git+https://github.com/XAMPPRocky/octocrab.git?rev=7db3611fce5a19c6e84ca60958da0631d54d3713#7db3611fce5a19c6e84ca60958da0631d54d3713"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "496442a5ec5ad38376a0c49bc0f31ba55dbda5276cf12757498c378c3bc2ea1c"
 dependencies = [
  "arc-swap",
  "async-trait",
- "base64 0.20.0",
+ "base64 0.21.0",
  "bytes 1.1.0",
  "cfg-if",
  "chrono",
  "either",
  "futures-core",
  "futures-util",
- "hyperx",
  "jsonwebtoken",
  "once_cell",
  "reqwest",
@@ -2035,6 +2007,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "snafu",
+ "tracing",
  "url",
 ]
 
@@ -2101,9 +2074,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.80"
+version = "0.9.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+checksum = "666416d899cf077260dac8698d60a60b435a46d57e82acb1be3d0dad87284e5b"
 dependencies = [
  "autocfg",
  "cc",

--- a/crates/download/Cargo.toml
+++ b/crates/download/Cargo.toml
@@ -15,7 +15,7 @@ futures-core = "0.3.25"
 futures-util = "0.3.25"
 indicatif = "0.17.3"
 itertools = "0.10.5"
-octocrab = { git = "https://github.com/XAMPPRocky/octocrab.git", rev = "7db3611fce5a19c6e84ca60958da0631d54d3713", default-features = false, features = ["rustls-tls", "stream"] }
+octocrab = { version = "0.19.0", default-features = false, features = ["rustls-tls", "stream"] }
 once_cell.workspace = true
 platforms = "3.0.2"
 rayon = "1.6.1"

--- a/deny.toml
+++ b/deny.toml
@@ -165,7 +165,6 @@ allow-build-scripts = [
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-org = { github = [
-    "XAMPPRocky", # https://github.com/VOICEVOX/voicevox_core/pull/375#discussion_r1089642845
     "VOICEVOX",
     "wesleywiser", # https://github.com/VOICEVOX/voicevox_core/issues/437#issuecomment-1465078889
 ] }


### PR DESCRIPTION
## 内容

<https://github.com/XAMPPRocky/octocrab/pull/296>が含まれたoctocrab v0.19.0が出たのでそちらに切り替えます。

`git`指定のdependencyは`cargo upgrade`の対象にならないため、やらないと忘れる類かと思うのでこうして単体でPRを出しておきます。

## 関連 Issue

- #375

## その他
