### PR TITLE
[project-vvm-async-api] C/Python APIクレート側のバージョンを出す

### DIFF
--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -139,7 +139,7 @@ pub extern "C" fn voicevox_make_default_initialize_options() -> VoicevoxInitiali
 }
 
 static VOICEVOX_VERSION: once_cell::sync::Lazy<CString> =
-    once_cell::sync::Lazy::new(|| CString::new(voicevox_core::get_version()).unwrap());
+    once_cell::sync::Lazy::new(|| CString::new(env!("CARGO_PKG_VERSION")).unwrap());
 
 /// voicevoxのバージョンを取得する
 /// @return SemVerでフォーマットされたバージョン

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -24,7 +24,7 @@ static RUNTIME: Lazy<Runtime> = Lazy::new(|| Runtime::new().unwrap());
 fn rust(_py: Python<'_>, module: &PyModule) -> PyResult<()> {
     pyo3_log::init();
 
-    module.add("__version__", voicevox_core::get_version())?;
+    module.add("__version__", env!("CARGO_PKG_VERSION"))?;
     module.add_wrapped(wrap_pyfunction!(supported_devices))?;
 
     module.add_class::<Synthesizer>()?;


### PR DESCRIPTION
## 内容

C APIとPython APIが出す"version"を、Rust APIのものではなく各クレート自体のものにします。

<https://github.com/VOICEVOX/voicevox_core/pull/503#discussion_r1213507143>

今までPython APIではパッケージのバージョンが`0.14.4+cpu`であるにもかかわらず`__version__`が`"0.14.4"`になっていたという問題もあったので、それも理由です。

## 関連 Issue

## その他
