### PR TITLE
Fix: voicevox_json_freeの対象が漏れていたことの修正

### DIFF
--- a/crates/voicevox_core_c_api/include/voicevox_core.h
+++ b/crates/voicevox_core_c_api/include/voicevox_core.h
@@ -914,6 +914,7 @@ VoicevoxResultCode voicevox_synthesizer_tts(const struct VoicevoxSynthesizer *sy
  *     - ::voicevox_synthesizer_replace_mora_data
  *     - ::voicevox_synthesizer_replace_phoneme_length
  *     - ::voicevox_synthesizer_replace_mora_pitch
+ *     - ::voicevox_user_dict_to_json
  * - 文字列の長さは生成時より変更されていてはならない。
  * - `json`は<a href="#voicevox-core-safety">読み込みと書き込みについて有効</a>でなければならない。
  * - `json`は以後<b>ダングリングポインタ</b>(_dangling pointer_)として扱われなくてはならない。
@@ -1075,6 +1076,8 @@ VoicevoxResultCode voicevox_user_dict_remove_word(const struct VoicevoxUserDict 
 
 /**
  * ユーザー辞書の単語をJSON形式で出力する。
+ *
+ * 生成したJSON文字列を解放するには ::voicevox_json_free を使う。
  *
  * @param [in] user_dict ユーザー辞書
  * @param [out] output_json 出力先

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -887,6 +887,7 @@ pub unsafe extern "C" fn voicevox_synthesizer_tts(
 ///     - ::voicevox_synthesizer_replace_mora_data
 ///     - ::voicevox_synthesizer_replace_phoneme_length
 ///     - ::voicevox_synthesizer_replace_mora_pitch
+///     - ::voicevox_user_dict_to_json
 /// - 文字列の長さは生成時より変更されていてはならない。
 /// - `json`は<a href="#voicevox-core-safety">読み込みと書き込みについて有効</a>でなければならない。
 /// - `json`は以後<b>ダングリングポインタ</b>(_dangling pointer_)として扱われなくてはならない。
@@ -1123,6 +1124,8 @@ pub extern "C" fn voicevox_user_dict_remove_word(
 }
 
 /// ユーザー辞書の単語をJSON形式で出力する。
+/// 
+/// 生成したJSON文字列を解放するには ::voicevox_json_free を使う。
 ///
 /// @param [in] user_dict ユーザー辞書
 /// @param [out] output_json 出力先

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -1124,7 +1124,7 @@ pub extern "C" fn voicevox_user_dict_remove_word(
 }
 
 /// ユーザー辞書の単語をJSON形式で出力する。
-/// 
+///
 /// 生成したJSON文字列を解放するには ::voicevox_json_free を使う。
 ///
 /// @param [in] user_dict ユーザー辞書


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

`C_STRING_DROP_CHECKER.whitelist` に入れられた文字列は、Rust側でfreeする必要があるが、
user_dictが出力しているjson文字列も対象であることがdocumentから抜け落ちていた。

それに対応し、C-Headerを再生成した。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他
