### PR TITLE
Fix: ドキュメント周りの色々を修正

### DIFF
--- a/crates/voicevox_core_python_api/python/voicevox_core/_models.py
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_models.py
@@ -166,28 +166,61 @@ class AudioQuery:
 
 
 class UserDictWordType(str, Enum):
+    """ユーザー辞書の単語の品詞。"""
+
     PROPER_NOUN = "PROPER_NOUN"
+    """固有名詞。"""
+
     COMMON_NOUN = "COMMON_NOUN"
+    """一般名詞。"""
+
     VERB = "VERB"
+    """動詞。"""
+
     ADJECTIVE = "ADJECTIVE"
+    """形容詞。"""
+
     SUFFIX = "SUFFIX"
+    """語尾。"""
 
 
 @pydantic.dataclasses.dataclass
 class UserDictWord:
+    """ユーザー辞書の単語。"""
+
     surface: str
+    """言葉の表層形。"""
+
     pronunciation: str
+    """言葉の発音。
+
+    カタカナで表記する。
+    """
+
     accent_type: int = dataclasses.field(default=0)
+    """アクセント型。
+
+    音が下がる場所を指す。
+    """
+
     word_type: UserDictWordType = dataclasses.field(
         default=UserDictWordType.COMMON_NOUN
     )
+    """品詞。"""
+
     priority: int = dataclasses.field(default=5)
+    """単語の優先度。
+
+    0から10までの整数。
+    数字が大きいほど優先度が高くなる。
+    1から9までの値を指定することを推奨する。
+    """
 
     @pydantic.validator("pronunciation")
-    def validate_pronunciation(cls, v):
+    def _validate_pronunciation(cls, v):
         _validate_pronunciation(v)
         return v
 
     @pydantic.validator("surface")
-    def validate_surface(cls, v):
+    def _validate_surface(cls, v):
         return _to_zenkaku(v)

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust.pyi
@@ -4,8 +4,9 @@ from uuid import UUID
 
 import numpy as np
 from numpy.typing import NDArray
+
 if TYPE_CHECKING:
-    from voicevox_core._models import (
+    from voicevox_core import (
         AccelerationMode,
         AccentPhrase,
         AudioQuery,
@@ -18,8 +19,7 @@ if TYPE_CHECKING:
 __version__: str
 
 def supported_devices() -> SupportedDevices:
-    """
-    このライブラリで利用可能なデバイスの情報を取得する。
+    """このライブラリで利用可能なデバイスの情報を取得する。
 
     .. code-block::
 
@@ -33,11 +33,13 @@ class VoiceModel:
     """音声モデル。"""
 
     @staticmethod
-    async def from_path(path: Union[Path, str]) -> "VoiceModel":
-        """
-        VVMファイルから ``VoiceModel`` を生成する。
+    async def from_path(path: Union[Path, str]) -> VoiceModel:
+        """VVMファイルから ``VoiceModel`` を生成する。
 
-        :param path: VVMファイルへのパス。
+        Parameters
+        ----------
+        path
+            VVMファイルへのパス。
         """
         ...
     @property
@@ -50,13 +52,17 @@ class VoiceModel:
         ...
 
 class OpenJtalk:
-    """
-    テキスト解析器としてのOpen JTalk。
+    """テキスト解析器としてのOpen JTalk。"""
 
-    :param open_jtalk_dict_dir: open_jtalkの辞書ディレクトリ。
-    """
+    def __init__(self, open_jtalk_dict_dir: Union[Path, str]) -> None:
+        """Open JTalkを初期化する。
 
-    def __init__(self, open_jtalk_dict_dir: Union[Path, str]) -> None: ...
+        Parameters
+        ----------
+        open_jtalk_dict_dir
+            Open JTalkの辞書ディレクトリ。
+        """
+        ...
     def use_user_dict(self, user_dict: UserDict) -> None:
         """ユーザー辞書を設定する。
 
@@ -81,13 +87,18 @@ class Synthesizer:
         cpu_num_threads: int = 0,
         load_all_models: bool = False,
     ) -> "Synthesizer":
-        """
-        :class:`Synthesizer` を生成する。
+        """:class:`Synthesizer` を生成する。
 
-        :param open_jtalk: Open JTalk。
-        :param acceleration_mode: ハードウェアアクセラレーションモード。
-        :param cpu_num_threads: CPU利用数を指定。0を指定すると環境に合わせたCPUが利用される。
-        :param load_all_models: 全てのモデルを読み込む。
+        Parameters
+        ----------
+        open_jtalk
+            Open JTalk。
+        acceleration_mode
+            ハードウェアアクセラレーションモード。
+        cpu_num_threads
+            CPU利用数を指定。0を指定すると環境に合わせたCPUが利用される。
+        load_all_models
+            全てのモデルを読み込む。
         """
         ...
     def __repr__(self) -> str: ...
@@ -100,23 +111,34 @@ class Synthesizer:
         """メタ情報。"""
         ...
     async def load_voice_model(self, model: VoiceModel) -> None:
-        """
-        モデルを読み込む。
+        """モデルを読み込む。
 
-        :param style_id: 読み込むモデルのスタイルID。
+        Parameters
+        ----------
+        style_id
+            読み込むモデルのスタイルID。
         """
         ...
     def unload_voice_model(self, voice_model_id: str) -> None:
         """音声モデルの読み込みを解除する。
 
-        :param voice_model_id: 音声モデルID。
+        Parameters
+        ----------
+        voice_model_id
+            音声モデルID。
         """
         ...
     def is_loaded_voice_model(self, voice_model_id: str) -> bool:
-        """
-        指定したvoice_model_idのモデルが読み込まれているか判定する。
+        """指定したvoice_model_idのモデルが読み込まれているか判定する。
 
-        :returns: モデルが読み込まれているかどうか。
+        Parameters
+        ----------
+        voice_model_id
+            音声モデルID。
+
+        Returns
+        -------
+        モデルが読み込まれているかどうか。
         """
         ...
     async def audio_query(
@@ -125,14 +147,20 @@ class Synthesizer:
         style_id: int,
         kana: bool = False,
     ) -> AudioQuery:
-        """
-        :class:`AudioQuery` を生成する。
+        """:class:`AudioQuery` を生成する。
 
-        :param text: テキスト。文字コードはUTF-8。
-        :param style_id: スタイルID。
-        :param kana: ``text`` をAquesTalk風記法として解釈する。
+        Parameters
+        ----------
+        text
+            テキスト。文字コードはUTF-8。
+        style_id
+            スタイルID。
+        kana
+            ``text`` をAquesTalk風記法として解釈するかどうか。
 
-        :returns: 話者とテキストから生成された :class:`AudioQuery` 。
+        Returns
+        -------
+        話者とテキストから生成された :class:`AudioQuery` 。
         """
         ...
     async def create_accent_phrases(
@@ -141,14 +169,20 @@ class Synthesizer:
         style_id: int,
         kana: bool = False,
     ) -> List[AccentPhrase]:
-        """
-        AccentPhrase (アクセント句)の配列を生成する。
+        """AccentPhrase（アクセント句）の配列を生成する。
 
-        :param text: UTF-8の日本語テキストまたはAquesTalk風記法。
-        :param style_id: スタイルID。
-        :param kana: ``text`` をAquesTalk風記法として解釈する。
+        Parameters
+        ----------
+        text
+            UTF-8の日本語テキストまたはAquesTalk風記法。
+        style_id
+            スタイルID。
+        kana
+            ``text`` をAquesTalk風記法として解釈するかどうか。
 
-        :returns: :class:`AccentPhrase` の配列。
+        Returns
+        -------
+        :class:`AccentPhrase` の配列。
         """
         ...
     async def replace_mora_data(
@@ -156,10 +190,20 @@ class Synthesizer:
         accent_phrases: List[AccentPhrase],
         style_id: int,
     ) -> List[AccentPhrase]:
-        """アクセント句の音高・音素長を変更する。
+        """アクセント句の音高・音素長を変更した新しいアクセント句の配列を生成する。
 
-        :param accent_phrases: 変更元のアクセント句。
-        :param style_id: スタイルID。
+        元のアクセント句の音高・音素長は変更されない。
+
+        Parameters
+        ----------
+        accent_phrases:
+            変更元のアクセント句。
+        style_id:
+            スタイルID。
+
+        Returns
+        -------
+        新しいアクセント句の配列。
         """
         ...
     async def replace_phoneme_length(
@@ -167,11 +211,16 @@ class Synthesizer:
         accent_phrases: List[AccentPhrase],
         style_id: int,
     ) -> List[AccentPhrase]:
-        """
-        アクセント句の音素長を変更する。
+        """アクセント句の音素長を変更した新しいアクセント句の配列を生成する。
 
-        :param accent_phrases: 変更元のアクセント句。
-        :param style_id: スタイルID。
+        元のアクセント句の音素長は変更されない。
+
+        Parameters
+        ----------
+        accent_phrases
+            変更元のアクセント句。
+        style_id
+            スタイルID。
         """
         ...
     async def replace_mora_pitch(
@@ -179,11 +228,16 @@ class Synthesizer:
         accent_phrases: List[AccentPhrase],
         style_id: int,
     ) -> List[AccentPhrase]:
-        """
-        アクセント句の音高を変更する。
+        """アクセント句の音高を変更した新しいアクセント句の配列を生成する。
 
-        :param accent_phrases: 変更元のアクセント句。
-        :param style_id: スタイルID。
+        元のアクセント句の音高は変更されない。
+
+        Parameters
+        ----------
+        accent_phrases
+            変更元のアクセント句。
+        style_id
+            スタイルID。
         """
         ...
     async def synthesis(
@@ -192,14 +246,20 @@ class Synthesizer:
         style_id: int,
         enable_interrogative_upspeak: bool = True,
     ) -> bytes:
-        """
-        :class:`AudioQuery` から音声合成する。
+        """:class:`AudioQuery` から音声合成する。
 
-        :param audio_query: :class:`AudioQuery` 。
-        :param style_id: スタイルID。
-        :param enable_interrogative_upspeak: 疑問文の調整を有効にする。
+        Parameters
+        ----------
+        audio_query
+            :class:`AudioQuery` 。
+        style_id
+            スタイルID。
+        enable_interrogative_upspeak
+            疑問文の調整を有効にするかどうか。
 
-        :returns: WAVデータ。
+        Returns
+        -------
+        WAVデータ。
         """
         ...
     async def tts(
@@ -209,30 +269,35 @@ class Synthesizer:
         kana: bool = False,
         enable_interrogative_upspeak: bool = True,
     ) -> bytes:
-        """
-        テキスト音声合成を実行する。
+        """テキスト音声合成を実行する。
 
-        :param text: UTF-8の日本語テキストまたはAquesTalk風記法。
-        :param style_id: スタイルID。
-        :param kana: ``text`` をAquesTalk風記法として解釈する。
-        :param enable_interrogative_upspeak: 疑問文の調整を有効にする。
+        Parameters
+        ----------
+        text
+            UTF-8の日本語テキストまたはAquesTalk風記法。
+        style_id
+            スタイルID。
+        kana
+            ``text`` をAquesTalk風記法として解釈するかどうか。
+        enable_interrogative_upspeak
+            疑問文の調整を有効にするかどうか。
 
-        :returns: WAVデータ。
+        Returns
+        -------
+        WAVデータ。
         """
         ...
 
 class UserDict:
-    """ユーザー辞書。
+    """ユーザー辞書。"""
 
-    Attributes
-    ----------
-    words
-        エントリーのリスト。
-    """
+    @property
+    def words(self) -> Dict[UUID, UserDictWord]:
+        """単語のDict。"""
+        ...
 
-    words: Dict[UUID, UserDictWord]
     def __init__(self) -> None:
-        """ユーザー辞書をまたは新規作成する。"""
+        """ユーザー辞書を新規作成する。"""
         ...
     def load(self, path: str) -> None:
         """ファイルに保存されたユーザー辞書を読み込む。

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust.pyi
@@ -1,18 +1,19 @@
 from pathlib import Path
-from typing import Dict, Final, List, Literal, Union
+from typing import Dict, Final, List, Literal, Union, TYPE_CHECKING
 from uuid import UUID
 
 import numpy as np
 from numpy.typing import NDArray
-from voicevox_core import (
-    AccelerationMode,
-    AccentPhrase,
-    AudioQuery,
-    SpeakerMeta,
-    SupportedDevices,
-    UserDict,
-    UserDictWord,
-)
+if TYPE_CHECKING:
+    from voicevox_core._models import (
+        AccelerationMode,
+        AccentPhrase,
+        AudioQuery,
+        SpeakerMeta,
+        SupportedDevices,
+        UserDict,
+        UserDictWord,
+    )
 
 __version__: str
 

--- a/docs/apis/python_api/conf.py
+++ b/docs/apis/python_api/conf.py
@@ -16,7 +16,7 @@ project = "voicevox_core_python_api"
 
 autodoc_docstring_signature = True
 
-extensions = ["autoapi.extension"]
+extensions = ["autoapi.extension", "sphinx.ext.napoleon"]
 
 autoapi_type = "python"
 autoapi_dirs = ["../../../crates/voicevox_core_python_api/python"]

--- a/docs/apis/python_api/conf.py
+++ b/docs/apis/python_api/conf.py
@@ -6,7 +6,7 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'voicevox_core_python_api'
+project = "voicevox_core_python_api"
 # copyright = '2022, _'
 # author = '_'
 # release = '_'
@@ -20,6 +20,7 @@ extensions = ["autoapi.extension"]
 
 autoapi_type = "python"
 autoapi_dirs = ["../../../crates/voicevox_core_python_api/python"]
+autoapi_ignore = ["*test*"]
 autoapi_options = [
     "members",
     "undoc-members",
@@ -31,7 +32,6 @@ autoapi_options = [
 
 # templates_path = ['_templates']
 exclude_patterns = []
-
 
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION
## 内容

- ユーザー辞書の`__init__`がおかしかったので修正しました。
- ドキュメントをNumpy記法で統一しました。
	- ドキュメント生成のために[napoleon](https://www.sphinx-doc.org/ja/master/usage/extensions/napoleon.html)を拡張に入れました。標準付属のためrequirementsは変わっていません。

## 関連 Issue

- ref: https://github.com/VOICEVOX/voicevox_core/pull/532

## その他

逆にreSTに統一しても良かったかも？