### PR TITLE
ビルドを全通り試さない簡易テストモードを追加する

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -339,7 +339,7 @@ jobs:
           target_commitish: ${{ github.sha }}
 
   build_xcframework:
-    if: ${{ ${{ github.event_name != 'release' && github.event_name != 'workflow_dispatch' }} }} # env.IS_SIMPLE_TEST と同じ
+    if: ${{ github.event_name != 'release' && github.event_name != 'workflow_dispatch' }} # env.IS_SIMPLE_TEST と同じ
     needs: build_and_deploy
     runs-on: macos-12
     steps:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -44,13 +44,13 @@ defaults:
     shell: bash
 
 jobs:
-  strategy-matrix: # 実行対象の条件をフィルタリングする
+  build_and_deploy_strategy_matrix: # 実行対象の条件をフィルタリングする
     runs-on: ubuntu-latest
     outputs:
-      includes: ${{ steps.strategy-matrix.outputs.includes }}
+      includes: ${{ steps.strategy_matrix.outputs.includes }}
     steps:
       - name: declare strategy matrix
-        id: strategy-matrix
+        id: strategy_matrix
         run: |
           includes='[
             {
@@ -183,11 +183,11 @@ jobs:
           echo "includes=${includes}" >> "$GITHUB_OUTPUT"
 
   build_and_deploy:
-    needs: strategy-matrix
+    needs: build_and_deploy_strategy_matrix
     environment: ${{ github.event.inputs.is_production == 'true' && 'production' || '' }} # 製品版のenvironment
     strategy:
       matrix:
-        include: ${{ fromJson(needs.strategy-matrix.outputs.includes) }}
+        include: ${{ fromJson(needs.build_and_deploy_strategy_matrix.outputs.includes) }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3 # 製品版ではない場合

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -29,100 +29,165 @@ on:
     branches:
       - "*"
       - "**/*"
+
 env:
   VOICEVOX_RESOURCE_VERSION: "0.15.0-preview.1"
   VOICEVOX_FAT_RESOURCE_VERSION: "0.15.0-preview.0"
   # releaseタグ名か、workflow_dispatchでのバージョン名か、'0.0.0'が入る
   VERSION: ${{ github.event.release.tag_name || github.event.inputs.version || '0.0.0' }}
   PRODUCTION_REPOSITORY_TAG: "0.15.0-preview.0" # 製品版のタグ名
+  # 簡易テストとするかどうか。releaseとworkflow_dispatch以外は簡易テストとする
+  IS_SIMPLE_TEST: ${{ !(github.event.release || github.event.inputs) }}
+
 defaults:
   run:
     shell: bash
+
 jobs:
+  strategy-matrix: # 実行対象の条件をフィルタリングする
+    runs-on: ubuntu-latest
+    outputs:
+      includes: ${{ steps.strategy-matrix.outputs.includes }}
+    steps:
+      - name: declare strategy matrix
+        id: strategy-matrix
+        run: |
+          includes='[
+            {
+              "os": "windows-2019",
+              "features": "",
+              "target": "x86_64-pc-windows-msvc",
+              "artifact_name": "windows-x64-cpu",
+              "whl_local_version": "cpu",
+              "use_cuda": false,
+              "can_skip_in_simple_test": true
+            },
+            {
+              "os": "windows-2019",
+              "features": "directml",
+              "target": "x86_64-pc-windows-msvc",
+              "artifact_name": "windows-x64-directml",
+              "whl_local_version": "directml",
+              "use_cuda": false,
+              "can_skip_in_simple_test": false
+            },
+            {
+              "os": "windows-2019",
+              "features": "",
+              "target": "x86_64-pc-windows-msvc",
+              "artifact_name": "windows-x64-cuda",
+              "whl_local_version": "cuda",
+              "use_cuda": true,
+              "can_skip_in_simple_test": true
+            },
+            {
+              "os": "windows-2019",
+              "features": "",
+              "target": "i686-pc-windows-msvc",
+              "artifact_name": "windows-x86-cpu",
+              "whl_local_version": "cpu",
+              "use_cuda": false,
+              "can_skip_in_simple_test": true
+            },
+            {
+              "os": "ubuntu-20.04",
+              "features": "",
+              "target": "x86_64-unknown-linux-gnu",
+              "artifact_name": "linux-x64-cpu",
+              "whl_local_version": "cpu",
+              "use_cuda": false,
+              "can_skip_in_simple_test": true
+            },
+            {
+              "os": "ubuntu-20.04",
+              "features": "",
+              "target": "x86_64-unknown-linux-gnu",
+              "artifact_name": "linux-x64-gpu",
+              "whl_local_version": "cuda",
+              "use_cuda": true,
+              "can_skip_in_simple_test": false
+            },
+            {
+              "os": "ubuntu-20.04",
+              "features": "",
+              "target": "aarch64-unknown-linux-gnu",
+              "artifact_name": "linux-arm64-cpu",
+              "whl_local_version": "cpu",
+              "use_cuda": false,
+              "can_skip_in_simple_test": true
+            },
+            {
+              "os": "ubuntu-20.04",
+              "features": "",
+              "target": "aarch64-linux-android",
+              "artifact_name": "android-arm64-cpu",
+              "use_cuda": false,
+              "can_skip_in_simple_test": true
+            },
+            {
+              "os": "ubuntu-20.04",
+              "features": "",
+              "target": "x86_64-linux-android",
+              "artifact_name": "android-x86_64-cpu",
+              "use_cuda": false,
+              "can_skip_in_simple_test": true
+            },
+            {
+              "os": "macos-11",
+              "features": "",
+              "target": "aarch64-apple-darwin",
+              "artifact_name": "osx-arm64-cpu",
+              "whl_local_version": "cpu",
+              "use_cuda": false,
+              "can_skip_in_simple_test": false
+            },
+            {
+              "os": "macos-11",
+              "features": "",
+              "target": "x86_64-apple-darwin",
+              "artifact_name": "osx-x64-cpu",
+              "whl_local_version": "cpu",
+              "use_cuda": false,
+              "can_skip_in_simple_test": true
+            },
+            {
+              "os": "macos-12",
+              "features": "",
+              "target": "aarch64-apple-ios",
+              "artifact_name": "ios-arm64-cpu",
+              "use_cuda": false,
+              "can_skip_in_simple_test": true
+            },
+            {
+              "os": "macos-12",
+              "features": "",
+              "target": "aarch64-apple-ios-sim",
+              "artifact_name": "ios-arm64-cpu-sim",
+              "use_cuda": false,
+              "can_skip_in_simple_test": true
+            },
+            {
+              "os": "macos-12",
+              "features": "",
+              "target": "x86_64-apple-ios",
+              "artifact_name": "ios-x64-cpu",
+              "use_cuda": false,
+              "can_skip_in_simple_test": true
+            }
+          ]'
+
+          if ${{ env.IS_SIMPLE_TEST }}; then
+            includes=$(echo $includes | jq -c '[.[] | select(.can_skip_in_simple_test == false)]')
+          fi
+          includes=$(echo $includes | jq -c '[.[] | del(.can_skip_in_simple_test)]')
+          echo "includes=${includes}" >> $GITHUB_OUTPUT
+
   build_and_deploy:
+    needs: strategy-matrix
     environment: ${{ github.event.inputs.is_production == 'true' && 'production' || '' }} # 製品版のenvironment
     strategy:
       matrix:
-        include:
-          - os: windows-2019
-            features: ""
-            target: x86_64-pc-windows-msvc
-            artifact_name: windows-x64-cpu
-            whl_local_version: cpu
-            use_cuda: false
-          - os: windows-2019
-            features: directml
-            target: x86_64-pc-windows-msvc
-            artifact_name: windows-x64-directml
-            whl_local_version: directml
-            use_cuda: false
-          - os: windows-2019
-            features: ""
-            target: x86_64-pc-windows-msvc
-            artifact_name: windows-x64-cuda
-            whl_local_version: cuda
-            use_cuda: true
-          - os: windows-2019
-            features: ""
-            target: i686-pc-windows-msvc
-            artifact_name: windows-x86-cpu
-            whl_local_version: cpu
-            use_cuda: false
-          - os: ubuntu-20.04
-            features: ""
-            target: x86_64-unknown-linux-gnu
-            artifact_name: linux-x64-cpu
-            whl_local_version: cpu
-            use_cuda: false
-          - os: ubuntu-20.04
-            features: ""
-            target: x86_64-unknown-linux-gnu
-            artifact_name: linux-x64-gpu
-            whl_local_version: cuda
-            use_cuda: true
-          - os: ubuntu-20.04
-            features: ""
-            target: aarch64-unknown-linux-gnu
-            artifact_name: linux-arm64-cpu
-            whl_local_version: cpu
-            use_cuda: false
-          - os: ubuntu-20.04
-            features: ""
-            target: aarch64-linux-android
-            artifact_name: android-arm64-cpu
-            use_cuda: false
-          - os: ubuntu-20.04
-            features: ""
-            target: x86_64-linux-android
-            artifact_name: android-x86_64-cpu
-            use_cuda: false
-          - os: macos-11
-            features: ""
-            target: aarch64-apple-darwin
-            artifact_name: osx-arm64-cpu
-            whl_local_version: cpu
-            use_cuda: false
-          - os: macos-11
-            features: ""
-            target: x86_64-apple-darwin
-            artifact_name: osx-x64-cpu
-            whl_local_version: cpu
-            use_cuda: false
-          - os: macos-12
-            features: ""
-            target: aarch64-apple-ios
-            artifact_name: ios-arm64-cpu
-            use_cuda: false
-          - os: macos-12
-            features: ""
-            target: aarch64-apple-ios-sim
-            artifact_name: ios-arm64-cpu-sim
-            use_cuda: false
-          - os: macos-12
-            features: ""
-            target: x86_64-apple-ios
-            artifact_name: ios-x64-cpu
-            use_cuda: false
+        include: ${{ fromJson(needs.strategy-matrix.outputs.includes) }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3 # 製品版ではない場合
@@ -272,6 +337,7 @@ jobs:
           files: |-
             ${{ steps.build-voicevox-core-python-api.outputs.whl }}
           target_commitish: ${{ github.sha }}
+
   build_xcframework:
     needs: build_and_deploy
     runs-on: macos-12
@@ -316,6 +382,7 @@ jobs:
           files: |-
             ${{ env.ASSET_NAME }}.zip
           target_commitish: ${{ github.sha }}
+
   deploy_downloader:
     runs-on: ubuntu-latest
     steps:
@@ -329,6 +396,7 @@ jobs:
           files: |-
             scripts/downloads/*
           target_commitish: ${{ github.sha }}
+
   deploy_precompiled_downloader:
     environment: ${{ github.event.inputs.is_production == 'true' && 'production' || '' }} # コード署名用のenvironment
     strategy:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -37,7 +37,7 @@ env:
   VERSION: ${{ github.event.release.tag_name || github.event.inputs.version || '0.0.0' }}
   PRODUCTION_REPOSITORY_TAG: "0.15.0-preview.0" # 製品版のタグ名
   # 簡易テストとするかどうか。releaseとworkflow_dispatch以外は簡易テストとする
-  IS_SIMPLE_TEST: ${{ !(github.event.release || github.event.inputs) }}
+  IS_SIMPLE_TEST: ${{ github.event_name != 'release' && github.event_name != 'workflow_dispatch' }}
 
 defaults:
   run:
@@ -339,7 +339,7 @@ jobs:
           target_commitish: ${{ github.sha }}
 
   build_xcframework:
-    if: ${{ !(github.event.release || github.event.inputs) }} # env.IS_SIMPLE_TEST と同じ
+    if: ${{ ${{ github.event_name != 'release' && github.event_name != 'workflow_dispatch' }} }} # env.IS_SIMPLE_TEST と同じ
     needs: build_and_deploy
     runs-on: macos-12
     steps:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -339,7 +339,7 @@ jobs:
           target_commitish: ${{ github.sha }}
 
   build_xcframework:
-    if: ${{ github.event_name != 'release' && github.event_name != 'workflow_dispatch' }} # env.IS_SIMPLE_TEST と同じ
+    if: ${{ !(github.event_name != 'release' && github.event_name != 'workflow_dispatch') }} # !env.IS_SIMPLE_TEST と同じ
     needs: build_and_deploy
     runs-on: macos-12
     steps:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -339,6 +339,7 @@ jobs:
           target_commitish: ${{ github.sha }}
 
   build_xcframework:
+    if: ${{ !(github.event.release || github.event.inputs) }} # env.IS_SIMPLE_TEST と同じ
     needs: build_and_deploy
     runs-on: macos-12
     steps:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -177,9 +177,9 @@ jobs:
           ]'
 
           if ${{ env.IS_SIMPLE_TEST }}; then
-            includes=$(echo $includes | jq -c '[.[] | select(.can_skip_in_simple_test == false)]')
+            includes=$(echo "$includes" | jq -c '[.[] | select(.can_skip_in_simple_test == false)]')
           fi
-          includes=$(echo $includes | jq -c '[.[] | del(.can_skip_in_simple_test)]')
+          includes=$(echo "$includes" | jq -c '[.[] | del(.can_skip_in_simple_test)]')
           echo "includes=${includes}" >> $GITHUB_OUTPUT
 
   build_and_deploy:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -176,6 +176,7 @@ jobs:
             }
           ]'
 
+          # FIXME: composite action に切り出す
           if ${{ env.IS_SIMPLE_TEST }}; then
             includes=$(echo "$includes" | jq -c '[.[] | select(.can_skip_in_simple_test == false)]')
           fi

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -180,7 +180,7 @@ jobs:
             includes=$(echo "$includes" | jq -c '[.[] | select(.can_skip_in_simple_test == false)]')
           fi
           includes=$(echo "$includes" | jq -c '[.[] | del(.can_skip_in_simple_test)]')
-          echo "includes=${includes}" >> $GITHUB_OUTPUT
+          echo "includes=${includes}" >> "$GITHUB_OUTPUT"
 
   build_and_deploy:
     needs: strategy-matrix

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -251,7 +251,7 @@ jobs:
         working-directory: ${{env.GITHUB_WORKSPACE}}
         run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
 
-  build-python-api:
+  build-and-test-python-api:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,22 @@
 name: test workflow
+
 on:
   push:
     branches:
       - "*"
       - "**/*"
   pull_request:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  # 簡易テストとするかどうか。workflow_dispatch以外は簡易テストとする
+  IS_SIMPLE_TEST: ${{ !(github.event.inputs) }}
+
 defaults:
   run:
     shell: bash
+
 jobs:
   shellcheck:
     runs-on: ubuntu-22.04
@@ -82,7 +91,33 @@ jobs:
       - name: Run cargo unit test
         run: RUST_BACKTRACE=full cargo test --lib --bins -vv --features , -- --include-ignored
 
+  rust-integration-test-strategy-matrix: # 実行対象の条件をフィルタリングする
+    runs-on: ubuntu-latest
+    outputs:
+      includes: ${{ steps.strategy-matrix.outputs.includes }}
+    steps:
+      - name: declare strategy matrix
+        id: strategy-matrix
+        run: |
+          includes='[
+            { "os": "windows-2019", "features": "", "can_skip_in_simple_test": true },
+            { "os": "windows-2022", "features": "", "can_skip_in_simple_test": true },
+            { "os": "windows-2019", "features": "directml", "can_skip_in_simple_test": false },
+            { "os": "windows-2022", "features": "directml", "can_skip_in_simple_test": true },
+            { "os": "macos-11", "features": "", "can_skip_in_simple_test": false },
+            { "os": "macos-12", "features": "", "can_skip_in_simple_test": true },
+            { "os": "ubuntu-20.04", "features": "", "can_skip_in_simple_test": false },
+            { "os": "ubuntu-22.04", "features": "", "can_skip_in_simple_test": true }
+          ]'
+
+          if ${{ env.IS_SIMPLE_TEST }}; then
+            includes=$(echo "$includes" | jq -c '[.[] | select(.can_skip_in_simple_test == false)]')
+          fi
+          includes=$(echo "$includes" | jq -c '[.[] | del(.can_skip_in_simple_test)]')
+          echo "includes=${includes}" >> "$GITHUB_OUTPUT"
+
   rust-integration-test:
+    needs: rust-integration-test-strategy-matrix
     strategy:
       fail-fast: false
       matrix:
@@ -264,6 +299,3 @@ jobs:
 
           pip install -r requirements-test.txt
           pytest
-
-env:
-  CARGO_TERM_COLOR: always

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,6 +110,7 @@ jobs:
             { "os": "ubuntu-22.04", "features": "", "can_skip_in_simple_test": true }
           ]'
 
+          # FIXME: composite action に切り出す
           if ${{ env.IS_SIMPLE_TEST }}; then
             includes=$(echo "$includes" | jq -c '[.[] | select(.can_skip_in_simple_test == false)]')
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   # 簡易テストとするかどうか。workflow_dispatch以外は簡易テストとする
-  IS_SIMPLE_TEST: ${{ !(github.event.inputs) }}
+  IS_SIMPLE_TEST: ${{ github.event_name != 'workflow_dispatch' }}
 
 defaults:
   run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,23 +121,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: windows-2019
-            features: ""
-          - os: windows-2022
-            features: ""
-          - os: windows-2019
-            features: directml
-          - os: windows-2022
-            features: directml
-          - os: macos-11
-            features: ""
-          - os: macos-12
-            features: ""
-          - os: ubuntu-20.04
-            features: ""
-          - os: ubuntu-22.04
-            features: ""
+        include: ${{ fromJson(needs.rust-integration-test-strategy-matrix.outputs.includes) }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/voicevox_core/issues/373

の一環です。

プッシュするたびにかなり多くの環境と条件でビルドタスクが回っていて、その影響でテストがすごく時間かかっていました。
このプルリクエストでは簡易テストという概念を導入し、各OSにつき1つだけビルドテストするようにしてみました。

workflow_dispatch（Github Actionsから直接実行できるやつ）とreleaseの経路では全部のビルドを行います。
それ以外の経路（push・pull_request）では簡易テストとします。


## 関連 Issue

- https://github.com/VOICEVOX/voicevox_core/issues/373
- https://github.com/VOICEVOX/voicevox_core/pull/382

## その他

条件matrixを動的に変更する必要があるのですが、現状のgithub actionsでは前段階としてジョブを実行し、その出力結果を持ってmatrixを変更する以外方法がありません。
なので前段階のジョブ側に全条件のjsonを作っておいてフィルタリングするようにしました。

さすがに見づらかったのでジョブごとに改行を導入しました。
