### PR TITLE
製品版のタグを0.15.0-preview.2に

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -32,7 +32,7 @@ env:
   VOICEVOX_FAT_RESOURCE_VERSION: "0.15.0-preview.1"
   # releaseタグ名か、workflow_dispatchでのバージョン名か、'0.0.0'が入る
   VERSION: ${{ github.event.release.tag_name || github.event.inputs.version || '0.0.0' }}
-  PRODUCTION_REPOSITORY_TAG: "0.15.0-preview.1" # 製品版のタグ名
+  PRODUCTION_REPOSITORY_TAG: "0.15.0-preview.2" # 製品版のタグ名
   # 簡易テストとするかどうか。releaseとworkflow_dispatch以外は簡易テストとする
   IS_SIMPLE_TEST: ${{ github.event_name != 'release' && github.event_name != 'workflow_dispatch' }}
 


### PR DESCRIPTION
## 内容

https://github.com/VOICEVOX/voicevox_core/releases/tag/0.15.0-preview.7
のビルドが失敗していました。
メインブランチのバージョンが進んでコンフリクトが発生しているためだったので、コンフリクトを解消したバージョンに置き換えました。

## その他
