### PR TITLE
build_and_deploy_downloader.ymlにworkflow_callを追加

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -31,7 +31,7 @@ env:
   VOICEVOX_RESOURCE_VERSION: "0.15.0-preview.1"
   VOICEVOX_FAT_RESOURCE_VERSION: "0.15.0-preview.1"
   # releaseタグ名か、workflow_dispatchでのバージョン名か、'0.0.0'が入る
-  VERSION: ${{ github.event.release.tag_name || github.event.inputs.version || '0.0.0' }}
+  VERSION: ${{ github.event.release.tag_name || inputs.version || '0.0.0' }}
   PRODUCTION_REPOSITORY_TAG: "0.15.0-preview.2" # 製品版のタグ名
   # 簡易テストとするかどうか。releaseとworkflow_dispatch以外は簡易テストとする
   IS_SIMPLE_TEST: ${{ github.event_name != 'release' && github.event_name != 'workflow_dispatch' }}
@@ -182,21 +182,21 @@ jobs:
 
   build_and_deploy:
     needs: build_and_deploy_strategy_matrix
-    environment: ${{ github.event.inputs.is_production == 'true' && 'production' || '' }} # 製品版のenvironment
+    environment: ${{ inputs.is_production == 'true' && 'production' || '' }} # 製品版のenvironment
     strategy:
       matrix:
         include: ${{ fromJson(needs.build_and_deploy_strategy_matrix.outputs.includes) }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3 # 製品版ではない場合
-        if: ${{ github.event.inputs.is_production != 'true' }}
+        if: ${{ inputs.is_production != 'true' }}
       - uses: actions/checkout@v3 # 製品版の場合
-        if: ${{ github.event.inputs.is_production == 'true' }}
+        if: ${{ inputs.is_production == 'true' }}
         with:
           fetch-depth: 0 # 全履歴取得
           token: ${{ secrets.PRODUCTION_GITHUB_TOKEN }}
       - name: Merge production branch
-        if: github.event.inputs.is_production == 'true'
+        if: inputs.is_production == 'true'
         shell: bash
         run: |
           (
@@ -229,21 +229,21 @@ jobs:
           echo "$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/bin" >> "$GITHUB_PATH"
           echo "AR_${{ matrix.target }}=llvm-ar" >> "$GITHUB_ENV"
       - name: Checkout VOICEVOX RESOURCE
-        if: github.event.inputs.is_production == 'true'
+        if: inputs.is_production == 'true'
         uses: actions/checkout@v3
         with:
           repository: VOICEVOX/voicevox_resource
           ref: ${{ env.VOICEVOX_RESOURCE_VERSION }}
           path: download/resource
       - name: Checkout VOICEVOX FAT RESOURCE
-        if: github.event.inputs.is_production == 'true'
+        if: inputs.is_production == 'true'
         uses: actions/checkout@v3
         with:
           repository: VOICEVOX/voicevox_fat_resource
           ref: ${{ env.VOICEVOX_FAT_RESOURCE_VERSION }}
           path: download/fat_resource
       - name: Raplace resource
-        if: github.event.inputs.is_production == 'true'
+        if: inputs.is_production == 'true'
         shell: bash
         run: |
           mv -f download/resource/core/README.md ./README.md
@@ -262,7 +262,7 @@ jobs:
           function build() {
             cargo build -p voicevox_core_c_api -vv --features ${{ matrix.features }}, --target ${{ matrix.target }} --release
           }
-          if ${{ github.event.inputs.is_production != 'true' }}; then
+          if ${{ inputs.is_production != 'true' }}; then
             build
           else
             build > /dev/null 2>&1
@@ -278,7 +278,7 @@ jobs:
           function build() {
             maturin build --manifest-path ./crates/voicevox_core_python_api/Cargo.toml --features ${{ matrix.features }}, --target ${{ matrix.target }} --release
           }
-          if ${{ github.event.inputs.is_production != 'true' }}; then
+          if ${{ inputs.is_production != 'true' }}; then
             build
           else
             build > /dev/null 2>&1
@@ -301,7 +301,7 @@ jobs:
           cp -vr model "artifact/${{ env.ASSET_NAME }}/"
           echo "${{ env.VERSION }}" > "artifact/${{ env.ASSET_NAME }}/VERSION"
       - name: Code signing (Windows)
-        if: startsWith(matrix.os, 'windows') && github.event.inputs.code_signing == 'true'
+        if: startsWith(matrix.os, 'windows') && inputs.code_signing == 'true'
         run: |
           bash build_util/codesign.bash "artifact/${{ env.ASSET_NAME }}/voicevox_core.dll"
         env:
@@ -389,3 +389,11 @@ jobs:
           files: |-
             ${{ env.ASSET_NAME }}.zip
           target_commitish: ${{ github.sha }}
+
+  build_and_deploy_downloader:
+    uses: ./.github/workflows/build_and_deploy_downloader.yml
+    secrets: inherit
+    with:
+      version: ${{ inputs.version }}
+      code_signing: ${{ inputs.code_signing }}
+      is_production: ${{ inputs.is_production }}

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -391,6 +391,7 @@ jobs:
           target_commitish: ${{ github.sha }}
 
   build_and_deploy_downloader:
+    needs: build_and_deploy
     uses: ./.github/workflows/build_and_deploy_downloader.yml
     secrets: inherit
     with:

--- a/.github/workflows/build_and_deploy_downloader.yml
+++ b/.github/workflows/build_and_deploy_downloader.yml
@@ -5,6 +5,23 @@ on:
     inputs:
       version:
         description: "バージョン情報（A.BB.C / A.BB.C-preview.D）"
+        type: string
+        required: true
+      code_signing:
+        description: "コード署名する"
+        type: boolean
+        required: false
+        default: false
+      is_production:
+        description: "製品版をビルドする"
+        type: boolean
+        required: false
+        default: false
+  workflow_call:
+    inputs:
+      version:
+        description: "バージョン情報（A.BB.C / A.BB.C-preview.D）"
+        type: string
         required: true
       code_signing:
         description: "コード署名する"
@@ -34,7 +51,7 @@ on:
 
 env:
   # releaseタグ名か、workflow_dispatchでのバージョン名か、'0.0.0'が入る
-  VERSION: ${{ github.event.release.tag_name || github.event.inputs.version || '0.0.0' }}
+  VERSION: ${{ github.event.release.tag_name || inputs.version || '0.0.0' }}
 
 defaults:
   run:
@@ -42,7 +59,7 @@ defaults:
 
 jobs:
   deploy_and_deploy_downloader:
-    environment: ${{ github.event.inputs.is_production == 'true' && 'production' || '' }} # コード署名用のenvironment
+    environment: ${{ inputs.is_production == 'true' && 'production' || '' }} # コード署名用のenvironment
     strategy:
       matrix:
         include:
@@ -94,7 +111,7 @@ jobs:
           mv $"target/${{ matrix.target }}/release/download$exe_suffix" ./${{ matrix.name }}
 
       - name: Code signing (Windows)
-        if: startsWith(matrix.os, 'windows') && github.event.inputs.code_signing == 'true'
+        if: startsWith(matrix.os, 'windows') && inputs.code_signing == 'true'
         run: |
           bash build_util/codesign.bash ./${{ matrix.name }}
         env:


### PR DESCRIPTION
## 内容

ダウンローダーのビルドとデプロイ用のスクリプトを関数化（`workflow_call`）し、全部ビルドしてデプロイする用のスクリプトから呼び出せるようにしました。

<s>
こちらで言及していた内容（本体をビルドしないとダウンローダーの実行テストができない）を解決するための前準備みたいなプルリクエストです。

- https://github.com/VOICEVOX/voicevox_core/pull/603#issuecomment-1712560245

</s>
コメントしていますが、勘違いでした。。
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他



上のプルリクエストのコメントでは`workflow_dispatch`を消して`workflow_call`だけにしようと思っていたのですが、やっぱりディスパッチできた方が単体でテストできて便利そうなので一旦残してみました。

というのも面倒だったのがdispatch用の`github.event.inputs`とcall用の`inputs`の2つの変数をどちらも見れるようにしないといけないと思っていたのですが、どうやら`inputs`で統一できるようになっていたので思ったより簡単だったという理由があります。
https://developer.mamezou-tech.com/blogs/2022/06/11/github-actions-inputs-unified/

他のリポジトリもこうして行きたいかもです。