### PR TITLE
Docs: 事例紹介にvoicevoxcore.goを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,8 @@ typos
 **[Node VOICEVOX Engine](https://github.com/y-chan/node-voicevox-engine) [@y-chan](https://github.com/y-chan)** ･･･ VOICEVOX ENGINE の Node.js/C++ 実装  
 **[VOICEVOX ENGINE SHARP](https://github.com/yamachu/VoicevoxEngineSharp) [@yamachu](https://github.com/yamachu)** ･･･ VOICEVOX ENGINE の C# 実装  
 **[voicevoxcore4s](https://github.com/windymelt/voicevoxcore4s) [@windymelt](https://github.com/windymelt)** ･･･ VOICEVOX CORE の Scala(JVM) 向け FFI ラッパー  
-**[voicevox_flutter](https://github.com/char5742/voicevox_flutter) [@char5742](https://github.com/char5742)** ･･･ VOICEVOX CORE の Flutter 向け FFI ラッパー  
+**[voicevox_flutter](https://github.com/char5742/voicevox_flutter) [@char5742](https://github.com/char5742)** ･･･ VOICEVOX CORE の Flutter 向け FFI ラッパー 
+**[voicevoxcore.go](https://github.com/sh1ma/voicevoxcore.go) [@sh1ma](https://github.com/sh1ma)** ･･･ VOICEVOX CORE の Go 言語 向け FFI ラッパー  
 ## ライセンス
 
 ソースコードのライセンスは [MIT LICENSE](./LICENSE) です。


### PR DESCRIPTION
## 内容

README.mdの事例紹介の項に拙作[voicevoxcore.go](https://github.com/sh1ma/voicevoxcore.go)を追加しました。

## 関連 Issue

特にありません。

## その他

特にありません。