### PR TITLE
[docs] update-rust-branchの案内を追加

### DIFF
--- a/.github/workflows/update_rust_toolchain.yml
+++ b/.github/workflows/update_rust_toolchain.yml
@@ -31,3 +31,4 @@ jobs:
           title: Update rust toolchain ${{ env.RUST_VERSION }}
           body: |
             Update rust toolchain ${{ env.RUST_VERSION }}
+            （１度プルリクエストを閉じて再度開くことでテストが実行できます。）


### PR DESCRIPTION
## 内容

定期的に実行されるRustのアップデートに関しての自動プルリクエストですが、1回プルリクエストを閉じて再オープンすることでテストを簡単に実行できることが分かりました。
忘れそうなので自分自身に案内してもらうように変更してみました。
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_core/pull/567#event-10004388002
<!--

関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他
