### PR TITLE
Github Actionsでshell: bashを毎回書かなくても良いようにする

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -24,6 +24,9 @@ env:
   # Raw character weights are not public.
   # Skip uploading to GitHub Release on public repo.
   SKIP_UPLOADING_RELEASE_ASSET: ${{ secrets.SKIP_UPLOADING_RELEASE_ASSET || '1' }}
+defaults:
+  run:
+    shell: bash
 jobs:
   build_and_deploy:
     environment: ${{ github.event.inputs.code_signing == 'true' && 'code_signing' || '' }} # コード署名用のenvironment
@@ -124,7 +127,6 @@ jobs:
           targets: ${{ matrix.target }}
       - name: Install cross compiler for aarch64-unknown-linux-gnu
         if: matrix.target == 'aarch64-unknown-linux-gnu'
-        shell: bash
         run: |
           sudo apt update
           sudo apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
@@ -134,17 +136,14 @@ jobs:
           ndk-version: r25b
       - name: Set path for android
         if: endsWith(matrix.target, '-linux-android')
-        shell: bash
         run: |
           echo "$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/bin" >> "$GITHUB_PATH"
           echo "AR_${{ matrix.target }}=llvm-ar" >> "$GITHUB_ENV"
       - name: Install cargo-binstall
         uses: taiki-e/install-action@cargo-binstall
       - name: Install cargo-edit
-        shell: bash
         run: cargo binstall cargo-edit@^0.11 --no-confirm --log-level debug
       - name: set cargo version
-        shell: bash
         run: |
           cargo set-version "$VERSION" --exclude voicevox_core_python_api --exclude download --exclude xtask
           if ${{ !!matrix.whl_local_version }}; then cargo set-version "$VERSION+"${{ matrix.whl_local_version }} -p voicevox_core_python_api; fi
@@ -156,7 +155,6 @@ jobs:
       - name: build voicevox_core_python_api
         if: matrix.whl_local_version
         id: build-voicevox-core-python-api
-        shell: bash
         run: |
           pip install -r ./crates/voicevox_core_python_api/requirements.txt
           maturin build --manifest-path ./crates/voicevox_core_python_api/Cargo.toml --features ${{ matrix.features }}, --target ${{ matrix.target }} --release
@@ -164,10 +162,8 @@ jobs:
         env:
           ORT_USE_CUDA: ${{ matrix.use_cuda }}
       - name: Set ASSET_NAME env var
-        shell: bash
         run: echo "ASSET_NAME=voicevox_core-${{ matrix.artifact_name }}-${{ env.VERSION }}" >> "$GITHUB_ENV"
       - name: Organize artifact
-        shell: bash
         run: |
           mkdir -p "artifact/${{ env.ASSET_NAME }}"
           cp -v crates/voicevox_core_c_api/include/voicevox_core.h "artifact/${{ env.ASSET_NAME }}"
@@ -181,7 +177,6 @@ jobs:
           echo "${{ env.VERSION }}" > "artifact/${{ env.ASSET_NAME }}/VERSION"
       - name: Code signing (Windows)
         if: startsWith(matrix.os, 'windows') && github.event.inputs.code_signing == 'true'
-        shell: bash
         run: |
           bash build_util/codesign.bash "artifact/${{ env.ASSET_NAME }}/voicevox_core.dll"
         env:
@@ -194,7 +189,6 @@ jobs:
           name: voicevox_core-${{ matrix.target }}
           path: artifact/${{ env.ASSET_NAME }}
       - name: Archive artifact
-        shell: bash
         run: |
           cd artifact
           7z a "../${{ env.ASSET_NAME }}.zip" "${{ env.ASSET_NAME }}"
@@ -221,7 +215,6 @@ jobs:
     runs-on: macos-12
     steps:
       - name: Set ASSET_NAME env var
-        shell: bash
         run: echo "ASSET_NAME=voicevox_core-ios-xcframework-cpu-${{ env.VERSION }}" >> "$GITHUB_ENV"
       - uses: actions/download-artifact@v2
         with:
@@ -236,12 +229,10 @@ jobs:
           name: voicevox_core-aarch64-apple-ios
           path: artifact/voicevox_core-aarch64-apple-ios
       - name: Create fat binary
-        shell: bash
         run: |
           mkdir -p "artifact/voicevox_core-sim"
           lipo -create "artifact/voicevox_core-x86_64-apple-ios/libvoicevox_core.dylib" "artifact/voicevox_core-aarch64-apple-ios-sim/libvoicevox_core.dylib" -output "artifact/voicevox_core-sim/libvoicevox_core.dylib"
       - name: Create XCFramework
-        shell: bash
         run: |
           mkdir -p "artifact/${{ env.ASSET_NAME }}"
           xcodebuild -create-xcframework \
@@ -251,7 +242,6 @@ jobs:
             -headers "artifact/voicevox_core-aarch64-apple-ios/voicevox_core.h" \
             -output "artifact/${{ env.ASSET_NAME }}/voicevox_core.xcframework"
       - name: Archive artifact
-        shell: bash
         run: |
           cd artifact/${{ env.ASSET_NAME }}
           7z a "../../${{ env.ASSET_NAME }}.zip" "voicevox_core.xcframework"
@@ -302,7 +292,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install cross compiler for aarch64-unknown-linux-gnu
         if: matrix.target == 'aarch64-unknown-linux-gnu'
-        shell: bash
         run: |
           sudo apt update
           sudo apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
@@ -313,7 +302,6 @@ jobs:
       - name: Build downloader
         run: cargo build -vv --release -p download --target ${{ matrix.target }}
       - name: Rename the binary
-        shell: bash
         run: |
           case "$OS" in
             Windows) exe_suffix=.exe;;
@@ -322,7 +310,6 @@ jobs:
           mv $"target/${{ matrix.target }}/release/download$exe_suffix" ./${{ matrix.name }}
       - name: Code signing (Windows)
         if: startsWith(matrix.os, 'windows') && github.event.inputs.code_signing == 'true'
-        shell: bash
         run: |
           bash build_util/codesign.bash ./${{ matrix.name }}
         env:

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -2,6 +2,9 @@ name: cargo-deny
 on:
   push:
   pull_request:
+defaults:
+  run:
+    shell: bash
 jobs:
   cargo-deny:
     runs-on: ubuntu-20.04

--- a/.github/workflows/download_test.yml
+++ b/.github/workflows/download_test.yml
@@ -9,6 +9,9 @@ on:
       - "crates/download/**"
       - "scripts/downloads/*"
       - ".github/workflows/download_test.yml"
+defaults:
+  run:
+    shell: bash
 jobs:
   download-releases:
     strategy:
@@ -296,18 +299,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Get latest version
         if: ${{ env.EXPECTED_VOICEVOX_CORE_VERSION == 'latest' }}
-        shell: bash
         run: |
           echo "EXPECTED_VOICEVOX_CORE_VERSION=$(gh release view --repo VOICEVOX/voicevox_core --json 'tagName' --jq '.tagName')" >> "$GITHUB_ENV"
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: Check downloaded version
-        shell: bash
         run: |
           [ -e "${{ matrix.download_dir }}/VERSION" ]
           [ "$(cat "${{ matrix.download_dir }}/VERSION")" = "${{ env.EXPECTED_VOICEVOX_CORE_VERSION }}" ]
       - name: Check downloaded files
-        shell: bash
         run: |
           mapfile -t items < <(echo -n '${{ matrix.check_items }}')
           for item in "${items[@]}"
@@ -317,7 +317,6 @@ jobs:
             [ -e "${{ matrix.download_dir }}"/${item} ]
           done
       - name: Check should not exists files
-        shell: bash
         run: |
           mapfile -t items < <(echo -n '${{ matrix.check_not_exists_items }}')
           for item in "${items[@]}"

--- a/.github/workflows/generate_document.yml
+++ b/.github/workflows/generate_document.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
   pull_request:
+defaults:
+  run:
+    shell: bash
 jobs:
   generate_api_document:
     runs-on: ubuntu-latest

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,6 +2,9 @@ name: Issue Labeler
 on:
   issues:
     types: [opened]
+defaults:
+  run:
+    shell: bash
 
 jobs:
   triage:

--- a/.github/workflows/psscriptanalyzer.yml
+++ b/.github/workflows/psscriptanalyzer.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - '**.ps1'
       - '.github/workflows/psscriptanalyzer.yml'
+defaults:
+  run:
+    shell: bash
 jobs:
   psscriptanalyzer:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -193,6 +193,9 @@ jobs:
       SOLUTION_FILE_PATH: example\cpp\windows\windows_example.sln
       # Configuration type to build.
       BUILD_CONFIGURATION: Debug
+    defaults:
+      run:
+        shell: pwsh
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
       - "*"
       - "**/*"
   pull_request:
+defaults:
+  run:
+    shell: bash
 jobs:
   shellcheck:
     runs-on: ubuntu-22.04
@@ -102,7 +105,6 @@ jobs:
           # cargoのキャッシュが原因でテストが失敗する場合はバージョン部分をカウントアップすること
           key: "v2-cargo-test-cache-${{ matrix.features }}-${{ matrix.os }}"
       - name: Run cargo test
-        shell: bash
         run: cargo test -vv --features ,${{ matrix.features }} -- --include-ignored
 
   c-header:
@@ -173,12 +175,10 @@ jobs:
         uses: jwlawson/actions-setup-cmake@v1.13
       - name: Install build dependencies
         if: startsWith(matrix.os, 'ubuntu')
-        shell: bash
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake
       - name: Build
-        shell: bash
         run: |
           cd example/cpp/unix
           cmake -S . -B build
@@ -237,14 +237,10 @@ jobs:
         uses: ./.github/actions/rust-toolchain-from-file
       - name: venv作成
         uses: ./.github/actions/create-venv
-      - shell: bash
-        run: pip install -r ./crates/voicevox_core_python_api/requirements.txt
-      - shell: bash
-        run: cargo build -p voicevox_core_c_api -vv
-      - shell: bash
-        run: maturin build --manifest-path ./crates/voicevox_core_python_api/Cargo.toml --locked
-      - shell: bash
-        run: maturin develop --manifest-path ./crates/voicevox_core_python_api/Cargo.toml --locked
+      - run: pip install -r ./crates/voicevox_core_python_api/requirements.txt
+      - run: cargo build -p voicevox_core_c_api -vv
+      - run: maturin build --manifest-path ./crates/voicevox_core_python_api/Cargo.toml --locked
+      - run: maturin develop --manifest-path ./crates/voicevox_core_python_api/Cargo.toml --locked
       - name: 必要なDLLをカレントディレクトリにコピー
         run: |
           cp -v target/debug/build/onnxruntime-sys-*/out/onnxruntime_*/onnxruntime-*/lib/onnxruntime.dll . || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -204,7 +204,7 @@ jobs:
         run: cargo build -p voicevox_core_c_api -vv
       - name: 必要なfileをexampleのディレクトリに移動させる
         run: |
-          mkdir example/cpp/windows/simple_tts/lib/x64
+          mkdir -p example/cpp/windows/simple_tts/lib/x64
           cp -v crates/voicevox_core_c_api/include/voicevox_core.h example/cpp/windows/simple_tts/
           cp target/debug/voicevox_core.dll.lib example/cpp/windows/simple_tts/lib/x64/voicevox_core.lib
 

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -7,6 +7,10 @@ on:
       - "**"
   workflow_dispatch:
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   typos:
     runs-on: ubuntu-latest

--- a/.github/workflows/update_rust_toolchain.yml
+++ b/.github/workflows/update_rust_toolchain.yml
@@ -5,6 +5,9 @@ on:
       - main
   schedule:
     - cron: "0 0 * * *"
+defaults:
+  run:
+    shell: bash
 jobs:
   update-rust-toolchain:
     runs-on: ubuntu-latest
@@ -14,7 +17,6 @@ jobs:
       - name: set up stable rust
         uses: dtolnay/rust-toolchain@stable
       - name: update rust toolchain
-        shell: bash
         run: |
           rust_version=$(rustup run stable rustc --version | sed -r "s/.*([0-9]+\.[0-9]+\.[0-9]+[^ ]*).*/\1/")
           echo "$rust_version" > ./rust-toolchain


### PR DESCRIPTION
## 内容

shell: bashを不要にできるオプションがあったので指定してみました。
とりあえずubuntu以外でのOSで実行していたworkflowにのみ付けています。
https://docs.github.com/ja/actions/using-workflows/workflow-syntax-for-github-actions#defaultsrun

2023/06/19 14:30追記
shell: bashを付けるか付けないかでubuntu/mac上の挙動が変わり、かつ付けたときのほうが良さそうなので全部に付けました。