### PR TITLE
`#[serde(default)]`を入れる

### DIFF
--- a/crates/voicevox_core/src/engine/model.rs
+++ b/crates/voicevox_core/src/engine/model.rs
@@ -19,6 +19,7 @@ pub struct AccentPhraseModel {
     moras: Vec<MoraModel>,
     accent: usize,
     pause_mora: Option<MoraModel>,
+    #[serde(default)]
     is_interrogative: bool,
 }
 
@@ -44,6 +45,7 @@ pub struct AudioQueryModel {
     post_phoneme_length: f32,
     output_sampling_rate: u32,
     output_stereo: bool,
+    #[serde(default)]
     kana: String,
 }
 

--- a/crates/voicevox_core/src/engine/model.rs
+++ b/crates/voicevox_core/src/engine/model.rs
@@ -45,8 +45,7 @@ pub struct AudioQueryModel {
     post_phoneme_length: f32,
     output_sampling_rate: u32,
     output_stereo: bool,
-    #[serde(default)]
-    kana: String,
+    kana: Option<String>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 内容

`#[serde(default)]`を入れて、ENGINEでは省略可能なフィールドを省略できるようにします。

## 関連 Issue

- <https://github.com/VOICEVOX/voicevox_mobile/pull/19#discussion_r1187462625>

## その他
