### PR TITLE
[project-vvm-async-api] `$OUT_DIR`を使うものをtest_utilクレートに移動

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3437,9 +3437,12 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-std",
+ "async_zip",
  "flate2",
+ "once_cell",
  "surf",
  "tar",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ publish = false
 
 [workspace.dependencies]
 anyhow = "1.0.65"
+async_zip = { version = "0.0.11", features = ["full"] }
 clap = { version = "4.0.10", features = ["derive"] }
 const-default = { version = "1.0.0", features = ["derive"] }
 easy-ext = "1.0.1"

--- a/crates/test_util/Cargo.toml
+++ b/crates/test_util/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.0.0"
 edition.workspace = true
 publish.workspace = true
 
+[dependencies]
+async_zip.workspace = true
+once_cell.workspace = true
+tokio.workspace = true
+
 [build-dependencies]
 anyhow.workspace = true
 async-std = { version = "1.12.0", features = ["attributes"] }

--- a/crates/test_util/src/lib.rs
+++ b/crates/test_util/src/lib.rs
@@ -1,1 +1,59 @@
+use async_zip::{write::ZipFileWriter, Compression, ZipEntryBuilder};
+use once_cell::sync::Lazy;
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
+use tokio::{
+    fs::{self, File},
+    io::{AsyncReadExt, AsyncWriteExt},
+    sync::Mutex,
+};
+
 pub const OPEN_JTALK_DIC_DIR: &str = concat!(env!("OUT_DIR"), "/open_jtalk_dic_utf_8-1.11");
+
+static PATH_MUTEX: Lazy<Mutex<HashMap<PathBuf, Mutex<()>>>> =
+    Lazy::new(|| Mutex::new(HashMap::default()));
+
+pub async fn convert_zip_vvm(dir: impl AsRef<Path>) -> PathBuf {
+    let dir = dir.as_ref();
+    let output_file_name = dir.file_name().unwrap().to_str().unwrap().to_owned() + ".vvm";
+
+    let out_file_path = PathBuf::from(env!("OUT_DIR"))
+        .join("test_data/models/")
+        .join(output_file_name);
+    let mut path_map = PATH_MUTEX.lock().await;
+    if !path_map.contains_key(&out_file_path) {
+        path_map.insert(out_file_path.clone(), Mutex::new(()));
+    }
+    let _m = path_map.get(&out_file_path).unwrap().lock().await;
+
+    if !out_file_path.exists() {
+        fs::create_dir_all(out_file_path.parent().unwrap())
+            .await
+            .unwrap();
+        let mut out_file = File::create(&out_file_path).await.unwrap();
+        let mut writer = ZipFileWriter::new(&mut out_file);
+
+        for entry in dir.read_dir().unwrap().flatten() {
+            let entry_builder = ZipEntryBuilder::new(
+                entry
+                    .path()
+                    .file_name()
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
+                    .to_string(),
+                Compression::Deflate,
+            );
+            let mut entry_writer = writer.write_entry_stream(entry_builder).await.unwrap();
+            let mut file = File::open(entry.path()).await.unwrap();
+            let mut buf = Vec::with_capacity(entry.metadata().unwrap().len() as usize);
+            file.read_to_end(&mut buf).await.unwrap();
+            entry_writer.write_all(&buf).await.unwrap();
+            entry_writer.close().await.unwrap();
+        }
+        writer.close().await.unwrap();
+    }
+    out_file_path
+}

--- a/crates/voicevox_core/Cargo.toml
+++ b/crates/voicevox_core/Cargo.toml
@@ -28,7 +28,7 @@ thiserror.workspace = true
 tracing.workspace = true
 open_jtalk = { git = "https://github.com/VOICEVOX/open_jtalk-rs.git", rev="d766a52bad4ccafe18597e57bd6842f59dca881e" }
 regex.workspace = true
-async_zip = { version = "0.0.11", features = ["full"] }
+async_zip.workspace = true
 futures = "0.3.26"
 nanoid = "0.4.0"
 tokio.workspace = true 

--- a/crates/voicevox_core/src/test_util.rs
+++ b/crates/voicevox_core/src/test_util.rs
@@ -1,20 +1,10 @@
-use async_zip::{write::ZipFileWriter, Compression, ZipEntryBuilder};
-use once_cell::sync::Lazy;
-use std::{
-    collections::HashMap,
-    path::{Path, PathBuf},
-};
-use tokio::{
-    fs::{self, File},
-    io::{AsyncReadExt, AsyncWriteExt},
-    sync::Mutex,
-};
+use std::path::PathBuf;
 
 use crate::VoiceModel;
 
 pub async fn open_default_vvm_file() -> VoiceModel {
     VoiceModel::from_path(
-        convert_zip_vvm(
+        ::test_util::convert_zip_vvm(
             PathBuf::from(env!("CARGO_WORKSPACE_DIR"))
                 .join(file!())
                 .parent()
@@ -26,50 +16,4 @@ pub async fn open_default_vvm_file() -> VoiceModel {
     )
     .await
     .unwrap()
-}
-
-static PATH_MUTEX: Lazy<Mutex<HashMap<PathBuf, Mutex<()>>>> =
-    Lazy::new(|| Mutex::new(HashMap::default()));
-
-async fn convert_zip_vvm(dir: impl AsRef<Path>) -> PathBuf {
-    let dir = dir.as_ref();
-    let output_file_name = dir.file_name().unwrap().to_str().unwrap().to_owned() + ".vvm";
-
-    let out_file_path = PathBuf::from(env!("OUT_DIR"))
-        .join("test_data/models/")
-        .join(output_file_name);
-    let mut path_map = PATH_MUTEX.lock().await;
-    if !path_map.contains_key(&out_file_path) {
-        path_map.insert(out_file_path.clone(), Mutex::new(()));
-    }
-    let _m = path_map.get(&out_file_path).unwrap().lock().await;
-
-    if !out_file_path.exists() {
-        fs::create_dir_all(out_file_path.parent().unwrap())
-            .await
-            .unwrap();
-        let mut out_file = File::create(&out_file_path).await.unwrap();
-        let mut writer = ZipFileWriter::new(&mut out_file);
-
-        for entry in dir.read_dir().unwrap().flatten() {
-            let entry_builder = ZipEntryBuilder::new(
-                entry
-                    .path()
-                    .file_name()
-                    .unwrap()
-                    .to_str()
-                    .unwrap()
-                    .to_string(),
-                Compression::Deflate,
-            );
-            let mut entry_writer = writer.write_entry_stream(entry_builder).await.unwrap();
-            let mut file = File::open(entry.path()).await.unwrap();
-            let mut buf = Vec::with_capacity(entry.metadata().unwrap().len() as usize);
-            file.read_to_end(&mut buf).await.unwrap();
-            entry_writer.write_all(&buf).await.unwrap();
-            entry_writer.close().await.unwrap();
-        }
-        writer.close().await.unwrap();
-    }
-    out_file_path
 }


### PR DESCRIPTION
## 内容

project-vvm-async-apiにそろそろmainをマージしようと思ったのですが、こっちではこのままだと #508 が適用できないことに気付きました。

このPRはvoicevox\_coreクレート内で`$OUT_DIR`を使っているテストユーティリティを、test\_utilクレートに移動します。

## 関連 Issue

#497

## その他
