### PR TITLE
[project-s] project-s用のモデルを可能に

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -31,7 +31,7 @@ on:
       - "**/*"
 env:
   VOICEVOX_RESOURCE_VERSION: "0.15.0-preview.1"
-  VOICEVOX_FAT_RESOURCE_VERSION: "0.15.0-projects.1"
+  VOICEVOX_FAT_RESOURCE_VERSION: "0.15.0-projects.0"
   # releaseタグ名か、workflow_dispatchでのバージョン名か、'0.0.0'が入る
   VERSION: ${{ github.event.release.tag_name || github.event.inputs.version || '0.0.0' }}
   PRODUCTION_REPOSITORY_TAG: "0.15.0-projects.0" # 製品版のタグ名

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -31,7 +31,7 @@ on:
       - "**/*"
 env:
   VOICEVOX_RESOURCE_VERSION: "0.15.0-preview.1"
-  VOICEVOX_FAT_RESOURCE_VERSION: "0.15.0-preview.0"
+  VOICEVOX_FAT_RESOURCE_VERSION: "0.15.0-projects.0"
   # releaseタグ名か、workflow_dispatchでのバージョン名か、'0.0.0'が入る
   VERSION: ${{ github.event.release.tag_name || github.event.inputs.version || '0.0.0' }}
   PRODUCTION_REPOSITORY_TAG: "0.15.0-preview.0" # 製品版のタグ名

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -34,7 +34,7 @@ env:
   VOICEVOX_FAT_RESOURCE_VERSION: "0.15.0-projects.1"
   # releaseタグ名か、workflow_dispatchでのバージョン名か、'0.0.0'が入る
   VERSION: ${{ github.event.release.tag_name || github.event.inputs.version || '0.0.0' }}
-  PRODUCTION_REPOSITORY_TAG: "0.15.0-preview.0" # 製品版のタグ名
+  PRODUCTION_REPOSITORY_TAG: "0.15.0-projects.0" # 製品版のタグ名
 defaults:
   run:
     shell: bash

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -31,7 +31,7 @@ on:
       - "**/*"
 env:
   VOICEVOX_RESOURCE_VERSION: "0.15.0-preview.1"
-  VOICEVOX_FAT_RESOURCE_VERSION: "0.15.0-projects.0"
+  VOICEVOX_FAT_RESOURCE_VERSION: "0.15.0-projects.1"
   # releaseタグ名か、workflow_dispatchでのバージョン名か、'0.0.0'が入る
   VERSION: ${{ github.event.release.tag_name || github.event.inputs.version || '0.0.0' }}
   PRODUCTION_REPOSITORY_TAG: "0.15.0-preview.0" # 製品版のタグ名


### PR DESCRIPTION
## 内容

project-s用のfat_resourceと秘匿コードを使って製品版のモデルを使用可能にします。
https://github.com/VOICEVOX/voicevox_fat_resource/releases/tag/0.15.0-projects.0

ローカルでビルドした結果はこちらです
https://github.com/Hiroshiba/voicevox_core/releases/tag/0.15.0-checkprojects.1

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_project/issues/15

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他

マージしてビルドしてみます。
