### PR TITLE
VoiceModelのget_all_modelsがvvm以外のファイルも読み込もうとしてクラッシュすることの修正

### DIFF
--- a/crates/voicevox_core/src/voice_model.rs
+++ b/crates/voicevox_core/src/voice_model.rs
@@ -114,15 +114,12 @@ impl VoiceModel {
         for entry in root_dir
             .read_dir()
             .and_then(|entries| entries.collect::<std::result::Result<Vec<_>, _>>())
-            .map(|entries| {
-                entries
-                    .into_iter()
-                    .filter(|entry| entry.path().extension().map_or(false, |ext| ext == "vvm"))
-            })
             .map_err(|e| Error::LoadModel {
                 path: root_dir.clone(),
                 source: e.into(),
             })?
+            .into_iter()
+            .filter(|entry| entry.path().extension().map_or(false, |ext| ext == "vvm"))
         {
             vvm_paths.push(Self::from_path(entry.path()));
         }

--- a/crates/voicevox_core/src/voice_model.rs
+++ b/crates/voicevox_core/src/voice_model.rs
@@ -110,8 +110,7 @@ impl VoiceModel {
                 .join("model")
         };
 
-        let mut vvm_paths = Vec::new();
-        for entry in root_dir
+        let vvm_paths = root_dir
             .read_dir()
             .and_then(|entries| entries.collect::<std::result::Result<Vec<_>, _>>())
             .map_err(|e| Error::LoadModel {
@@ -120,9 +119,7 @@ impl VoiceModel {
             })?
             .into_iter()
             .filter(|entry| entry.path().extension().map_or(false, |ext| ext == "vvm"))
-        {
-            vvm_paths.push(Self::from_path(entry.path()));
-        }
+            .map(|entry| Self::from_path(entry.path()));
 
         join_all(vvm_paths).await.into_iter().collect()
     }

--- a/crates/voicevox_core/src/voice_model.rs
+++ b/crates/voicevox_core/src/voice_model.rs
@@ -111,17 +111,16 @@ impl VoiceModel {
         };
 
         let mut vvm_paths = Vec::new();
-        for entry in root_dir.read_dir().map_err(|e| Error::LoadModel {
-            path: root_dir.clone(),
-            source: e.into(),
-        })? {
-            match entry {
-                Ok(entry) => vvm_paths.push(Self::from_path(entry.path())),
-                Err(e) => Err(Error::LoadModel {
-                    path: root_dir.clone(),
-                    source: e.into(),
-                })?,
-            }
+        for entry in root_dir
+            .read_dir()
+            .map_err(|e| Error::LoadModel {
+                path: root_dir.clone(),
+                source: e.into(),
+            })?
+            .filter_map(|v| v.ok())
+            .filter(|entry| entry.path().extension().map_or(false, |ext| ext == "vvm"))
+        {
+            vvm_paths.push(Self::from_path(entry.path()));
         }
 
         join_all(vvm_paths).await.into_iter().collect()

--- a/crates/voicevox_core/src/voice_model.rs
+++ b/crates/voicevox_core/src/voice_model.rs
@@ -194,3 +194,15 @@ impl VvmEntryReader {
         Ok(buf)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[rstest]
+    #[tokio::test]
+    async fn get_all_models_only_load_vvm() {
+        let all_models = VoiceModel::get_all_models().await;
+        assert!(all_models.is_ok());
+    }
+}

--- a/crates/voicevox_core/src/voice_model.rs
+++ b/crates/voicevox_core/src/voice_model.rs
@@ -113,12 +113,16 @@ impl VoiceModel {
         let mut vvm_paths = Vec::new();
         for entry in root_dir
             .read_dir()
+            .and_then(|entries| entries.collect::<std::result::Result<Vec<_>, _>>())
+            .map(|entries| {
+                entries
+                    .into_iter()
+                    .filter(|entry| entry.path().extension().map_or(false, |ext| ext == "vvm"))
+            })
             .map_err(|e| Error::LoadModel {
                 path: root_dir.clone(),
                 source: e.into(),
             })?
-            .filter_map(|v| v.ok())
-            .filter(|entry| entry.path().extension().map_or(false, |ext| ext == "vvm"))
         {
             vvm_paths.push(Self::from_path(entry.path()));
         }

--- a/model/README.md
+++ b/model/README.md
@@ -1,0 +1,7 @@
+# サンプル VVM ファイル
+
+ここには、自分で一からビルドしたコアライブラリでのみ使用できるサンプルの [VVM ファイル](../docs/vvm.md) が含まれています。
+
+## 注意
+
+[Releases](https://github.com/VOICEVOX/voicevox_core/releases) にあるビルド済みのコアライブラリを使用している場合、このディレクトリの VVM ファイルは使用できません。

--- a/model/model.json
+++ b/model/model.json
@@ -1,3 +1,0 @@
-{
-  "message": "this model.json is not used, for testing purposes only"
-}

--- a/model/model.json
+++ b/model/model.json
@@ -1,0 +1,3 @@
+{
+  "message": "this model.json is not used, for testing purposes only"
+}


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

`get_all_models` 関数は `model` ディレクトリ内のファイルを列挙し、それぞれのファイルを `vvm` ファイルとして扱いロードを行う。
対象のディレクトリに `vvm` ファイル以外のファイルが含まれていた場合、そのファイルを `vvm` ファイルとして扱おうと処理を行い `VOICEVOX_OPEN_FILE_ERROR` を返してしまう。

`get_all_models` は `vvm` ファイルのみを対象とした関数としたほうが良いと考え、ディレクトリ内のファイルを検索した際、`vvm` の拡張子を持つファイルのみを読み込む対象にした。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他
