### PR TITLE
C-APIのnew_with_initializeで初期化した場合、metas jsonが空になってしまうことの修正

### DIFF
--- a/crates/voicevox_core_c_api/src/c_impls.rs
+++ b/crates/voicevox_core_c_api/src/c_impls.rs
@@ -55,3 +55,24 @@ impl VoicevoxVoiceModel {
         Ok(Self { model, id, metas })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ::test_util::OPEN_JTALK_DIC_DIR;
+    use rstest::*;
+
+    #[rstest]
+    #[tokio::test]
+    async fn new_with_initialize_must_output_metas_json() {
+        let open_jtalk = OpenJtalkRc::new_with_initialize(OPEN_JTALK_DIC_DIR).unwrap();
+        let mut options = InitializeOptions::default();
+        options.load_all_models = true;
+        let synthesizer = VoicevoxSynthesizer::new_with_initialize(&open_jtalk, &options)
+            .await
+            .unwrap();
+
+        println!("{:?}", synthesizer.metas());
+        assert_eq!(CStr::is_empty(synthesizer.metas()), false);
+    }
+}

--- a/crates/voicevox_core_c_api/src/c_impls.rs
+++ b/crates/voicevox_core_c_api/src/c_impls.rs
@@ -58,24 +58,3 @@ impl VoicevoxVoiceModel {
         Ok(Self { model, id, metas })
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use ::test_util::OPEN_JTALK_DIC_DIR;
-    use rstest::*;
-
-    #[rstest]
-    #[tokio::test]
-    async fn new_with_initialize_must_output_metas_json() {
-        let open_jtalk = OpenJtalkRc::new_with_initialize(OPEN_JTALK_DIC_DIR).unwrap();
-        let mut options = InitializeOptions::default();
-        options.load_all_models = true;
-        let synthesizer = VoicevoxSynthesizer::new_with_initialize(&open_jtalk, &options)
-            .await
-            .unwrap();
-
-        println!("{:?}", synthesizer.metas());
-        assert_eq!(CStr::is_empty(synthesizer.metas()), false);
-    }
-}

--- a/crates/voicevox_core_c_api/src/c_impls.rs
+++ b/crates/voicevox_core_c_api/src/c_impls.rs
@@ -21,10 +21,13 @@ impl VoicevoxSynthesizer {
         open_jtalk: &OpenJtalkRc,
         options: &InitializeOptions,
     ) -> Result<Self> {
+        let synthesizer =
+            Synthesizer::new_with_initialize(open_jtalk.open_jtalk.clone(), options).await?;
+        let metas = synthesizer.metas();
+        let metas_cstring = CString::new(serde_json::to_string(&metas).unwrap()).unwrap();
         Ok(Self {
-            synthesizer: Synthesizer::new_with_initialize(open_jtalk.open_jtalk.clone(), options)
-                .await?,
-            metas_cstring: CString::default(),
+            synthesizer,
+            metas_cstring,
         })
     }
 

--- a/crates/voicevox_core_c_api/tests/e2e/snapshots.toml
+++ b/crates/voicevox_core_c_api/tests/e2e/snapshots.toml
@@ -58,6 +58,49 @@ stderr.windows = '''
 '''
 stderr.unix = ""
 
+[synthesizer_new_with_initialize_output_json]
+metas = '''
+[
+  {
+    "name": "dummy1",
+    "styles": [
+      {
+        "id": 0,
+        "name": "style1"
+      }
+    ],
+    "version": "0.0.1",
+    "speaker_uuid": "574bc678-8370-44be-b941-08e46e7b47d7"
+  },
+  {
+    "name": "dummy2",
+    "styles": [
+      {
+        "id": 1,
+        "name": "style2"
+      }
+    ],
+    "version": "0.0.1",
+    "speaker_uuid": "dd9ccd75-75f6-40ce-a3db-960cbed2e905"
+  },
+  {
+    "name": "dummy3",
+    "styles": [
+      {
+        "id": 302,
+        "name": "style3-1"
+      },
+      {
+        "id": 303,
+        "name": "style3-2"
+      }
+    ],
+    "version": "0.0.1",
+    "speaker_uuid": "5d3d9aa9-88e5-4a96-8ef7-f13a3cad1cb3"
+  }
+]'''
+stderr = ""
+
 [tts_via_audio_query]
 output."こんにちは、音声合成の世界へようこそ".wav_length = 176172
 stderr.windows = '''

--- a/crates/voicevox_core_c_api/tests/e2e/snapshots.toml
+++ b/crates/voicevox_core_c_api/tests/e2e/snapshots.toml
@@ -99,7 +99,10 @@ metas = '''
     "speaker_uuid": "5d3d9aa9-88e5-4a96-8ef7-f13a3cad1cb3"
   }
 ]'''
-stderr = ""
+stderr.windows = '''
+{windows-video-cards}
+'''
+stderr.unix = ""
 
 [tts_via_audio_query]
 output."こんにちは、音声合成の世界へようこそ".wav_length = 176172

--- a/crates/voicevox_core_c_api/tests/e2e/symbols.rs
+++ b/crates/voicevox_core_c_api/tests/e2e/symbols.rs
@@ -250,7 +250,7 @@ pub(crate) enum VoicevoxAccelerationMode {
 pub(crate) struct VoicevoxInitializeOptions {
     pub(crate) acceleration_mode: VoicevoxAccelerationMode,
     pub(crate) _cpu_num_threads: u16,
-    pub(crate) _load_all_models: bool,
+    pub(crate) load_all_models: bool,
 }
 
 #[derive(Clone, Copy)]

--- a/crates/voicevox_core_c_api/tests/e2e/testcases.rs
+++ b/crates/voicevox_core_c_api/tests/e2e/testcases.rs
@@ -5,3 +5,4 @@ mod simple_tts;
 mod tts_via_audio_query;
 mod user_dict_load;
 mod user_dict_manipulate;
+mod synthesizer_new_with_initialize_output_json;

--- a/crates/voicevox_core_c_api/tests/e2e/testcases.rs
+++ b/crates/voicevox_core_c_api/tests/e2e/testcases.rs
@@ -2,7 +2,7 @@ mod compatible_engine;
 mod compatible_engine_load_model_before_initialize;
 mod global_info;
 mod simple_tts;
+mod synthesizer_new_with_initialize_output_json;
 mod tts_via_audio_query;
 mod user_dict_load;
 mod user_dict_manipulate;
-mod synthesizer_new_with_initialize_output_json;

--- a/crates/voicevox_core_c_api/tests/e2e/testcases/synthesizer_new_with_initialize_output_json.rs
+++ b/crates/voicevox_core_c_api/tests/e2e/testcases/synthesizer_new_with_initialize_output_json.rs
@@ -1,0 +1,97 @@
+use std::{
+    ffi::{CStr, CString},
+    mem::MaybeUninit,
+};
+
+use assert_cmd::assert::AssertResult;
+use libloading::Library;
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+
+use test_util::OPEN_JTALK_DIC_DIR;
+use voicevox_core::result_code::VoicevoxResultCode;
+
+use crate::{
+    assert_cdylib::{self, case, Utf8Output},
+    snapshots,
+    symbols::{Symbols, VoicevoxAccelerationMode, VoicevoxInitializeOptions},
+};
+
+case!(TestCase);
+
+#[derive(Serialize, Deserialize)]
+struct TestCase;
+
+#[typetag::serde(name = "synthesizer_new_with_initialize_output_json")]
+impl assert_cdylib::TestCase for TestCase {
+    unsafe fn exec(&self, lib: &Library) -> anyhow::Result<()> {
+        let Symbols {
+            voicevox_default_initialize_options,
+            voicevox_open_jtalk_rc_new,
+            voicevox_open_jtalk_rc_delete,
+            voicevox_synthesizer_new_with_initialize,
+            voicevox_synthesizer_delete,
+            voicevox_synthesizer_get_metas_json,
+            ..
+        } = Symbols::new(lib)?;
+
+        let openjtalk = {
+            let mut openjtalk = MaybeUninit::uninit();
+            let open_jtalk_dic_dir = CString::new(OPEN_JTALK_DIC_DIR).unwrap();
+            assert_ok(voicevox_open_jtalk_rc_new(
+                open_jtalk_dic_dir.as_ptr(),
+                openjtalk.as_mut_ptr(),
+            ));
+            openjtalk.assume_init()
+        };
+
+        let synthesizer = {
+            let mut synthesizer = MaybeUninit::uninit();
+            assert_ok(voicevox_synthesizer_new_with_initialize(
+                openjtalk,
+                VoicevoxInitializeOptions {
+                    acceleration_mode: VoicevoxAccelerationMode::VOICEVOX_ACCELERATION_MODE_CPU,
+                    _load_all_models: true,
+                    ..**voicevox_default_initialize_options
+                },
+                synthesizer.as_mut_ptr(),
+            ));
+            synthesizer.assume_init()
+        };
+
+        let metas_json = {
+            let metas_json =
+                CStr::from_ptr(voicevox_synthesizer_get_metas_json(synthesizer)).to_str()?;
+            serde_json::to_string_pretty(&metas_json.parse::<serde_json::Value>()?).unwrap()
+        };
+
+        std::assert_eq!(SNAPSHOTS.metas, metas_json);
+
+        voicevox_open_jtalk_rc_delete(openjtalk);
+        voicevox_synthesizer_delete(synthesizer);
+
+        return Ok(());
+
+        fn assert_ok(result_code: VoicevoxResultCode) {
+            std::assert_eq!(VoicevoxResultCode::VOICEVOX_RESULT_OK, result_code);
+        }
+    }
+
+    fn assert_output(&self, output: Utf8Output) -> AssertResult {
+        output
+            .mask_timestamps()
+            .mask_windows_video_cards()
+            .assert()
+            .try_success()?
+            .try_stdout("")?
+            .try_stderr(&*SNAPSHOTS.stderr)
+    }
+}
+
+static SNAPSHOTS: Lazy<Snapshots> = snapshots::section!(synthesizer_new_with_initialize_output_json);
+
+#[derive(Deserialize)]
+struct Snapshots {
+    metas: String,
+    stderr: String,
+}

--- a/crates/voicevox_core_c_api/tests/e2e/testcases/synthesizer_new_with_initialize_output_json.rs
+++ b/crates/voicevox_core_c_api/tests/e2e/testcases/synthesizer_new_with_initialize_output_json.rs
@@ -94,5 +94,6 @@ static SNAPSHOTS: Lazy<Snapshots> =
 #[derive(Deserialize)]
 struct Snapshots {
     metas: String,
+    #[serde(deserialize_with = "snapshots::deserialize_platform_specific_snapshot")]
     stderr: String,
 }

--- a/crates/voicevox_core_c_api/tests/e2e/testcases/synthesizer_new_with_initialize_output_json.rs
+++ b/crates/voicevox_core_c_api/tests/e2e/testcases/synthesizer_new_with_initialize_output_json.rs
@@ -51,7 +51,7 @@ impl assert_cdylib::TestCase for TestCase {
                 openjtalk,
                 VoicevoxInitializeOptions {
                     acceleration_mode: VoicevoxAccelerationMode::VOICEVOX_ACCELERATION_MODE_CPU,
-                    _load_all_models: true,
+                    load_all_models: true,
                     ..**voicevox_default_initialize_options
                 },
                 synthesizer.as_mut_ptr(),

--- a/crates/voicevox_core_c_api/tests/e2e/testcases/synthesizer_new_with_initialize_output_json.rs
+++ b/crates/voicevox_core_c_api/tests/e2e/testcases/synthesizer_new_with_initialize_output_json.rs
@@ -88,7 +88,8 @@ impl assert_cdylib::TestCase for TestCase {
     }
 }
 
-static SNAPSHOTS: Lazy<Snapshots> = snapshots::section!(synthesizer_new_with_initialize_output_json);
+static SNAPSHOTS: Lazy<Snapshots> =
+    snapshots::section!(synthesizer_new_with_initialize_output_json);
 
 #[derive(Deserialize)]
 struct Snapshots {


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

`new_with_initialize` を `load_all_models = true` な options で Synthesizerを初期化した後に、`voicevox_synthesizer_get_metas_json`  を呼び出すとmetasが空文字列で返ってきてしまう。
内部でmetasは取得できているのに default で返ってきてしまうのは不適切な挙動に見える。

そのため、空文字列で `metas_cstring ` を初期化せずに、先にsynthesizerを初期化し、そこから取得したmetasを初期値とした。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他
