### PR TITLE
Python APIでは`panic=unwind`にする

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -151,6 +151,7 @@ jobs:
       - name: build voicevox_core_c_api
         run: cargo build -p voicevox_core_c_api -vv --features ${{ matrix.features }}, --target ${{ matrix.target }} --release
         env:
+          RUSTFLAGS: -C panic=abort
           ORT_USE_CUDA: ${{ matrix.use_cuda }}
       - name: build voicevox_core_python_api
         if: matrix.whl_local_version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,5 +36,4 @@ voicevox_core = { path = "crates/voicevox_core" }
 opt-level = "z"
 lto = true
 codegen-units = 1
-panic = "abort"
 strip = true


### PR DESCRIPTION
## 内容

Python APIを`panic=unwind`でビルドすることにより、ユーザー環境で万が一パニックが発生した際の挙動を「プロセスのabort」ではなく「例外の発生」に変えます。

C APIおよびPython APIでは現在(#218 によって)[パニック](https://doc.rust-jp.rs/book-ja/ch09-01-unrecoverable-errors-with-panic.html)発生時の動作がデフォルトの`panic=unwind`から`panic=abort`、すなわち「問答無用でのプロセスの強制終了」となっています。

提供するのがC APIのみならこれはバイナリサイズ縮小の効果しかありませんでした。なぜならパニックはそもそも[`extern "C"`の境界を越えられない](https://doc.rust-lang.org/nomicon/ffi.html#ffi-and-unwinding)からです(リンク先の`extern "C-unwind"`は[まだnightly-onlyです](https://github.com/rust-lang/rust/issues/74990))。
(なので<https://github.com/sh1ma/voicevoxcore.go/issues/5>のようなことはおそらく不可能です)

しかしPyO3であれば話は別です。PyO3はRustのパニックを`pyo3_runtime.PanicException`というC Pythonの例外に変換してくれます。[例外はCPythonのAPIを通じて外に出る](https://github.com/python/cpython/blob/3.12/Doc/c-api/exceptions.rst)ため、DLLの壁を越えることができます。

`panic=abort`:

```console
thread '<unnamed>' panicked at 'パニックメッセージ', crates/voicevox_core/src/publish.rs:36:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
zsh: IOT instruction (core dumped)  python ./run.py
```

`panic=unwind`:

```diff
 thread '<unnamed>' panicked at 'パニックメッセージ', crates/voicevox_core/src/publish.rs:36:9
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-zsh: IOT instruction (core dumped)  python ./run.py
+Traceback (most recent call last):
+  File "./run.py", line 86, in <module>
+    main()
+  File "./run.py", line 25, in main
+    core = VoicevoxCore(
+pyo3_runtime.PanicException: パニックメッセージ
 ❯ echo $?
-134
+1
```

バイナリサイズの微妙な減少と例外への変換を比べたとき、ユーザーにとってどちらが望ましいかですが、個人的には後者だと思っています。

- [x] Cargo.tomlで`panic=abort`を指定するのをやめる
- [x] Actionsを更新し、C APIだけこれまで通り`panic=abort`でビルドされるようにする

## 関連 Issue

なし

## その他
