### PR TITLE
[project-vvm-async-api] Fix up #500

### DIFF
--- a/crates/voicevox_core_c_api/src/helpers.rs
+++ b/crates/voicevox_core_c_api/src/helpers.rs
@@ -284,7 +284,6 @@ impl BufferManager {
         drop(CString::from_raw(ptr));
     }
 
-    #[allow(dead_code)] // FIXME: これの代わりに、定数全部をコンストラクタに与える形にする
     pub fn memorize_static_str(&self, ptr: *const c_char) -> *const c_char {
         let BufferManagerInner {
             static_str_addrs, ..

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -670,7 +670,9 @@ pub unsafe extern "C" fn voicevox_wav_free(wav: *mut u8) {
 pub extern "C" fn voicevox_error_result_to_message(
     result_code: VoicevoxResultCode,
 ) -> *const c_char {
-    voicevox_core::result_code::error_result_to_message(result_code).as_ptr() as *const c_char
+    BUFFER_MANAGER.memorize_static_str(
+        voicevox_core::result_code::error_result_to_message(result_code).as_ptr() as *const c_char,
+    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 内容

<https://github.com/VOICEVOX/voicevox_core/pull/516#discussion_r1225373597>のやつです。

使わなくなった`memorize_static_str`を削除して代わりに定数である`voicevox_version`のみに反応するようにする、というのを元々考えていました。

ただよく考えたら定数をfreeしようとする人は多分いないし、 あと #500 のときに忘れていたけど`voicevox_error_result_to_message`に対して`memorize_static_str`の出番があるはず、ということでこのようになりました。

## 関連 Issue

- #500
- #497

## その他

このPRはmainの方に出すべきかもしれませんが、またマージするのも面倒だろうしこっちでいいかなと思いました。