### PR TITLE
製品版VVMを使うようにする

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -29,10 +29,10 @@ on:
 
 env:
   VOICEVOX_RESOURCE_VERSION: "0.15.0-preview.1"
-  VOICEVOX_FAT_RESOURCE_VERSION: "0.15.0-preview.0"
+  VOICEVOX_FAT_RESOURCE_VERSION: "0.15.0-preview.1"
   # releaseタグ名か、workflow_dispatchでのバージョン名か、'0.0.0'が入る
   VERSION: ${{ github.event.release.tag_name || github.event.inputs.version || '0.0.0' }}
-  PRODUCTION_REPOSITORY_TAG: "0.15.0-preview.0" # 製品版のタグ名
+  PRODUCTION_REPOSITORY_TAG: "0.15.0-preview.1" # 製品版のタグ名
   # 簡易テストとするかどうか。releaseとworkflow_dispatch以外は簡易テストとする
   IS_SIMPLE_TEST: ${{ github.event_name != 'release' && github.event_name != 'workflow_dispatch' }}
 


### PR DESCRIPTION
## 内容

製品版のvvmを作成したので、それらが使えるようにします。

↓のvvmファイルが読み込めるはずです。
https://github.com/VOICEVOX/voicevox_fat_resource/tree/0d952dabaee41c239af528c98fa6fea4b32054f8/core/model

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_core/issues/545

## その他
