### PR TITLE
Fix up #486

### DIFF
--- a/crates/voicevox_core/src/engine/model.rs
+++ b/crates/voicevox_core/src/engine/model.rs
@@ -57,7 +57,7 @@ mod tests {
     #[rstest]
     fn check_audio_query_model_json_field_snake_case() {
         let audio_query_model =
-            AudioQueryModel::new(vec![], 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0, false, "".into());
+            AudioQueryModel::new(vec![], 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0, false, None);
         let val = serde_json::to_value(audio_query_model).unwrap();
         check_json_field_snake_case(&val);
     }

--- a/crates/voicevox_core/src/publish.rs
+++ b/crates/voicevox_core/src/publish.rs
@@ -180,7 +180,7 @@ impl VoicevoxCore {
             0.1,
             SynthesisEngine::DEFAULT_SAMPLING_RATE,
             false,
-            kana,
+            Some(kana),
         ))
     }
 
@@ -1071,7 +1071,7 @@ mod tests {
             }
         }
 
-        assert_eq!(query.kana(), expected_kana_text);
+        assert_eq!(query.kana().as_deref(), Some(expected_kana_text));
     }
 
     #[rstest]


### PR DESCRIPTION
## 内容

#486 においてcommit suggestionを押した後CIを待たずにマージした結果、ビルドが通らない状態になっているため直します。

## 関連 Issue

- #486

## その他

Rustの`Option<T>`はPythonやTSのような合併型 (union type)ではなく、直和型 (sum type) (a.k.a. ADT, tagged union)と言えるものです。`T`は`Option<T>`のサブタイプではないため、値を書くときは`None`ではない場合も`Some(…)`と書く必要があります。
