### PR TITLE
ダウンローダのCLIオプションで`clap::Arg::value_name`を設定

### DIFF
--- a/crates/download/src/main.rs
+++ b/crates/download/src/main.rs
@@ -53,15 +53,15 @@ struct Args {
     min: bool,
 
     /// 出力先の指定
-    #[arg(short, long, default_value(DEFAULT_OUTPUT))]
+    #[arg(short, long, value_name("DIRECTORY"), default_value(DEFAULT_OUTPUT))]
     output: PathBuf,
 
     /// ダウンロードするvoicevox_coreのバージョンの指定
-    #[arg(short, long, default_value("latest"))]
+    #[arg(short, long, value_name("GIT_TAG_OR_LATEST"), default_value("latest"))]
     version: String,
 
     /// 追加でダウンロードするライブラリのバージョン
-    #[arg(long, default_value("latest"))]
+    #[arg(long, value_name("GIT_TAG_OR_LATEST"), default_value("latest"))]
     additional_libraries_version: String,
 
     /// ダウンロードするデバイスを指定する(cudaはlinuxのみ)


### PR DESCRIPTION
## 内容

[`clap::Arg::value_name`](https://docs.rs/clap/4/clap/struct.Arg.html#method.value_name)

```console
❯ cargo run -p download -- -h
```

```diff
 Usage: download [OPTIONS]

 Options:
       --min
           ダウンロードするライブラリを最小限にするように指定
-  -o, --output <OUTPUT>
+  -o, --output <DIRECTORY>
           出力先の指定 [default: ./voicevox_core]
-  -v, --version <VERSION>
+  -v, --version <GIT_TAG_OR_LATEST>
           ダウンロードするvoicevox_coreのバージョンの指定 [default: latest]
-      --additional-libraries-version <ADDITIONAL_LIBRARIES_VERSION>
+      --additional-libraries-version <GIT_TAG_OR_LATEST>
           追加でダウンロードするライブラリのバージョン [default: latest]
       --device <DEVICE>
           ダウンロードするデバイスを指定する(cudaはlinuxのみ) [default: cpu] [possible values: cpu, cuda, directml]
       --cpu-arch <CPU_ARCH>
           ダウンロードするcpuのアーキテクチャを指定する [default: x64] [possible values: x86, x64, arm64]
       --os <OS>
           ダウンロードする対象のOSを指定する [default: linux] [possible values: windows, linux, osx]
```

## 関連 Issue

## その他
