### PR TITLE
引数の`VoicevoxUserDictWord*`がunalignedであることを許す

### DIFF
--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -1057,7 +1057,7 @@ pub unsafe extern "C" fn voicevox_user_dict_load(
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_user_dict_add_word(
     user_dict: &VoicevoxUserDict,
-    word: *const VoicevoxUserDictWord, // FIXME: <https://github.com/VOICEVOX/voicevox_core/pull/534>に従う
+    word: *const VoicevoxUserDictWord,
     output_word_uuid: NonNull<[u8; 16]>,
 ) -> VoicevoxResultCode {
     into_result_code_with_error((|| {
@@ -1088,7 +1088,7 @@ pub unsafe extern "C" fn voicevox_user_dict_add_word(
 pub unsafe extern "C" fn voicevox_user_dict_update_word(
     user_dict: &VoicevoxUserDict,
     word_uuid: &[u8; 16],
-    word: *const VoicevoxUserDictWord, // FIXME: <https://github.com/VOICEVOX/voicevox_core/pull/534>に従う
+    word: *const VoicevoxUserDictWord,
 ) -> VoicevoxResultCode {
     into_result_code_with_error((|| {
         let word_uuid = Uuid::from_slice(word_uuid).map_err(CApiError::InvalidUuid)?;

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -1061,7 +1061,7 @@ pub unsafe extern "C" fn voicevox_user_dict_add_word(
     output_word_uuid: NonNull<[u8; 16]>,
 ) -> VoicevoxResultCode {
     into_result_code_with_error((|| {
-        let word = (*word).try_into_word()?;
+        let word = word.read_unaligned().try_into_word()?;
         let uuid = {
             let mut dict = user_dict.dict.lock().expect("lock failed");
             dict.add_word(word)?
@@ -1092,7 +1092,7 @@ pub unsafe extern "C" fn voicevox_user_dict_update_word(
 ) -> VoicevoxResultCode {
     into_result_code_with_error((|| {
         let word_uuid = Uuid::from_slice(word_uuid).map_err(CApiError::InvalidUuid)?;
-        let word = (*word).try_into_word()?;
+        let word = word.read_unaligned().try_into_word()?;
         {
             let mut dict = user_dict.dict.lock().expect("lock failed");
             dict.update_word(word_uuid, word)?;

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -956,6 +956,7 @@ pub struct VoicevoxUserDict {
 }
 
 /// ユーザー辞書の単語。
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct VoicevoxUserDictWord {
     /// 表記
@@ -1056,11 +1057,11 @@ pub unsafe extern "C" fn voicevox_user_dict_load(
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_user_dict_add_word(
     user_dict: &VoicevoxUserDict,
-    word: &VoicevoxUserDictWord, // FIXME: <https://github.com/VOICEVOX/voicevox_core/pull/534>に従う
+    word: *const VoicevoxUserDictWord, // FIXME: <https://github.com/VOICEVOX/voicevox_core/pull/534>に従う
     output_word_uuid: NonNull<[u8; 16]>,
 ) -> VoicevoxResultCode {
     into_result_code_with_error((|| {
-        let word = word.try_into_word()?;
+        let word = (*word).try_into_word()?;
         let uuid = {
             let mut dict = user_dict.dict.lock().expect("lock failed");
             dict.add_word(word)?
@@ -1087,11 +1088,11 @@ pub unsafe extern "C" fn voicevox_user_dict_add_word(
 pub unsafe extern "C" fn voicevox_user_dict_update_word(
     user_dict: &VoicevoxUserDict,
     word_uuid: &[u8; 16],
-    word: &VoicevoxUserDictWord, // FIXME: <https://github.com/VOICEVOX/voicevox_core/pull/534>に従う
+    word: *const VoicevoxUserDictWord, // FIXME: <https://github.com/VOICEVOX/voicevox_core/pull/534>に従う
 ) -> VoicevoxResultCode {
     into_result_code_with_error((|| {
         let word_uuid = Uuid::from_slice(word_uuid).map_err(CApiError::InvalidUuid)?;
-        let word = word.try_into_word()?;
+        let word = (*word).try_into_word()?;
         {
             let mut dict = user_dict.dict.lock().expect("lock failed");
             dict.update_word(word_uuid, word)?;


### PR DESCRIPTION
## 内容

#534 の方針を継続し、FIXMEとしていた部分を解消します。

## 関連 Issue

## その他

というより`VoicevoxUserDictWord`はby valueで渡した方がよいかもしれません。