### PR TITLE
download_testをデフォルトでprerelease込みのlatestが使われるように変更

### DIFF
--- a/.github/workflows/download_test.yml
+++ b/.github/workflows/download_test.yml
@@ -1,11 +1,5 @@
 name: Download test workflow
 on:
-  workflow_call:
-    inputs:
-      version:
-        description: "テスト対象のコアのバージョン。無指定時はprerelease込みの最新release。"
-        type: string
-        required: false
   push:
     branches:
       - main
@@ -16,7 +10,7 @@ on:
       - ".github/workflows/download_test.yml"
 
 env:
-  VERSION: ${{ inputs.version || 'prerelease-latest' }}
+  VERSION: "prerelease-latest"
 
 defaults:
   run:

--- a/.github/workflows/download_test.yml
+++ b/.github/workflows/download_test.yml
@@ -24,7 +24,7 @@ jobs:
         include:
           - name: 通常ダウンロード
             os: windows-latest
-            download_command: cargo run -vv -p download
+            download_command: cargo run -vv -p download -- # バージョン指定のために -- が必要
             download_dir: voicevox_core
             check_items: |
               voicevox_core.dll

--- a/.github/workflows/download_test.yml
+++ b/.github/workflows/download_test.yml
@@ -182,7 +182,7 @@ jobs:
         if: ${{ env.VERSION == 'prerelease-latest' }}
         run: |
           VERSION=$(
-            curl -s https://api.github.com/repos/VOICEVOX/voicevox_core/releases \
+            curl -sSf https://api.github.com/repos/VOICEVOX/voicevox_core/releases \
               -H 'authorization: Bearer ${{ github.token }}' \
               -H 'content-type: application/json' |
             jq -er '.[0].tag_name'

--- a/.github/workflows/download_test.yml
+++ b/.github/workflows/download_test.yml
@@ -1,5 +1,11 @@
 name: Download test workflow
 on:
+  workflow_call:
+    inputs:
+      version:
+        description: "テスト対象のコアのバージョン。無指定時はprerelease込みの最新release。"
+        type: string
+        required: false
   push:
     branches:
       - main
@@ -8,9 +14,14 @@ on:
       - "Cargo.*"
       - "crates/download/**"
       - ".github/workflows/download_test.yml"
+
+env:
+  VERSION: ${{ inputs.version || 'prerelease-latest' }}
+
 defaults:
   run:
     shell: bash
+
 jobs:
   download-releases:
     strategy:
@@ -169,29 +180,28 @@ jobs:
               open_jtalk_dic_utf_8-1.11
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.name }}-${{ matrix.os }}
-    env:
-      EXPECTED_VOICEVOX_CORE_VERSION: latest
-      # See https://github.com/VOICEVOX/voicevox_core/issues/310
-      #EXPECTED_VOICEVOX_CORE_VERSION: ${{ matrix.expected_version || 'latest' }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Rust
-        if: ${{ startsWith(matrix.download_command, 'cargo ') }}
         uses: ./.github/actions/rust-toolchain-from-file
+      - name: Get prerelease latest version
+        if: ${{ env.VERSION == 'prerelease-latest' }}
+        run: |
+          VERSION=$(
+            curl -s https://api.github.com/repos/VOICEVOX/voicevox_core/releases \
+              -H 'authorization: Bearer ${{ github.token }}' \
+              -H 'content-type: application/json' |
+            jq -er '.[0].tag_name'
+          )
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
       - name: Execute download command
-        run: ${{ matrix.download_command }}
+        run: ${{ matrix.download_command }} --version ${{ env.VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Get latest version
-        if: ${{ env.EXPECTED_VOICEVOX_CORE_VERSION == 'latest' }}
-        run: |
-          echo "EXPECTED_VOICEVOX_CORE_VERSION=$(gh release view --repo VOICEVOX/voicevox_core --json 'tagName' --jq '.tagName')" >> "$GITHUB_ENV"
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
       - name: Check downloaded version
         run: |
           [ -e "${{ matrix.download_dir }}/VERSION" ]
-          [ "$(cat "${{ matrix.download_dir }}/VERSION")" = "${{ env.EXPECTED_VOICEVOX_CORE_VERSION }}" ]
+          [ "$(cat "${{ matrix.download_dir }}/VERSION")" = "${{ env.VERSION }}" ]
       - name: Check downloaded files
         run: |
           mapfile -t items < <(echo -n '${{ matrix.check_items }}')


### PR DESCRIPTION
## 内容

ダウンローダーのテストはいつもlatestを見ているので、ダウンロード内容が変わった時にテストが必ず落ちるようになっています。
https://github.com/VOICEVOX/voicevox_core/pull/603#issuecomment-1712560245

プレリリースを含んだリリースのlatestを使うようにすれば、プレリリースしさえすればテストが落ちないようにすることができるはずなので、その提案を含めてプルリクエストを作ってみました。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_core/pull/603

## その他
