### PR TITLE
ダウンローダで`--min`と`--additional-libraries-version`の同時使用を禁止

### DIFF
--- a/crates/download/src/main.rs
+++ b/crates/download/src/main.rs
@@ -49,7 +49,7 @@ static OPEN_JTALK_DIC_URL: Lazy<Url> = Lazy::new(|| {
 #[derive(clap::Parser)]
 struct Args {
     /// ダウンロードするライブラリを最小限にするように指定
-    #[arg(long)]
+    #[arg(long, conflicts_with("additional_libraries_version"))]
     min: bool,
 
     /// 出力先の指定


### PR DESCRIPTION
## 内容

`--min`が付く場合`--additional-libraries-version`は無意味なので、その組み合わせを弾くようにします。

```console
❯ cargo run -qp download -- --min --additional-libraries-version 0.1.0
error: The argument '--min' cannot be used with '--additional-libraries-version <ADDITIONAL_LIBRARIES_VERSION>'

Usage: download --min

For more information try '--help'
```

## 関連 Issue

## その他
