### PR TITLE
example/pythonの`logging`を改善

### DIFF
--- a/example/python/run.py
+++ b/example/python/run.py
@@ -12,9 +12,7 @@ SPEAKER_ID = 0
 
 
 def main() -> None:
-    logging.basicConfig(
-        format="[%(levelname)s] %(filename)s: %(message)s", level="DEBUG"
-    )
+    logging.basicConfig(format="[%(levelname)s] %(name)s: %(message)s", level="DEBUG")
     logger = logging.getLogger(__name__)
 
     (acceleration_mode, open_jtalk_dict_dir, text, out) = parse_args()

--- a/example/python/run.py
+++ b/example/python/run.py
@@ -12,8 +12,11 @@ SPEAKER_ID = 0
 
 
 def main() -> None:
-    logging.basicConfig(format="[%(levelname)s] %(name)s: %(message)s", level="DEBUG")
+    logging.basicConfig(format="[%(levelname)s] %(name)s: %(message)s")
     logger = logging.getLogger(__name__)
+    logger.setLevel("DEBUG")
+    logging.getLogger("voicevox_core_python_api").setLevel("DEBUG")
+    logging.getLogger("voicevox_core").setLevel("DEBUG")
 
     (acceleration_mode, open_jtalk_dict_dir, text, out) = parse_args()
 


### PR DESCRIPTION
## 内容

example/python/run.pyの`logging`の設定に以下の変更を加えます。

1. `logging`の`format`において、`%(filename)s`を`%(name)s`に

    <details>
    <summary>Before</summary>

    ```console
    ❯ python ./run.py ./open_jtalk_dic_utf_8-1.11 これはテストです ./audio.wav
    [DEBUG] run.py: voicevox_core.METAS=[Meta(name='dummy1', styles=[Style(name='style1', id=0)], speaker_uuid='574bc678-8370-44be-b941-08e46e7b47d7', version='0.0.1'), Meta(name='dummy2', styles=[Style(name='style2', id=1)], speaker_uuid='dd9ccd75-75f6-40ce-a3db-960cbed2e905', version='0.0.1'), Meta(name='dummy3', styles=[Style(name='style3-1', id=2), Style(name='style3-2', id=3)], speaker_uuid='5d3d9aa9-88e5-4a96-8ef7-f13a3cad1cb3', version='0.0.1')]
    [DEBUG] run.py: voicevox_core.SUPPORTED_DEVICES=SupportedDevices(cpu=True, cuda=False, dml=False)
    [INFO] run.py: Initializing (acceleration_mode=<AccelerationMode.AUTO: 'AUTO'>, open_jtalk_dict_dir=PosixPath('open_jtalk_dic_utf_8-1.11'))
    [DEBUG] run.py: core.is_gpu_mode=False
    [INFO] run.py: Loading model 0
    [DEBUG] run.py: core.is_model_loaded(0)=True
    [INFO] run.py: Creating an AudioQuery from 'これはテストです'
    [INFO] run.py: Synthesizing with {"accent_phrases": [{"moras": [{"text": "コ", "consonant": "k", "consonant_length": 0.063058704, "vowel": "o", "vowel_length": 0.08937682, "pitch": 5.5699606}, {"text": "レ", "consonant": "r", "consonant_length": 0.047547057, "vowel": "e", "vowel_length": 0.07596417, "pitch": 5.6643105}, {"text": "ワ", "consonant": "w", "consonant_length": 0.053706698, "vowel": "a", "vowel_length": 0.10348523, "pitch": 5.7773266}], "accent": 3, "pause_mora": null, "is_interrogative": false}, {"moras": [{"text": "テ", "consonant": "t", "consonant_length": 0.06311223, "vowel": "e", "vowel_length": 0.07596652, "pitch": 5.8817406}, {"text": "ス", "consonant": "s", "consonant_length": 0.038565055, "vowel": "U", "vowel_length": 0.050694168, "pitch": 0.0}, {"text": "ト", "consonant": "t", "consonant_length": 0.06685759, "vowel": "o", "vowel_length": 0.0753997, "pitch": 5.7373238}, {"text": "デ", "consonant": "d", "consonant_length": 0.058399618, "vowel": "e", "vowel_length": 0.09201351, "pitch": 5.474717}, {"text": "ス", "consonant": "s", "consonant_length": 0.08852549, "vowel": "U", "vowel_length": 0.1281984, "pitch": 0.0}], "accent": 1, "pause_mora": null, "is_interrogative": false}], "speed_scale": 1.0, "pitch_scale": 0.0, "intonation_scale": 1.0, "volume_scale": 1.0, "pre_phoneme_length": 0.1, "post_phoneme_length": 0.1, "output_sampling_rate": 24000, "output_stereo": false, "kana": "コレワ'/テ'_ストデ_ス"}
    [INFO] run.py: Wrote `audio.wav`
    [DEBUG] lib.rs: Destructing a VoicevoxCore
    ```

    </details>

    <details>
    <summary>After</summary>

    ```console
    ❯ python ./run.py ./open_jtalk_dic_utf_8-1.11 これはテストです ./audio.wav
    [DEBUG] __main__: voicevox_core.METAS=[Meta(name='dummy1', styles=[Style(name='style1', id=0)], speaker_uuid='574bc678-8370-44be-b941-08e46e7b47d7', version='0.0.1'), Meta(name='dummy2', styles=[Style(name='style2', id=1)], speaker_uuid='dd9ccd75-75f6-40ce-a3db-960cbed2e905', version='0.0.1'), Meta(name='dummy3', styles=[Style(name='style3-1', id=2), Style(name='style3-2', id=3)], speaker_uuid='5d3d9aa9-88e5-4a96-8ef7-f13a3cad1cb3', version='0.0.1')]
    [DEBUG] __main__: voicevox_core.SUPPORTED_DEVICES=SupportedDevices(cpu=True, cuda=False, dml=False)
    [INFO] __main__: Initializing (acceleration_mode=<AccelerationMode.AUTO: 'AUTO'>, open_jtalk_dict_dir=PosixPath('open_jtalk_dic_utf_8-1.11'))
    [DEBUG] __main__: core.is_gpu_mode=False
    [INFO] __main__: Loading model 0
    [DEBUG] __main__: core.is_model_loaded(0)=True
    [INFO] __main__: Creating an AudioQuery from 'これはテストです'
    [INFO] __main__: Synthesizing with {"accent_phrases": [{"moras": [{"text": "コ", "consonant": "k", "consonant_length": 0.063058704, "vowel": "o", "vowel_length": 0.08937682, "pitch": 5.5699606}, {"text": "レ", "consonant": "r", "consonant_length": 0.047547057, "vowel": "e", "vowel_length": 0.07596417, "pitch": 5.6643105}, {"text": "ワ", "consonant": "w", "consonant_length": 0.053706698, "vowel": "a", "vowel_length": 0.10348523, "pitch": 5.7773266}], "accent": 3, "pause_mora": null, "is_interrogative": false}, {"moras": [{"text": "テ", "consonant": "t", "consonant_length": 0.06311223, "vowel": "e", "vowel_length": 0.07596652, "pitch": 5.8817406}, {"text": "ス", "consonant": "s", "consonant_length": 0.038565055, "vowel": "U", "vowel_length": 0.050694168, "pitch": 0.0}, {"text": "ト", "consonant": "t", "consonant_length": 0.06685759, "vowel": "o", "vowel_length": 0.0753997, "pitch": 5.7373238}, {"text": "デ", "consonant": "d", "consonant_length": 0.058399618, "vowel": "e", "vowel_length": 0.09201351, "pitch": 5.474717}, {"text": "ス", "consonant": "s", "consonant_length": 0.08852549, "vowel": "U", "vowel_length": 0.1281984, "pitch": 0.0}], "accent": 1, "pause_mora": null, "is_interrogative": false}], "speed_scale": 1.0, "pitch_scale": 0.0, "intonation_scale": 1.0, "volume_scale": 1.0, "pre_phoneme_length": 0.1, "post_phoneme_length": 0.1, "output_sampling_rate": 24000, "output_stereo": false, "kana": "コレワ'/テ'_ストデ_ス"}
    [INFO] __main__: Wrote `audio.wav`
    [DEBUG] voicevox_core_python_api: Destructing a VoicevoxCore
    ```
    </details>

    pyo3-logは[Rustの世界の`::`区切りのモジュール名をわざわざ`.`区切りにしてまでPythonの世界の名前であるかのように扱っている](https://github.com/vorner/pyo3-log/blob/v0.8.1/src/lib.rs#L396)ため混乱が起きないかと思いはするのですが、`%(filename)s`もlib.rsとかmod.rsとかだけになって情報量が無なので、`%(name)s`の方がまだいいかなと思っています。

2. 対象モジュールを`__main__` (i.e. run.py), `voicevox_core_python_api` (Rustのモジュール), `voicevox_core` (Rustのモジュール) の3つに限定する

    <https://github.com/VOICEVOX/voicevox_core/pull/370>で[async\_zip](https://docs.rs/crate/async_zip)のログが出るようになってしまったので、それを抑える目的です。

## 関連 Issue

- #370

## その他
