### PR TITLE
[project-vvm-async-api] ドキュメントの表記ゆれを解消

### DIFF
--- a/crates/voicevox_core/src/metas.rs
+++ b/crates/voicevox_core/src/metas.rs
@@ -39,7 +39,7 @@ impl Display for StyleVersion {
     }
 }
 
-/// 音声合成モデルのメタ情報
+/// 音声モデルのメタ情報
 pub type VoiceModelMeta = Vec<SpeakerMeta>;
 
 /// スピーカーのメタ情報

--- a/crates/voicevox_core/src/voice_model.rs
+++ b/crates/voicevox_core/src/voice_model.rs
@@ -9,16 +9,16 @@ use std::{
     path::{Path, PathBuf},
 };
 
-/// 音声合成モデルIdの実体
+/// 音声モデルIdの実体
 pub type RawVoiceModelId = String;
 
-/// 音声合成モデルId (型を強く分けるためにこうしている)
+/// 音声モデルId (型を強く分けるためにこうしている)
 #[derive(PartialEq, Eq, Clone, Ord, PartialOrd, Deserialize, new, Getters, Debug)]
 pub struct VoiceModelId {
     raw_voice_model_id: RawVoiceModelId,
 }
 
-/// 音声合成モデル
+/// 音声モデル
 #[derive(Getters, Clone)]
 pub struct VoiceModel {
     id: VoiceModelId,

--- a/crates/voicevox_core/src/voice_synthesizer.rs
+++ b/crates/voicevox_core/src/voice_synthesizer.rs
@@ -122,7 +122,7 @@ impl Synthesizer {
         self.use_gpu
     }
 
-    /// 音声合成モデルを読み込む
+    /// 音声モデルを読み込む
     pub async fn load_voice_model(&mut self, model: &VoiceModel) -> Result<()> {
         self.synthesis_engine
             .inference_core_mut()
@@ -131,14 +131,14 @@ impl Synthesizer {
         Ok(())
     }
 
-    /// 指定したモデルIdの音声合成モデルを開放する
+    /// 指定したモデルIdの音声モデルを開放する
     pub fn unload_voice_model(&mut self, voice_model_id: &VoiceModelId) -> Result<()> {
         self.synthesis_engine
             .inference_core_mut()
             .unload_model(voice_model_id)
     }
 
-    /// 指定したモデルIdの音声合成モデルが読み込まれているか判定する
+    /// 指定したモデルIdの音声モデルが読み込まれているか判定する
     pub fn is_loaded_voice_model(&self, voice_model_id: &VoiceModelId) -> bool {
         self.synthesis_engine
             .inference_core()
@@ -152,7 +152,7 @@ impl Synthesizer {
             .is_model_loaded_by_style_id(style_id)
     }
 
-    /// 今読み込んでいる音声合成モデルのメタ情報を返す
+    /// 今読み込んでいる音声モデルのメタ情報を返す
     pub fn metas(&self) -> &VoiceModelMeta {
         self.synthesis_engine.inference_core().metas()
     }

--- a/crates/voicevox_core_c_api/include/voicevox_core.h
+++ b/crates/voicevox_core_c_api/include/voicevox_core.h
@@ -145,14 +145,14 @@ typedef struct VoicevoxInitializeOptions {
 } VoicevoxInitializeOptions;
 
 /**
- * 音声合成モデル
+ * 音声モデル
  */
 typedef struct VoicevoxVoiceModel {
 
 } VoicevoxVoiceModel;
 
 /**
- * 音声合成モデルID
+ * 音声モデルID
  */
 typedef const char *VoicevoxVoiceModelId;
 
@@ -320,7 +320,7 @@ void voicevox_voice_model_delete(struct VoicevoxVoiceModel *model);
  * 音声シンセサイザを生成して初期化する
  * @param [in] open_jtalk 参照カウントで管理されたOpenJtalk
  * @param [in] options 初期化オプション #VoicevoxInitializeOptions
- * @param [out] out_synthesizer 新しく生成された音声シンセサイザの出力先 #VoicevoxVoiceSynthesizer
+ * @param [out] out_synthesizer 新しく生成された音声シンセサイザの出力先 #VoicevoxSynthesizer
  * @return 結果コード #VoicevoxResultCode
  *
  * # Safety
@@ -336,10 +336,10 @@ VoicevoxResultCode voicevox_synthesizer_new_with_initialize(const struct OpenJta
 
 /**
  * 音声シンセサイザを破棄する
- * @param [in] synthesizer 破棄する音声シンセサイザ #VoicevoxVoiceSynthesizer
+ * @param [in] synthesizer 破棄する音声シンセサイザ #VoicevoxSynthesizer
  *
  * # Safety
- * @param synthesizer 有効な #VoicevoxVoiceSynthesizer へのポインタであること
+ * @param synthesizer 有効な #VoicevoxSynthesizer へのポインタであること
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -354,7 +354,7 @@ void voicevox_synthesizer_delete(struct VoicevoxSynthesizer *synthesizer);
  * @return 結果コード #VoicevoxResultCode
  *
  * # Safety
- * @param synthesizer 有効な #VoicevoxVoiceSynthesizer へのポインタであること
+ * @param synthesizer 有効な #VoicevoxSynthesizer へのポインタであること
  * @param model 有効な #VoicevoxVoiceModel へのポインタであること
  */
 #ifdef _WIN32
@@ -371,7 +371,7 @@ VoicevoxResultCode voicevox_synthesizer_load_voice_model(struct VoicevoxSynthesi
  * @return 結果コード #VoicevoxResultCode
  *
  * # Safety
- * @param synthesizer 有効な #VoicevoxVoiceSynthesizer へのポインタであること
+ * @param synthesizer 有効な #VoicevoxSynthesizer へのポインタであること
  * @param model_id NULL終端文字列であること
  */
 #ifdef _WIN32
@@ -387,7 +387,7 @@ VoicevoxResultCode voicevox_synthesizer_unload_voice_model(struct VoicevoxSynthe
  * @return GPUモードならtrue、そうでないならfalse
  *
  * # Safety
- * @param synthesizer 有効な #VoicevoxVoiceSynthesizer へのポインタであること
+ * @param synthesizer 有効な #VoicevoxSynthesizer へのポインタであること
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -397,12 +397,12 @@ bool voicevox_synthesizer_is_gpu_mode(const struct VoicevoxSynthesizer *synthesi
 
 /**
  * 指定したspeaker_idのモデルが読み込まれているか判定する
- * @param [in] synthesizer 音声シンセサイザ #VoicevoxVoiceSynthesizer
+ * @param [in] synthesizer 音声シンセサイザ #VoicevoxSynthesizer
  * @param [in] model_id 音声モデルのID #VoicevoxVoiceModelId
  * @return モデルが読み込まれているのであればtrue、そうでないならfalse
  *
  * # Safety
- * @param synthesizer 有効な #VoicevoxVoiceSynthesizer へのポインタであること
+ * @param synthesizer 有効な #VoicevoxSynthesizer へのポインタであること
  * @param model_id NULL終端文字列
  */
 #ifdef _WIN32
@@ -414,11 +414,11 @@ bool voicevox_is_loaded_voice_model(const struct VoicevoxSynthesizer *synthesize
 
 /**
  * メタ情報をjsonで取得する
- * @param [in] synthesizer 音声シンセサイザ #VoicevoxVoiceSynthesizer
+ * @param [in] synthesizer 音声シンセサイザ #VoicevoxSynthesizer
  * @return メタ情報のjson文字列
  *
  * # Safety
- * @param synthesizer 有効な #VoicevoxVoiceSynthesizer へのポインタであること
+ * @param synthesizer 有効な #VoicevoxSynthesizer へのポインタであること
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -447,7 +447,7 @@ struct VoicevoxAudioQueryOptions voicevox_make_default_audio_query_options(void)
 
 /**
  * AudioQuery を実行する
- * @param [in] synthesizer 音声シンセサイザ #VoicevoxVoiceSynthesizer
+ * @param [in] synthesizer 音声シンセサイザ #VoicevoxSynthesizer
  * @param [in] text テキスト。文字コードはUTF-8
  * @param [in] style_id スタイルID #VoicevoxStyleId
  * @param [in] options AudioQueryのオプション #VoicevoxAudioQueryOptions
@@ -480,7 +480,7 @@ struct VoicevoxAccentPhrasesOptions voicevox_make_default_accent_phrases_options
 
 /**
  * create_accent_phrases を実行する
- * @param [in] synthesizer 音声シンセサイザ #VoicevoxVoiceSynthesizer
+ * @param [in] synthesizer 音声シンセサイザ #VoicevoxSynthesizer
  * @param [in] text テキスト
  * @param [in] style_id スタイルID #VoicevoxStyleId
  * @param [in] output_accent_phrases_json アクセントフレーズのjson文字列
@@ -501,7 +501,7 @@ VoicevoxResultCode voicevox_synthesizer_create_accent_phrases(const struct Voice
 
 /**
  * replace_mora_data を実行する
- * @param [in] synthesizer 音声シンセサイザ #VoicevoxVoiceSynthesizer
+ * @param [in] synthesizer 音声シンセサイザ #VoicevoxSynthesizer
  * @param [in] accent_phrases_json 変換前のアクセントフレーズのjson文字列
  * @param [in] style_id スタイルID #VoicevoxStyleId
  * @param [in] output_accent_phrases_json 変換後のアクセントフレーズのjson文字列
@@ -521,7 +521,7 @@ VoicevoxResultCode voicevox_synthesizer_replace_mora_data(const struct VoicevoxS
 
 /**
  * replace_phoneme_length を実行する
- * @param [in] synthesizer 音声シンセサイザ #VoicevoxVoiceSynthesizer
+ * @param [in] synthesizer 音声シンセサイザ #VoicevoxSynthesizer
  * @param [in] accent_phrases_json 変換前のアクセントフレーズのjson文字列
  * @param [in] style_id スタイルID #VoicevoxStyleId
  * @param [in] output_accent_phrases_json 変換後のアクセントフレーズのjson文字列
@@ -541,7 +541,7 @@ VoicevoxResultCode voicevox_synthesizer_replace_phoneme_length(const struct Voic
 
 /**
  * replace_mora_pitch を実行する
- * @param [in] synthesizer 音声シンセサイザ #VoicevoxVoiceSynthesizer
+ * @param [in] synthesizer 音声シンセサイザ #VoicevoxSynthesizer
  * @param [in] accent_phrases_json 変換前のアクセントフレーズのjson文字列
  * @param [in] style_id スタイルID #VoicevoxStyleId
  * @param [in] output_accent_phrases_json 変換後のアクセントフレーズのjson文字列
@@ -571,7 +571,7 @@ struct VoicevoxSynthesisOptions voicevox_make_default_synthesis_options(void);
 
 /**
  * AudioQuery から音声合成する
- * @param [in] synthesizer 音声シンセサイザ #VoicevoxVoiceSynthesizer
+ * @param [in] synthesizer 音声シンセサイザ #VoicevoxSynthesizer
  * @param [in] audio_query_json jsonフォーマットされた AudioQuery
  * @param [in] style_id スタイルID #VoicevoxStyleId
  * @param [in] options AudioQueryから音声合成オプション
@@ -606,7 +606,7 @@ struct VoicevoxTtsOptions voicevox_make_default_tts_options(void);
 
 /**
  * テキスト音声合成を実行する
- * @param [in] synthesizer 音声シンセサイザ #VoicevoxVoiceSynthesizer
+ * @param [in] synthesizer 音声シンセサイザ #VoicevoxSynthesizer
  * @param [in] text テキスト。文字コードはUTF-8
  * @param [in] style_id スタイルID #VoicevoxStyleId
  * @param [in] options テキスト音声合成オプション

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -222,7 +222,7 @@ pub struct VoicevoxSynthesizer;
 /// 音声シンセサイザを生成して初期化する
 /// @param [in] open_jtalk 参照カウントで管理されたOpenJtalk
 /// @param [in] options 初期化オプション #VoicevoxInitializeOptions
-/// @param [out] out_synthesizer 新しく生成された音声シンセサイザの出力先 #VoicevoxVoiceSynthesizer
+/// @param [out] out_synthesizer 新しく生成された音声シンセサイザの出力先 #VoicevoxSynthesizer
 /// @return 結果コード #VoicevoxResultCode
 ///
 /// # Safety
@@ -245,10 +245,10 @@ pub unsafe extern "C" fn voicevox_synthesizer_new_with_initialize(
 }
 
 /// 音声シンセサイザを破棄する
-/// @param [in] synthesizer 破棄する音声シンセサイザ #VoicevoxVoiceSynthesizer
+/// @param [in] synthesizer 破棄する音声シンセサイザ #VoicevoxSynthesizer
 ///
 /// # Safety
-/// @param synthesizer 有効な #VoicevoxVoiceSynthesizer へのポインタであること
+/// @param synthesizer 有効な #VoicevoxSynthesizer へのポインタであること
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_synthesizer_delete(synthesizer: *mut VoicevoxSynthesizer) {
     let _ = Box::from_raw(synthesizer as *mut CSynthesizer);
@@ -260,7 +260,7 @@ pub unsafe extern "C" fn voicevox_synthesizer_delete(synthesizer: *mut VoicevoxS
 /// @return 結果コード #VoicevoxResultCode
 ///
 /// # Safety
-/// @param synthesizer 有効な #VoicevoxVoiceSynthesizer へのポインタであること
+/// @param synthesizer 有効な #VoicevoxSynthesizer へのポインタであること
 /// @param model 有効な #VoicevoxVoiceModel へのポインタであること
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_synthesizer_load_voice_model(
@@ -282,7 +282,7 @@ pub unsafe extern "C" fn voicevox_synthesizer_load_voice_model(
 /// @return 結果コード #VoicevoxResultCode
 ///
 /// # Safety
-/// @param synthesizer 有効な #VoicevoxVoiceSynthesizer へのポインタであること
+/// @param synthesizer 有効な #VoicevoxSynthesizer へのポインタであること
 /// @param model_id NULL終端文字列であること
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_synthesizer_unload_voice_model(
@@ -303,7 +303,7 @@ pub unsafe extern "C" fn voicevox_synthesizer_unload_voice_model(
 /// @return GPUモードならtrue、そうでないならfalse
 ///
 /// # Safety
-/// @param synthesizer 有効な #VoicevoxVoiceSynthesizer へのポインタであること
+/// @param synthesizer 有効な #VoicevoxSynthesizer へのポインタであること
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_synthesizer_is_gpu_mode(
     synthesizer: *const VoicevoxSynthesizer,
@@ -313,12 +313,12 @@ pub unsafe extern "C" fn voicevox_synthesizer_is_gpu_mode(
 }
 
 /// 指定したspeaker_idのモデルが読み込まれているか判定する
-/// @param [in] synthesizer 音声シンセサイザ #VoicevoxVoiceSynthesizer
+/// @param [in] synthesizer 音声シンセサイザ #VoicevoxSynthesizer
 /// @param [in] model_id 音声モデルのID #VoicevoxVoiceModelId
 /// @return モデルが読み込まれているのであればtrue、そうでないならfalse
 ///
 /// # Safety
-/// @param synthesizer 有効な #VoicevoxVoiceSynthesizer へのポインタであること
+/// @param synthesizer 有効な #VoicevoxSynthesizer へのポインタであること
 /// @param model_id NULL終端文字列
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_is_loaded_voice_model(
@@ -333,11 +333,11 @@ pub unsafe extern "C" fn voicevox_is_loaded_voice_model(
 }
 
 /// メタ情報をjsonで取得する
-/// @param [in] synthesizer 音声シンセサイザ #VoicevoxVoiceSynthesizer
+/// @param [in] synthesizer 音声シンセサイザ #VoicevoxSynthesizer
 /// @return メタ情報のjson文字列
 ///
 /// # Safety
-/// @param synthesizer 有効な #VoicevoxVoiceSynthesizer へのポインタであること
+/// @param synthesizer 有効な #VoicevoxSynthesizer へのポインタであること
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_synthesizer_get_metas_json(
     synthesizer: *const VoicevoxSynthesizer,
@@ -376,7 +376,7 @@ pub extern "C" fn voicevox_make_default_audio_query_options() -> VoicevoxAudioQu
 }
 
 /// AudioQuery を実行する
-/// @param [in] synthesizer 音声シンセサイザ #VoicevoxVoiceSynthesizer
+/// @param [in] synthesizer 音声シンセサイザ #VoicevoxSynthesizer
 /// @param [in] text テキスト。文字コードはUTF-8
 /// @param [in] style_id スタイルID #VoicevoxStyleId
 /// @param [in] options AudioQueryのオプション #VoicevoxAudioQueryOptions
@@ -425,7 +425,7 @@ pub extern "C" fn voicevox_make_default_accent_phrases_options() -> VoicevoxAcce
 }
 
 /// create_accent_phrases を実行する
-/// @param [in] synthesizer 音声シンセサイザ #VoicevoxVoiceSynthesizer
+/// @param [in] synthesizer 音声シンセサイザ #VoicevoxSynthesizer
 /// @param [in] text テキスト
 /// @param [in] style_id スタイルID #VoicevoxStyleId
 /// @param [in] output_accent_phrases_json アクセントフレーズのjson文字列
@@ -457,7 +457,7 @@ pub unsafe extern "C" fn voicevox_synthesizer_create_accent_phrases(
 }
 
 /// replace_mora_data を実行する
-/// @param [in] synthesizer 音声シンセサイザ #VoicevoxVoiceSynthesizer
+/// @param [in] synthesizer 音声シンセサイザ #VoicevoxSynthesizer
 /// @param [in] accent_phrases_json 変換前のアクセントフレーズのjson文字列
 /// @param [in] style_id スタイルID #VoicevoxStyleId
 /// @param [in] output_accent_phrases_json 変換後のアクセントフレーズのjson文字列
@@ -490,7 +490,7 @@ pub unsafe extern "C" fn voicevox_synthesizer_replace_mora_data(
 }
 
 /// replace_phoneme_length を実行する
-/// @param [in] synthesizer 音声シンセサイザ #VoicevoxVoiceSynthesizer
+/// @param [in] synthesizer 音声シンセサイザ #VoicevoxSynthesizer
 /// @param [in] accent_phrases_json 変換前のアクセントフレーズのjson文字列
 /// @param [in] style_id スタイルID #VoicevoxStyleId
 /// @param [in] output_accent_phrases_json 変換後のアクセントフレーズのjson文字列
@@ -523,7 +523,7 @@ pub unsafe extern "C" fn voicevox_synthesizer_replace_phoneme_length(
 }
 
 /// replace_mora_pitch を実行する
-/// @param [in] synthesizer 音声シンセサイザ #VoicevoxVoiceSynthesizer
+/// @param [in] synthesizer 音声シンセサイザ #VoicevoxSynthesizer
 /// @param [in] accent_phrases_json 変換前のアクセントフレーズのjson文字列
 /// @param [in] style_id スタイルID #VoicevoxStyleId
 /// @param [in] output_accent_phrases_json 変換後のアクセントフレーズのjson文字列
@@ -570,7 +570,7 @@ pub extern "C" fn voicevox_make_default_synthesis_options() -> VoicevoxSynthesis
 }
 
 /// AudioQuery から音声合成する
-/// @param [in] synthesizer 音声シンセサイザ #VoicevoxVoiceSynthesizer
+/// @param [in] synthesizer 音声シンセサイザ #VoicevoxSynthesizer
 /// @param [in] audio_query_json jsonフォーマットされた AudioQuery
 /// @param [in] style_id スタイルID #VoicevoxStyleId
 /// @param [in] options AudioQueryから音声合成オプション
@@ -626,7 +626,7 @@ pub extern "C" fn voicevox_make_default_tts_options() -> VoicevoxTtsOptions {
 }
 
 /// テキスト音声合成を実行する
-/// @param [in] synthesizer 音声シンセサイザ #VoicevoxVoiceSynthesizer
+/// @param [in] synthesizer 音声シンセサイザ #VoicevoxSynthesizer
 /// @param [in] text テキスト。文字コードはUTF-8
 /// @param [in] style_id スタイルID #VoicevoxStyleId
 /// @param [in] options テキスト音声合成オプション

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -148,11 +148,11 @@ pub extern "C" fn voicevox_get_version() -> *const c_char {
     VOICEVOX_VERSION.as_ptr()
 }
 
-/// 音声合成モデル
+/// 音声モデル
 #[repr(C)]
 pub struct VoicevoxVoiceModel;
 
-/// 音声合成モデルID
+/// 音声モデルID
 pub type VoicevoxVoiceModelId = *const c_char;
 
 /// スタイルID

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -139,7 +139,7 @@ impl Synthesizer {
     }
 
     fn __repr__(&self) -> &'static str {
-        "VoiceSynthesizer { .. }"
+        "Synthesizer { .. }"
     }
 
     #[getter]


### PR DESCRIPTION
## 内容

次の表記ゆれを統一します。

- "VoiceSynthesizer" → "Synthesizer" (`Synthesizer`/`VoicevoxSynthesizer`のはずなので)
- "音声合成モデル" → "音声モデル"

## 関連 Issue

- #497
- <https://github.com/VOICEVOX/voicevox_core/pull/370#discussion_r1141398754>
- <https://github.com/VOICEVOX/voicevox_core/pull/370#discussion_r1141399252>

## その他
