### PR TITLE
windows-latestでなぜかdownload_testが落ちるのを改修

### DIFF
--- a/.github/workflows/download_test.yml
+++ b/.github/workflows/download_test.yml
@@ -298,7 +298,7 @@ jobs:
         if: ${{ env.EXPECTED_VOICEVOX_CORE_VERSION == 'latest' }}
         shell: bash
         run: |
-          echo "EXPECTED_VOICEVOX_CORE_VERSION=$(curl -sSfI "https://github.com/VOICEVOX/voicevox_core/releases/latest"| grep "location:" | sed -e "s%location: https://github.com/VOICEVOX/voicevox_core/releases/tag/%%" | sed 's/\r//g')" >> "$GITHUB_ENV"
+          echo "EXPECTED_VOICEVOX_CORE_VERSION=$(gh release view --repo VOICEVOX/voicevox_core --json 'tagName' --jq '.tagName')" >> "$GITHUB_ENV"
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: Check downloaded version

--- a/.github/workflows/download_test.yml
+++ b/.github/workflows/download_test.yml
@@ -299,6 +299,8 @@ jobs:
         shell: bash
         run: |
           echo "EXPECTED_VOICEVOX_CORE_VERSION=$(curl -sSfI "https://github.com/VOICEVOX/voicevox_core/releases/latest"| grep "location:" | sed -e "s%location: https://github.com/VOICEVOX/voicevox_core/releases/tag/%%" | sed 's/\r//g')" >> "$GITHUB_ENV"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
       - name: Check downloaded version
         shell: bash
         run: |


### PR DESCRIPTION
## 内容

github actionsのwindows-2022が更新されたらしく、なぜか最新バージョンのgetができなくなったので対応です。

- https://github.com/VOICEVOX/voicevox_core/actions/runs/5179482508/jobs/9445000743

github cliのを使うようにしてみました。

## その他

原因は不明ですがとりあえず詳細メモ。

- https://github.com/VOICEVOX/voicevox_core/pull/516#issuecomment-1585751707

以前のと比較すると`Runner Image`が`Version: 20230606.1`になってました（以前のは`Version: 20230517.1`）
`Chocolatey`のメジャーバージョンアップ･･･？

```bash
diff \
  <(curl https://raw.githubusercontent.com/actions/runner-images/win22/20230517.1/images/win/Windows2022-Readme.md) \
  <(curl https://raw.githubusercontent.com/actions/runner-images/win22/20230606.1/images/win/Windows2022-Readme.md)
```

<details>
<summary>diff</summary>

```diff
3c3,5
< | [python2.7 will be removed from the images on May 22, 2023](https://github.com/actions/runner-images/issues/7401) |
---
> | [[All OSs] .NET 3.1 will be removed from the images on July, 3](https://github.com/actions/runner-images/issues/7667) |
> | [Actions runner image scheduled maintenance (June 2 2023 through June 12 20223)](https://github.com/actions/runner-images/issues/7660) |
> | [python2.7 will be removed from the images on June 12, 2023](https://github.com/actions/runner-images/issues/7401) |
7c9
< - Image Version: 20230517.1
---
> - Image Version: 20230606.1
27,28c29,30
< - Chocolatey 1.4.0
< - Composer 2.5.5
---
> - Chocolatey 2.0.0
> - Composer 2.5.7
32c34
< - NuGet 6.5.0.154
---
> - NuGet 6.6.0.61
36c38
< - Vcpkg (build from commit 7b30311f0)
---
> - Vcpkg (build from commit 750591668)
49c51
< - sbt 1.8.3
---
> - sbt 1.9.0
54,55c56,57
< - azcopy 10.18.1
< - Bazel 6.2.0
---
> - azcopy 10.19.0
> - Bazel 6.2.1
59,61c61,63
< - CMake 3.26.3
< - CodeQL Action Bundles 2.13.0 2.13.1
< - Docker 24.0.0
---
> - CMake 3.26.4
> - CodeQL Action Bundles 2.13.1 2.13.3
> - Docker 24.0.2
65,66c67,68
< - ghc 9.6.1
< - Git 2.40.1.windows.1
---
> - ghc 9.6.2
> - Git 2.41.0.windows.1
68c70
< - ImageMagick 7.1.1-9
---
> - ImageMagick 7.1.1-11
72c74
< - Kubectl 1.27.1
---
> - Kubectl 1.27.2
77c79
< - OpenSSL 1.1.1t
---
> - OpenSSL 1.1.1u
79c81
< - Pulumi 3.67.1
---
> - Pulumi 3.69.0
82c84
< - Stack 2.9.3
---
> - Stack 2.11.1
88c90
< - yamllint 1.31.0
---
> - yamllint 1.32.0
92,94c94,96
< - Alibaba Cloud CLI 3.0.164
< - AWS CLI 2.11.20
< - AWS SAM CLI 1.84.0
---
> - Alibaba Cloud CLI 3.0.165
> - AWS CLI 2.11.25
> - AWS SAM CLI 1.86.0
96c98
< - Azure CLI 2.48.1
---
> - Azure CLI 2.49.0
98c100
< - GitHub CLI 2.29.0
---
> - GitHub CLI 2.30.0
102,104c104,106
< - Cargo 1.69.0
< - Rust 1.69.0
< - Rustdoc 1.69.0
---
> - Cargo 1.70.0
> - Rust 1.70.0
> - Rustdoc 1.70.0
111,112c113,114
< - cbindgen 0.24.3
< - Clippy 0.1.69
---
> - cbindgen 0.24.5
> - Clippy 0.1.70
116,120c118,122
< - Google Chrome 113.0.5672.127
< - Chrome Driver 113.0.5672.63
< - Microsoft Edge 113.0.1774.42
< - Microsoft Edge Driver 113.0.1774.42
< - Mozilla Firefox 113.0.1
---
> - Google Chrome 114.0.5735.110
> - Chrome Driver 114.0.5735.90
> - Microsoft Edge 114.0.1823.37
> - Microsoft Edge Driver 114.0.1823.37
> - Mozilla Firefox 114.0
217c219
< | Nginx  | 1.23.4  | C:\tools\nginx-1.23.4\conf\nginx.conf | nginx       | Stopped       | 80         |
---
> | Nginx  | 1.25.0  | C:\tools\nginx-1.25.0\conf\nginx.conf | nginx       | Stopped       | 80         |
222c224
< | Visual Studio Enterprise 2022 | 17.6.33712.159 | C:\Program Files\Microsoft Visual Studio\2022\Enterprise |
---
> | Visual Studio Enterprise 2022 | 17.6.33723.286 | C:\Program Files\Microsoft Visual Studio\2022\Enterprise |
536c538
< - nbgv 3.6.132+bc56096f69
---
> - nbgv 3.6.133+2d32d93cb1
548c550
< - AWSPowershell: 4.1.334
---
> - AWSPowershell: 4.1.346
556c558
< - SqlServer: 22.0.59
---
> - SqlServer: 22.1.1
571c573
< | Android SDK Platform-Tools | 34.0.1                                                                                                                                                                                                       |
---
> | Android SDK Platform-Tools | 34.0.3                                                                                                                                                                                                       |
```

</details>
