### PR TITLE
RustのdoctestをCI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,6 +87,8 @@ jobs:
           key: "cargo-unit-test-cache"
       - name: Run cargo unit test
         run: RUST_BACKTRACE=full cargo test --lib --bins -vv --features , -- --include-ignored
+      - name: Run cargo documentation test
+        run: RUST_BACKTRACE=full cargo test --doc -vv
 
   rust-integration-test-strategy-matrix: # 実行対象の条件をフィルタリングする
     runs-on: ubuntu-latest

--- a/crates/voicevox_core/src/voice_synthesizer.rs
+++ b/crates/voicevox_core/src/voice_synthesizer.rs
@@ -333,8 +333,8 @@ impl Synthesizer {
     ///
     /// let accent_phrases = syntesizer
     ///     .create_accent_phrases(
-    ///         "こんにちは",    // 日本語のテキスト
-    ///         StyleId::new(2), // "四国めたん (ノーマル)",
+    ///         "こんにちは", // 日本語のテキスト
+    ///         StyleId::new(302),
     ///         &Default::default(),
     ///     )
     ///     .await?;
@@ -378,8 +378,8 @@ impl Synthesizer {
     ///
     /// let accent_phrases = syntesizer
     ///     .create_accent_phrases(
-    ///         "コンニチワ'",   // AquesTalk風記法
-    ///         StyleId::new(2), // "四国めたん (ノーマル)",
+    ///         "コンニチワ'", // AquesTalk風記法
+    ///         StyleId::new(302),
     ///         &AccentPhrasesOptions { kana: true },
     ///     )
     ///     .await?;
@@ -484,8 +484,8 @@ impl Synthesizer {
     ///
     /// let audio_query = syntesizer
     ///     .audio_query(
-    ///         "こんにちは",    // 日本語のテキスト
-    ///         StyleId::new(2), // "四国めたん (ノーマル)",
+    ///         "こんにちは", // 日本語のテキスト
+    ///         StyleId::new(302),
     ///         &Default::default(),
     ///     )
     ///     .await?;
@@ -529,8 +529,8 @@ impl Synthesizer {
     ///
     /// let audio_query = syntesizer
     ///     .audio_query(
-    ///         "コンニチワ'",   // AquesTalk風記法
-    ///         StyleId::new(2), // "四国めたん (ノーマル)",
+    ///         "コンニチワ'", // AquesTalk風記法
+    ///         StyleId::new(302),
     ///         &AudioQueryOptions { kana: true },
     ///     )
     ///     .await?;


### PR DESCRIPTION
## 内容

#547 によってRustのdoctestがテスト対象から外れたので、戻します。

[Documentation tests - The rustdoc book](https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html)

また #551 により、doctestが壊れていたのでそれも修正します。

## 関連 Issue

## その他
