### PR TITLE
Fix up #392

### DIFF
--- a/crates/voicevox_core_c_api/src/helpers.rs
+++ b/crates/voicevox_core_c_api/src/helpers.rs
@@ -203,9 +203,11 @@ impl BufferManager {
         (ptr, len)
     }
 
-    /// vec_into_rawでC API利用側に貸し出したポインタに対し、デアロケートする
+    /// `vec_into_raw`でC API利用側に貸し出したポインタに対し、デアロケートする。
+    ///
     /// # Safety
-    /// @param buffer_ptr 必ずvec_into_rawで取得したポインタを設定する
+    ///
+    /// - `buffer_ptr`は`vec_into_raw`で取得したものであること。
     pub unsafe fn dealloc_slice<T: Copy>(&mut self, buffer_ptr: *const T) {
         let addr = buffer_ptr as usize;
         let layout = self.address_to_layout_table.remove(&addr).expect(
@@ -227,9 +229,11 @@ impl BufferManager {
         s.into_raw() as *const c_char
     }
 
-    /// c_string_into_rawでリークしたポインタをCStringに戻す
+    /// `c_string_into_raw`でリークしたポインタをCStringに戻す。
+    ///
     /// # Safety
-    /// @param s 必ずc_string_into_rawで取得したポインタを設定する
+    ///
+    /// - `s` は`c_string_into_raw`で取得したものであること。
     pub unsafe fn dealloc_c_string(&mut self, s: *const c_char) {
         // SAFETY:
         // - `s`は`CString::into_raw`で得たものである

--- a/crates/voicevox_core_c_api/src/helpers.rs
+++ b/crates/voicevox_core_c_api/src/helpers.rs
@@ -236,3 +236,71 @@ impl BufferManager {
         drop(CString::from_raw(s as *mut c_char));
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn buffer_manager_works() {
+        let mut buffer_manager = BufferManager::new();
+
+        unsafe {
+            let (ptr, len) = buffer_manager.vec_into_raw(vec![()]);
+            assert_eq!(1, len);
+            buffer_manager.dealloc_slice(ptr);
+        }
+
+        unsafe {
+            let (ptr, len) = buffer_manager.vec_into_raw(Vec::<u8>::new());
+            assert_eq!(0, len);
+            buffer_manager.dealloc_slice(ptr);
+        }
+
+        unsafe {
+            let (ptr, len) = buffer_manager.vec_into_raw(vec![0u8]);
+            assert_eq!(1, len);
+            buffer_manager.dealloc_slice(ptr);
+        }
+
+        unsafe {
+            let mut vec = Vec::with_capacity(2);
+            vec.push(0u8);
+            let (ptr, len) = buffer_manager.vec_into_raw(vec);
+            assert_eq!(1, len);
+            buffer_manager.dealloc_slice(ptr);
+        }
+
+        unsafe {
+            let (ptr, len) = buffer_manager.vec_into_raw(Vec::<f32>::new());
+            assert_eq!(0, len);
+            buffer_manager.dealloc_slice(ptr);
+        }
+
+        unsafe {
+            let (ptr, len) = buffer_manager.vec_into_raw(vec![0f32]);
+            assert_eq!(1, len);
+            buffer_manager.dealloc_slice(ptr);
+        }
+
+        unsafe {
+            let mut vec = Vec::with_capacity(2);
+            vec.push(0f32);
+            let (ptr, len) = buffer_manager.vec_into_raw(vec);
+            assert_eq!(1, len);
+            buffer_manager.dealloc_slice(ptr);
+        }
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "解放しようとしたポインタはvoicevox_coreの管理下にありません。誤ったポインタであるか、二重解放になっていることが考えられます"
+    )]
+    fn buffer_manager_denies_unknown_ptr() {
+        let mut buffer_manager = BufferManager::new();
+        unsafe {
+            let x = 42;
+            buffer_manager.dealloc_slice(&x as *const i32);
+        }
+    }
+}

--- a/crates/voicevox_core_c_api/src/helpers.rs
+++ b/crates/voicevox_core_c_api/src/helpers.rs
@@ -243,17 +243,14 @@ impl BufferManager {
         Vec::from_raw_parts(buffer_ptr as *mut T, size_info.len(), size_info.cap())
     }
 
-    pub fn leak_c_string(&mut self, s: CString) -> (*const c_char, usize) {
-        let (ptr, size) = self.leak_vec(s.into_bytes_with_nul());
-
-        (ptr as *const c_char, size)
+    pub fn c_string_into_raw(&mut self, s: CString) -> *const c_char {
+        s.into_raw() as *const c_char
     }
 
-    /// leak_c_stringでリークしたポインタをCStringに戻す
+    /// c_string_into_rawでリークしたポインタをCStringに戻す
     /// # Safety
-    /// @param buffer_ptr 必ずleak_c_stringで取得したポインタを設定する
-    pub unsafe fn restore_c_string(&mut self, buffer_ptr: *const c_char) -> CString {
-        let vec = self.restore_vec(buffer_ptr as *const u8);
-        CString::from_vec_unchecked(vec)
+    /// @param s 必ずc_string_into_rawで取得したポインタを設定する
+    pub unsafe fn dealloc_c_string(&mut self, s: *const c_char) {
+        drop(CString::from_raw(s as *mut c_char));
     }
 }

--- a/crates/voicevox_core_c_api/src/helpers.rs
+++ b/crates/voicevox_core_c_api/src/helpers.rs
@@ -288,50 +288,31 @@ mod tests {
     fn buffer_manager_works() {
         let mut buffer_manager = BufferManager::new();
 
-        unsafe {
-            let (ptr, len) = buffer_manager.vec_into_raw(vec![()]);
-            assert_eq!(1, len);
-            buffer_manager.dealloc_slice(ptr);
-        }
+        rent_and_dealloc(&mut buffer_manager, vec::<()>(0, &[]));
+        rent_and_dealloc(&mut buffer_manager, vec(0, &[()]));
+        rent_and_dealloc(&mut buffer_manager, vec(2, &[()]));
 
-        unsafe {
-            let (ptr, len) = buffer_manager.vec_into_raw(Vec::<u8>::new());
-            assert_eq!(0, len);
-            buffer_manager.dealloc_slice(ptr);
-        }
+        rent_and_dealloc(&mut buffer_manager, vec::<u8>(0, &[]));
+        rent_and_dealloc(&mut buffer_manager, vec(0, &[0u8]));
+        rent_and_dealloc(&mut buffer_manager, vec(2, &[0u8]));
 
-        unsafe {
-            let (ptr, len) = buffer_manager.vec_into_raw(vec![0u8]);
-            assert_eq!(1, len);
-            buffer_manager.dealloc_slice(ptr);
-        }
+        rent_and_dealloc(&mut buffer_manager, vec::<f32>(0, &[]));
+        rent_and_dealloc(&mut buffer_manager, vec(0, &[0f32]));
+        rent_and_dealloc(&mut buffer_manager, vec(2, &[0f32]));
 
-        unsafe {
-            let mut vec = Vec::with_capacity(2);
-            vec.push(0u8);
+        fn rent_and_dealloc(buffer_manager: &mut BufferManager, vec: Vec<impl Copy>) {
+            let expected_len = vec.len();
             let (ptr, len) = buffer_manager.vec_into_raw(vec);
-            assert_eq!(1, len);
-            buffer_manager.dealloc_slice(ptr);
+            assert_eq!(expected_len, len);
+            unsafe {
+                buffer_manager.dealloc_slice(ptr);
+            }
         }
 
-        unsafe {
-            let (ptr, len) = buffer_manager.vec_into_raw(Vec::<f32>::new());
-            assert_eq!(0, len);
-            buffer_manager.dealloc_slice(ptr);
-        }
-
-        unsafe {
-            let (ptr, len) = buffer_manager.vec_into_raw(vec![0f32]);
-            assert_eq!(1, len);
-            buffer_manager.dealloc_slice(ptr);
-        }
-
-        unsafe {
-            let mut vec = Vec::with_capacity(2);
-            vec.push(0f32);
-            let (ptr, len) = buffer_manager.vec_into_raw(vec);
-            assert_eq!(1, len);
-            buffer_manager.dealloc_slice(ptr);
+        fn vec<T: Copy>(initial_cap: usize, elems: &[T]) -> Vec<T> {
+            let mut vec = Vec::with_capacity(initial_cap);
+            vec.extend_from_slice(elems);
+            vec
         }
     }
 

--- a/crates/voicevox_core_c_api/src/helpers.rs
+++ b/crates/voicevox_core_c_api/src/helpers.rs
@@ -278,21 +278,6 @@ impl BufferManager {
             std::alloc::dealloc(addr as *mut u8, layout);
         }
     }
-
-    pub fn c_string_into_raw(&mut self, s: CString) -> *const c_char {
-        s.into_raw() as *const c_char
-    }
-
-    /// `c_string_into_raw`でリークしたポインタをCStringに戻す。
-    ///
-    /// # Safety
-    ///
-    /// - `s` は`c_string_into_raw`で取得したものであること。
-    pub unsafe fn dealloc_c_string(&mut self, s: *const c_char) {
-        // SAFETY:
-        // - `s`は`CString::into_raw`で得たものである
-        drop(CString::from_raw(s as *mut c_char));
-    }
 }
 
 #[cfg(test)]

--- a/crates/voicevox_core_c_api/src/helpers.rs
+++ b/crates/voicevox_core_c_api/src/helpers.rs
@@ -229,6 +229,9 @@ impl Default for VoicevoxSynthesisOptions {
     }
 }
 
+// libcのmallocで追加のアロケーションを行うことなく、`Vec<u8>`や`Vec<f32>`の内容を直接Cの世界に貸し出す。
+
+/// Rustの世界の`Box<[impl Copy]>`をCの世界に貸し出すため、アドレスとレイアウトを管理するもの。
 pub(crate) struct BufferManager {
     address_to_layout_table: BTreeMap<usize, Layout>,
 }

--- a/crates/voicevox_core_c_api/src/helpers.rs
+++ b/crates/voicevox_core_c_api/src/helpers.rs
@@ -208,10 +208,10 @@ impl BufferManager {
     /// @param buffer_ptr 必ずvec_into_rawで取得したポインタを設定する
     pub unsafe fn dealloc_slice<T: Copy>(&mut self, buffer_ptr: *const T) {
         let addr = buffer_ptr as usize;
-        let layout = self
-            .address_to_layout_table
-            .remove(&addr)
-            .expect("管理されていないポインタを渡した");
+        let layout = self.address_to_layout_table.remove(&addr).expect(
+            "解放しようとしたポインタはvoicevox_coreの管理下にありません。\
+             誤ったポインタであるか、二重解放になっていることが考えられます",
+        );
 
         if layout.size() > 0 {
             // `T: Copy`より、`T: !Drop`であるため`drop_in_place`は不要

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -421,7 +421,10 @@ pub unsafe extern "C" fn voicevox_accent_phrases(
         let accent_phrases =
             create_accent_phrases(text, speaker_id, Internal::accent_phrases, options)?;
 
-        let (ptr, _) = BUFFER_MANAGER.lock().unwrap().leak_c_string(accent_phrases);
+        let ptr = BUFFER_MANAGER
+            .lock()
+            .unwrap()
+            .c_string_into_raw(accent_phrases);
         output_accent_phrases_json.write(ptr as *mut c_char);
         Ok(())
     })())
@@ -452,10 +455,10 @@ pub unsafe extern "C" fn voicevox_mora_length(
         let accent_phrases_with_mora_length =
             modify_accent_phrases(&accent_phrases, speaker_id, Internal::mora_length)?;
 
-        let (ptr, _) = BUFFER_MANAGER
+        let ptr = BUFFER_MANAGER
             .lock()
             .unwrap()
-            .leak_c_string(accent_phrases_with_mora_length);
+            .c_string_into_raw(accent_phrases_with_mora_length);
         output_accent_phrases_json.write(ptr as *mut c_char);
         Ok(())
     })())
@@ -486,10 +489,10 @@ pub unsafe extern "C" fn voicevox_mora_pitch(
         let accent_phrases_with_mora_pitch =
             modify_accent_phrases(&accent_phrases, speaker_id, Internal::mora_pitch)?;
 
-        let (ptr, _) = BUFFER_MANAGER
+        let ptr = BUFFER_MANAGER
             .lock()
             .unwrap()
-            .leak_c_string(accent_phrases_with_mora_pitch);
+            .c_string_into_raw(accent_phrases_with_mora_pitch);
         output_accent_phrases_json.write(ptr as *mut c_char);
         Ok(())
     })())
@@ -520,10 +523,10 @@ pub unsafe extern "C" fn voicevox_mora_data(
         let accent_phrases_with_mora_data =
             modify_accent_phrases(&accent_phrases, speaker_id, Internal::mora_data)?;
 
-        let (ptr, _) = BUFFER_MANAGER
+        let ptr = BUFFER_MANAGER
             .lock()
             .unwrap()
-            .leak_c_string(accent_phrases_with_mora_data);
+            .c_string_into_raw(accent_phrases_with_mora_data);
         output_accent_phrases_json.write(ptr as *mut c_char);
         Ok(())
     })())

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -376,11 +376,7 @@ pub unsafe extern "C" fn voicevox_audio_query(
         let text = CStr::from_ptr(text);
         let audio_query = create_audio_query(text, speaker_id, Internal::audio_query, options)?;
 
-        let ptr = BUFFER_MANAGER
-            .lock()
-            .unwrap()
-            .c_string_into_raw(audio_query);
-        output_audio_query_json.write(ptr as *mut c_char);
+        output_audio_query_json.write(audio_query.into_raw());
         Ok(())
     })())
 }
@@ -421,11 +417,7 @@ pub unsafe extern "C" fn voicevox_accent_phrases(
         let accent_phrases =
             create_accent_phrases(text, speaker_id, Internal::accent_phrases, options)?;
 
-        let ptr = BUFFER_MANAGER
-            .lock()
-            .unwrap()
-            .c_string_into_raw(accent_phrases);
-        output_accent_phrases_json.write(ptr as *mut c_char);
+        output_accent_phrases_json.write(accent_phrases.into_raw());
         Ok(())
     })())
 }
@@ -455,11 +447,7 @@ pub unsafe extern "C" fn voicevox_mora_length(
         let accent_phrases_with_mora_length =
             modify_accent_phrases(&accent_phrases, speaker_id, Internal::mora_length)?;
 
-        let ptr = BUFFER_MANAGER
-            .lock()
-            .unwrap()
-            .c_string_into_raw(accent_phrases_with_mora_length);
-        output_accent_phrases_json.write(ptr as *mut c_char);
+        output_accent_phrases_json.write(accent_phrases_with_mora_length.into_raw());
         Ok(())
     })())
 }
@@ -489,11 +477,7 @@ pub unsafe extern "C" fn voicevox_mora_pitch(
         let accent_phrases_with_mora_pitch =
             modify_accent_phrases(&accent_phrases, speaker_id, Internal::mora_pitch)?;
 
-        let ptr = BUFFER_MANAGER
-            .lock()
-            .unwrap()
-            .c_string_into_raw(accent_phrases_with_mora_pitch);
-        output_accent_phrases_json.write(ptr as *mut c_char);
+        output_accent_phrases_json.write(accent_phrases_with_mora_pitch.into_raw());
         Ok(())
     })())
 }
@@ -523,11 +507,7 @@ pub unsafe extern "C" fn voicevox_mora_data(
         let accent_phrases_with_mora_data =
             modify_accent_phrases(&accent_phrases, speaker_id, Internal::mora_data)?;
 
-        let ptr = BUFFER_MANAGER
-            .lock()
-            .unwrap()
-            .c_string_into_raw(accent_phrases_with_mora_data);
-        output_accent_phrases_json.write(ptr as *mut c_char);
+        output_accent_phrases_json.write(accent_phrases_with_mora_data.into_raw());
         Ok(())
     })())
 }
@@ -633,10 +613,7 @@ pub unsafe extern "C" fn voicevox_tts(
 /// @param voicevox_audio_query で確保されたポインタであり、かつ呼び出し側でバッファの変更を行われていないこと
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_audio_query_json_free(audio_query_json: *mut c_char) {
-    BUFFER_MANAGER
-        .lock()
-        .unwrap()
-        .dealloc_c_string(audio_query_json as *const c_char);
+    drop(CString::from_raw(audio_query_json));
 }
 
 /// jsonフォーマットされた AccnetPhrase データのメモリを解放する
@@ -646,7 +623,7 @@ pub unsafe extern "C" fn voicevox_audio_query_json_free(audio_query_json: *mut c
 /// @param voicevox_accent_phrases で確保されたポインタであり、かつ呼び出し側でバッファの変更を行われていないこと
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_accent_phrases_json_free(accented_phrase_json: *mut c_char) {
-    voicevox_audio_query_json_free(accented_phrase_json);
+    drop(CString::from_raw(accented_phrase_json));
 }
 
 /// wav データのメモリを解放する


### PR DESCRIPTION
## 内容

#392 で入った内容に対して、次の5つの変更を行います。変更はこれらの名前そのままの5つのコミットに分割してあります。

- `CStr`の長さは記憶しない

    rust-lang/regexのC向けAPIである[rure](https://crates.io/crates/rure)の実装を参考にして、`CString`の長さはこちらでは記録しないようにしました。

- 余剰`capacity`は貸し出す前に削る

    `Vec::into_boxed_slice`は余剰capacityをちゃんと消し飛ばしてくれることがわかっているため、余剰`capacity`は記憶しないようにします。

    `T: Copy`を要求すれば`T: !Drop`が保証されるため、[`Layout`](https://doc.rust-lang.org/stable/std/alloc/struct.Layout.html)を保存してデアロケートに使うことにしました。

- パニックのメッセージを変更

    `"すでに値が入っている状態はおかしい"`はともかく`"管理されていないポインタを渡した"`は実際にエラーメッセージとして機能する可能性があるので、ユーザー向けのメッセージにしました。

- 簡単なテストを追加する

    soundnessを確認するテストは書けませんが、とりあえず一通り動作だけさせるものを追加しておきました。
    (追記) 管理下にないポインタを入れるとパニックしてメッセージを出すものも追加しておきました。

- privateなrustdocはrustdocのスタイルで書く

	Doxygen用でもないprivateな純粋なrustdocは、rustdocのスタイルに合わせるようにしました。

## 関連 Issue

- #392

## その他
