### PR TITLE
[project-vvm-async-api] `output_`系引数がunalignedであることを許す

### DIFF
--- a/crates/voicevox_core_c_api/src/slice_owner.rs
+++ b/crates/voicevox_core_c_api/src/slice_owner.rs
@@ -30,8 +30,8 @@ impl<T> SliceOwner<T> {
     ///
     /// # Safety
     ///
-    /// - `out_ptr`は有効でなければならない(ただし`*mut T`は有効である必要は無い)。
-    /// - `out_len`は有効でなければならない。
+    /// - `out_ptr`は書き込みについて有効でなければならない(ただし`*mut T`は有効である必要は無い)。
+    /// - `out_len`は書き込みについて有効でなければならない。
     pub(crate) unsafe fn own_and_lend(
         &self,
         slice: impl Into<Box<[T]>>,

--- a/crates/voicevox_core_c_api/src/slice_owner.rs
+++ b/crates/voicevox_core_c_api/src/slice_owner.rs
@@ -1,4 +1,4 @@
-use std::{cell::UnsafeCell, collections::BTreeMap, mem::MaybeUninit, sync::Mutex};
+use std::{cell::UnsafeCell, collections::BTreeMap, ptr::NonNull, sync::Mutex};
 
 /// Cの世界に貸し出す`[u8]`の所有者(owner)。
 ///
@@ -27,11 +27,16 @@ impl<T> SliceOwner<T> {
     }
 
     /// `Box<[T]>`を所有し、その先頭ポインタと長さを参照としてC API利用者に与える。
-    pub(crate) fn own_and_lend(
+    ///
+    /// # Safety
+    ///
+    /// - `out_ptr`は有効でなければならない(ただし`*mut T`は有効である必要は無い)。
+    /// - `out_len`は有効でなければならない。
+    pub(crate) unsafe fn own_and_lend(
         &self,
         slice: impl Into<Box<[T]>>,
-        out_ptr: &mut MaybeUninit<*mut T>,
-        out_len: &mut MaybeUninit<usize>,
+        out_ptr: NonNull<*mut T>,
+        out_len: NonNull<usize>,
     ) {
         let mut slices = self.slices.lock().unwrap();
 
@@ -42,8 +47,8 @@ impl<T> SliceOwner<T> {
         let duplicated = slices.insert(ptr as usize, slice.into()).is_some();
         assert!(!duplicated, "duplicated");
 
-        out_ptr.write(ptr);
-        out_len.write(len);
+        out_ptr.as_ptr().write_volatile(ptr);
+        out_len.as_ptr().write_volatile(len);
     }
 
     /// `own_and_lend`でC API利用者に貸し出したポインタに対応する`Box<[u8]>`をデストラクトする。
@@ -63,7 +68,7 @@ impl<T> SliceOwner<T> {
 
 #[cfg(test)]
 mod tests {
-    use std::mem::MaybeUninit;
+    use std::{mem::MaybeUninit, ptr::NonNull};
 
     use super::SliceOwner;
 
@@ -87,7 +92,11 @@ mod tests {
             let (ptr, len) = unsafe {
                 let mut ptr = MaybeUninit::uninit();
                 let mut len = MaybeUninit::uninit();
-                owner.own_and_lend(vec, &mut ptr, &mut len);
+                owner.own_and_lend(
+                    vec,
+                    NonNull::new(ptr.as_mut_ptr()).unwrap(),
+                    NonNull::new(len.as_mut_ptr()).unwrap(),
+                );
                 (ptr.assume_init(), len.assume_init())
             };
             assert_eq!(expected_len, len);


### PR DESCRIPTION
## 内容

C APIにおける`output_`系のポインタがunalignedであることを許可します。

Rustの[**参照** (_reference_)](https://doc.rust-lang.org/stable/std/primitive.reference.html)は**有効** (_valid_)であると同時に**アラインメントに沿って** (_aligned_)いなければなりません。そうでなければRustにおける**未定義動作** (_undefined behavior_)となります。そのためC側から渡される**生ポインタ** (_raw pointer_)を参照として解釈するときは、アラインメントにも注意する必要があります。

Cの`const VoicevoxSynthesizer*`を`&VoicevoxSynthesizer`として、`VoicevoxSynthesizer*`を`Box<VoicevoxSynthesizer>`として解釈するのにはアラインメント的な問題はありません。何故なら`VoicevoxSynthesizer`を作れるのはVOICEVOX COREだけであり、ユーザーは`VoicevoxSynthesizer`の実体に触れないようになっているため、「有効な`VoicevoxSynthesizer`のポインタ」がRustの世界で生まれたalignedなものであると言えるからです。また`const char*`を`&CStr`として読むときもアラインメントを気にする必要はありません。`c_char`は1バイトだからです。

しかしオブジェクトを"new"したり"create"したりする先の`T**`/`*mut *mut T`は別です。ドキュメントを通じてユーザーにお願いしない限り、`(T*)*`としてのアラインメントに沿わない (_unaligned_)ポインタが渡ってくる可能性があります。

このPRではC APIの`output_`系の引数をalignedだと仮定せず、`&mut`を経由しないように注意して[`<*mut T>::write_unaligned`](https://doc.rust-lang.org/stable/std/primitive.pointer.html#method.write_unaligned)で"new"/"create"対象を書き込むようにします。

最初「unalignedなポインタをよこすな」というドキュメントを書けばいいと思っていたのですが、実際に #532 で書こうとしたら我々とユーザーの両方に面倒を生じさせることに気づいてしまいました。アラインメントを気にする必要があるのは`output_`系の引数だけなので、`write_unaligned`する方が良いと思いました。

## 関連 Issue

- #497

## その他
