### PR TITLE
e2e系テストだけOS多めで、単体テストは１つのOSで

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/rust-toolchain-from-file
       - uses: Swatinem/rust-cache@v2
-      - name: Run cargo e2e test
+      - name: Run cargo integration test
         run: RUST_BACKTRACE=full cargo test --test "*" -vv --features ,${{ matrix.features }} -- --include-ignored
 
   c-header:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           # cargoのキャッシュが原因でテストが失敗する場合はバージョン部分をカウントアップすること
           key: "v1-cargo-unit-test-cache"
-      - name: Run cargo test
+      - name: Run cargo unit test
         run: RUST_BACKTRACE=full cargo test --lib --bins -vv --features , -- --include-ignored
 
   rust-e2e-test:
@@ -117,7 +117,7 @@ jobs:
         with:
           # cargoのキャッシュが原因でテストが失敗する場合はバージョン部分をカウントアップすること
           key: "v1-cargo-e2e-test-cache-${{ matrix.features }}-${{ matrix.os }}"
-      - name: Run cargo test
+      - name: Run cargo e2e test
         run: RUST_BACKTRACE=full cargo test --test "*" -vv --features ,${{ matrix.features }} -- --include-ignored
 
   c-header:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,20 @@ jobs:
       - run: cargo clippy -vv --all-features --features onnxruntime/disable-sys-build-script -- -D clippy::all -D warnings --no-deps
       - run: cargo fmt -- --check
 
-  rust-test:
+  rust-unit-test:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Rust
+        uses: ./.github/actions/rust-toolchain-from-file
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # cargoのキャッシュが原因でテストが失敗する場合はバージョン部分をカウントアップすること
+          key: "v1-cargo-unit-test-cache"
+      - name: Run cargo test
+        run: RUST_BACKTRACE=full cargo test --lib --bins -vv --features , -- --include-ignored
+
+  rust-e2e-test:
     strategy:
       fail-fast: false
       matrix:
@@ -103,9 +116,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           # cargoのキャッシュが原因でテストが失敗する場合はバージョン部分をカウントアップすること
-          key: "v2-cargo-test-cache-${{ matrix.features }}-${{ matrix.os }}"
+          key: "v1-cargo-e2e-test-cache-${{ matrix.features }}-${{ matrix.os }}"
       - name: Run cargo test
-        run: RUST_BACKTRACE=full cargo test -vv --features ,${{ matrix.features }} -- --include-ignored
+        run: RUST_BACKTRACE=full cargo test --test "*" -vv --features ,${{ matrix.features }} -- --include-ignored
 
   c-header:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Run cargo unit test
         run: RUST_BACKTRACE=full cargo test --lib --bins -vv --features , -- --include-ignored
 
-  rust-e2e-test:
+  rust-integration-test:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,9 +77,6 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/rust-toolchain-from-file
       - uses: Swatinem/rust-cache@v2
-        with:
-          # cargoのキャッシュが原因でテストが失敗する場合はバージョン部分をカウントアップすること
-          key: "v1-cargo-unit-test-cache"
       - name: Run cargo unit test
         run: RUST_BACKTRACE=full cargo test --lib --bins -vv --features , -- --include-ignored
 
@@ -114,9 +111,6 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/rust-toolchain-from-file
       - uses: Swatinem/rust-cache@v2
-        with:
-          # cargoのキャッシュが原因でテストが失敗する場合はバージョン部分をカウントアップすること
-          key: "v1-cargo-e2e-test-cache-${{ matrix.features }}-${{ matrix.os }}"
       - name: Run cargo e2e test
         run: RUST_BACKTRACE=full cargo test --test "*" -vv --features ,${{ matrix.features }} -- --include-ignored
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,8 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/rust-toolchain-from-file
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: "cargo-unit-test-cache"
       - name: Run cargo unit test
         run: RUST_BACKTRACE=full cargo test --lib --bins -vv --features , -- --include-ignored
 
@@ -111,6 +113,8 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/rust-toolchain-from-file
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: "cargo-integration-test-cache-${{ matrix.features }}-${{ matrix.os }}"
       - name: Run cargo integration test
         run: RUST_BACKTRACE=full cargo test --test "*" -vv --features ,${{ matrix.features }} -- --include-ignored
 


### PR DESCRIPTION
## 内容

テスト時間を減らすためのプルリクエストです。
endtoendテストだけは全OSで行って、単体テストは単一のOSのみで行うようにしてみました。

テスト指定方法はこちらのコメントを参考にさせていただきました。

https://github.com/rust-lang/cargo/issues/10491#issuecomment-1074078912

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_core/pull/382
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他

長いのはendtoendテストな気がするし、あまりあまり意味がないかも･･･。


