### PR TITLE
Add: #479 のPython APIを追加

### DIFF
--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust.pyi
@@ -4,7 +4,7 @@ from typing import Final, List, Literal, Union
 import numpy as np
 from numpy.typing import NDArray
 
-from voicevox_core import AccelerationMode, AudioQuery, Meta, SupportedDevices
+from voicevox_core import AccelerationMode, AccentPhrase, AudioQuery, Meta, SupportedDevices
 
 METAS: Final[List[Meta]]
 SUPPORTED_DEVICES: Final[SupportedDevices]
@@ -164,6 +164,82 @@ class VoicevoxCore:
         Returns
         -------
         :class:`AudioQuery`
+        """
+        ...
+    def accent_phrases(
+        self,
+        text: str,
+        speaker_id: int,
+        kana: bool = False,
+    ) -> List[AccentPhrase]:
+        """`accent_phrases` を実行する。
+
+        Parameters
+        ----------
+        text
+            テキスト。文字コードはUTF-8。
+        speaker_id
+            話者ID。
+        kana
+            aquestalk形式のkanaとしてテキストを解釈する。
+
+        Returns
+        -------
+        :class:`List` [:class:`AccentPhrase`]
+        """
+        ...
+    def mora_length( self,
+        accent_phrases: List[AccentPhrase],
+        speaker_id: int,
+    ) -> List[AccentPhrase]:
+        """アクセント句の音素長を変更する
+
+        Parameters
+        ----------
+        accent_phrases
+            変更元のアクセント句。
+        speaker_id
+            話者ID。
+
+        Returns
+        -------
+        :class:`List` [:class:`AccentPhrase`]
+        """
+        ...
+    def mora_pitch( self,
+        accent_phrases: List[AccentPhrase],
+        speaker_id: int,
+    ) -> List[AccentPhrase]:
+        """アクセント句の音高を変更する
+
+        Parameters
+        ----------
+        accent_phrases
+            変更元のアクセント句。
+        speaker_id
+            話者ID。
+
+        Returns
+        -------
+        :class:`List` [:class:`AccentPhrase`]
+        """
+        ...
+    def mora_data( self,
+        accent_phrases: List[AccentPhrase],
+        speaker_id: int,
+    ) -> List[AccentPhrase]:
+        """アクセント句の音高・音素長を変更する
+
+        Parameters
+        ----------
+        accent_phrases
+            変更元のアクセント句。
+        speaker_id
+            話者ID。
+
+        Returns
+        -------
+        :class:`List` [:class:`AccentPhrase`]
         """
         ...
     def synthesis(

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -201,7 +201,82 @@ impl VoicevoxCore {
                     py.import("voicevox_core")?.getattr("AccentPhrase")?,
                 )
             })
-            .collect::<PyResult<Vec<_>>>()
+            .collect()
+    }
+
+    fn mora_length<'py>(
+        &mut self,
+        accent_phrases: Vec<&'py PyAny>,
+        speaker_id: u32,
+        py: Python<'py>,
+    ) -> PyResult<Vec<&'py PyAny>> {
+        let rust_accent_phrases = accent_phrases
+            .iter()
+            .map(|a| from_dataclass::<AccentPhraseModel>(a))
+            .collect::<PyResult<Vec<_>>>()?;
+        let replaced_accent_phrases = &self
+            .inner
+            .mora_length(speaker_id, &rust_accent_phrases)
+            .into_py_result()?;
+        replaced_accent_phrases
+            .iter()
+            .map(|accent_phrase| {
+                to_pydantic_dataclass(
+                    accent_phrase,
+                    py.import("voicevox_core")?.getattr("AccentPhrase")?,
+                )
+            })
+            .collect()
+    }
+
+    fn mora_pitch<'py>(
+        &mut self,
+        accent_phrases: Vec<&'py PyAny>,
+        speaker_id: u32,
+        py: Python<'py>,
+    ) -> PyResult<Vec<&'py PyAny>> {
+        let rust_accent_phrases = accent_phrases
+            .iter()
+            .map(|a| from_dataclass::<AccentPhraseModel>(a))
+            .collect::<PyResult<Vec<_>>>()?;
+        let replaced_accent_phrases = &self
+            .inner
+            .mora_pitch(speaker_id, &rust_accent_phrases)
+            .into_py_result()?;
+        replaced_accent_phrases
+            .iter()
+            .map(|accent_phrase| {
+                to_pydantic_dataclass(
+                    accent_phrase,
+                    py.import("voicevox_core")?.getattr("AccentPhrase")?,
+                )
+            })
+            .collect()
+    }
+
+    fn mora_data<'py>(
+        &mut self,
+        accent_phrases: Vec<&'py PyAny>,
+        speaker_id: u32,
+        py: Python<'py>,
+    ) -> PyResult<Vec<&'py PyAny>> {
+        let rust_accent_phrases = accent_phrases
+            .iter()
+            .map(|a| from_dataclass::<AccentPhraseModel>(a))
+            .collect::<PyResult<Vec<_>>>()?;
+        let replaced_accent_phrases = &self
+            .inner
+            .mora_data(speaker_id, &rust_accent_phrases)
+            .into_py_result()?;
+        replaced_accent_phrases
+            .iter()
+            .map(|accent_phrase| {
+                to_pydantic_dataclass(
+                    accent_phrase,
+                    py.import("voicevox_core")?.getattr("AccentPhrase")?,
+                )
+            })
+            .collect()
     }
 
     #[args(enable_interrogative_upspeak = "TtsOptions::default().enable_interrogative_upspeak")]

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -12,8 +12,8 @@ use pyo3::{
 };
 use serde::{de::DeserializeOwned, Serialize};
 use voicevox_core::{
-    AccelerationMode, AudioQueryModel, AudioQueryOptions, InitializeOptions, SynthesisOptions,
-    TtsOptions,
+    AccelerationMode, AccentPhraseModel, AccentPhrasesOptions, AudioQueryModel, AudioQueryOptions,
+    InitializeOptions, SynthesisOptions, TtsOptions,
 };
 
 #[pymodule]
@@ -179,6 +179,29 @@ impl VoicevoxCore {
             audio_query,
             py.import("voicevox_core")?.getattr("AudioQuery")?,
         )
+    }
+
+    #[args(kana = "AccentPhrasesOptions::default().kana")]
+    fn accent_phrases<'py>(
+        &mut self,
+        text: &str,
+        speaker_id: u32,
+        kana: bool,
+        py: Python<'py>,
+    ) -> PyResult<Vec<&'py PyAny>> {
+        let accent_phrases = &self
+            .inner
+            .accent_phrases(text, speaker_id, AccentPhrasesOptions { kana })
+            .into_py_result()?;
+        accent_phrases
+            .iter()
+            .map(|accent_phrase| {
+                to_pydantic_dataclass(
+                    accent_phrase,
+                    py.import("voicevox_core")?.getattr("AccentPhrase")?,
+                )
+            })
+            .collect::<PyResult<Vec<_>>>()
     }
 
     #[args(enable_interrogative_upspeak = "TtsOptions::default().enable_interrogative_upspeak")]


### PR DESCRIPTION
## 内容

タイトル通り。

## 関連 Issue

- closes: #480

## その他

Rustは勉強中なので非効率的な書き方かも知れません。

<details>
<summary>サンプル</summary>

```py
import ctypes
import os
from pprint import pprint

ctypes.cdll.LoadLibrary(
    "/home/sevenc7c/onnxruntime-linux-x64-1.14.0/lib/libonnxruntime.so.1.14.0"
)
os.environ["VV_MODELS_ROOT_DIR"] = "/home/sevenc7c/voicevox/core/model"

import voicevox_core

c = voicevox_core.VoicevoxCore(
    open_jtalk_dict_dir="/home/sevenc7c/open_jtalk_dic_utf_8-1.11"
)
c.load_model(0)

base_phrases = c.accent_phrases("もち", 0)
pprint(base_phrases)

length_replaced = c.mora_length(base_phrases, 1)
pprint(length_replaced)

pitch_replaced = c.mora_pitch(base_phrases, 1)
pprint(pitch_replaced)

data_replaced = c.mora_data(base_phrases, 1)
pprint(data_replaced)
```
```
❯ python3 __gi_test.py 
[AccentPhrase(moras=[Mora(text='モ', consonant='m', consonant_length=0.04455498, vowel='o', vowel_length=0.12857193, pitch=5.729677), Mora(text='チ', consonant='ch', consonant_length=0.10641824, vowel='i', vowel_length=0.14448714, pitch=5.9074173)], accent=2, pause_mora=None, is_interrogative=False)]
[AccentPhrase(moras=[Mora(text='モ', consonant='m', consonant_length=0.042567946, vowel='o', vowel_length=0.13342857, pitch=5.729677), Mora(text='チ', consonant='ch', consonant_length=0.11405793, vowel='i', vowel_length=0.18405052, pitch=5.9074173)], accent=2, pause_mora=None, is_interrogative=False)]
[AccentPhrase(moras=[Mora(text='モ', consonant='m', consonant_length=0.04455498, vowel='o', vowel_length=0.12857193, pitch=5.7345743), Mora(text='チ', consonant='ch', consonant_length=0.10641824, vowel='i', vowel_length=0.14448714, pitch=5.9614882)], accent=2, pause_mora=None, is_interrogative=False)]
[AccentPhrase(moras=[Mora(text='モ', consonant='m', consonant_length=0.042567946, vowel='o', vowel_length=0.13342857, pitch=5.7345743), Mora(text='チ', consonant='ch', consonant_length=0.11405793, vowel='i', vowel_length=0.18405052, pitch=5.9614882)], accent=2, pause_mora=None, is_interrogative=False)]
```

</details>