### PR TITLE
[project-vvm-async-api] ZSTにポインタキャストして提供するのをやめる

### DIFF
--- a/crates/voicevox_core_c_api/include/voicevox_core.h
+++ b/crates/voicevox_core_c_api/include/voicevox_core.h
@@ -125,12 +125,12 @@ typedef int32_t VoicevoxResultCode;
  */
 typedef struct OpenJtalkRc OpenJtalkRc;
 
+typedef struct VoicevoxSynthesizer VoicevoxSynthesizer;
+
 /**
  * 音声モデル
  */
-typedef struct VoicevoxVoiceModel {
-
-} VoicevoxVoiceModel;
+typedef struct VoicevoxVoiceModel VoicevoxVoiceModel;
 
 /**
  * 音声モデルID
@@ -155,10 +155,6 @@ typedef struct VoicevoxInitializeOptions {
    */
   bool load_all_models;
 } VoicevoxInitializeOptions;
-
-typedef struct VoicevoxSynthesizer {
-
-} VoicevoxSynthesizer;
 
 /**
  * スタイルID

--- a/crates/voicevox_core_c_api/src/c_impls.rs
+++ b/crates/voicevox_core_c_api/src/c_impls.rs
@@ -1,4 +1,3 @@
-use derive_getters::Getters;
 use std::{
     ffi::{CStr, CString},
     path::Path,
@@ -7,11 +6,9 @@ use std::{
 
 use voicevox_core::{InitializeOptions, OpenJtalk, Result, Synthesizer, VoiceModel, VoiceModelId};
 
-pub(crate) struct COpenJtalkRc {
-    open_jtalk: Arc<OpenJtalk>,
-}
+use crate::{OpenJtalkRc, VoicevoxSynthesizer, VoicevoxVoiceModel};
 
-impl COpenJtalkRc {
+impl OpenJtalkRc {
     pub(crate) fn new_with_initialize(open_jtalk_dic_dir: impl AsRef<Path>) -> Result<Self> {
         Ok(Self {
             open_jtalk: Arc::new(OpenJtalk::new_with_initialize(open_jtalk_dic_dir)?),
@@ -19,15 +16,9 @@ impl COpenJtalkRc {
     }
 }
 
-#[derive(Getters)]
-pub(crate) struct CSynthesizer {
-    synthesizer: Synthesizer,
-    metas_cstring: CString,
-}
-
-impl CSynthesizer {
+impl VoicevoxSynthesizer {
     pub(crate) async fn new_with_initialize(
-        open_jtalk: &COpenJtalkRc,
+        open_jtalk: &OpenJtalkRc,
         options: &InitializeOptions,
     ) -> Result<Self> {
         Ok(Self {
@@ -56,14 +47,7 @@ impl CSynthesizer {
     }
 }
 
-#[derive(Getters)]
-pub(crate) struct CVoiceModel {
-    model: VoiceModel,
-    id: CString,
-    metas: CString,
-}
-
-impl CVoiceModel {
+impl VoicevoxVoiceModel {
     pub(crate) async fn from_path(path: impl AsRef<Path>) -> Result<Self> {
         let model = VoiceModel::from_path(path).await?;
         let id = CString::new(model.id().raw_voice_model_id().as_str()).unwrap();


### PR DESCRIPTION
## 内容

現在project-vvm-async-apiでは`VoicevoxSynthesizer`などの型はZST(**Z**ero **S**ized **T**ype)として.hに載せ、Rust側ではポインタのキャストを行っているという状態になっています。これをやめ、[repr(Rust)](https://doc.rust-lang.org/nomicon/repr-rust.html)にしてポインタのキャストをやめます。

さらにこれによりC側に提供される型は正しくopaqueになり、

```diff
-typedef struct VoicevoxSynthesizer {
-
-} VoicevoxSynthesizer;
+typedef struct VoicevoxSynthesizer VoicevoxSynthesizer;
```

次のコードのコンパイルは拒否されるようになります。

```c
sizeof(VoicevoxSynthesizer)
```

```c++
std::alignment_of<VoicevoxSynthesizer>()
```

```c
VoicevoxSynthesizer *ptr;
++ptr;
```

以下はこのPRを作るのを決断した理由です:

- ZSTにポインタキャストするのはC→Rustのときでは?

    そもそもqwertyさんが何故ZSTにわざわざポインタのキャストをしていたのですが、Rustでは**Cの型をRustに**持って来るときに[1861-extern-types](https://rust-lang.github.io/rfcs/1861-extern-types.html)の代用としてZSTを使うという慣習があり、私が思うにおそらくそれに則ったのではないでしょうか。

    しかしRustの型をCに提供する際にはそのようなことはしなくていいはずです。Rust側はRustで定義された型のレイアウトは当然知っていいはずだし、C側に対しても上記のようにレイアウトは完全に隠蔽できます。

- `*const (impl Sized)`/`*mut (impl Sized)`はFFI-safeであるはず

    `*const T`/`*mut T`をC側に提供するときに、`T`を`#[repr(C)]`にする必要はないと思います。

    cbindgenを作っている人達もそう考えているはずだし、 shepmaster氏([Stack OverflowのRustの質問への回答で頻繁に見るカービィアイコンの人](https://twitter.com/search?q=Rust%20stackoverflow%20%E3%82%AB%E3%83%BC%E3%83%93%E3%82%A3&src=typed_query&f=live))が書いた[The Rust FFI Omnibus](http://jakegoulding.com/rust-ffi-omnibus/)でも普通にrepr(Rust)な型のポインタをC側に提供しています。

- C++ではZSTは許容されない

    次のコードはCでは`0`となり、C++では`1`となります。
    (ちなみにGCCやLLVMではCでも`sizeof(void) == 1`です)

    ```c
    size_t size_of_zst() {
      typedef struct {} Zst;
      return sizeof(Zst);
    }
    ```

## 関連 Issue

- #497

## その他
