### PR TITLE
Java API：onnxruntimeを自前で用意するように

### DIFF
--- a/crates/voicevox_core_java_api/README.md
+++ b/crates/voicevox_core_java_api/README.md
@@ -40,28 +40,32 @@ VOICEVOX CORE の Java バインディング。
 バインディングは `cargo build` でビルドできます。
 Java プロジェクトを動かすには、
 
-- `LD_LIBRARY_PATH`などの環境変数に `[プロジェクトルート]/target/debug`（または`/release`） を追加するか、
-- `lib/src/main/resources/dll/[target]/libvoicevox_core_java_api.so` を作成する（`libvoicevox_core_java_api.so`はプラットフォームによって異なります、詳細は後述）。
+- `LD_LIBRARY_PATH`などの環境変数に `[プロジェクトルート]/target/debug`（または`/release`） や onnxruntime の DLL があるディレクトリを追加するか、
+- `lib/src/main/resources/dll/[target]/`内に onnxruntime と voicevox_core_java_api の DLL をコピーする
 
 必要があります。
 
 ```console
 ❯ cargo build
-❯ LD_LIBRARY_PATH=$(realpath ../../target/debug) ./gradlew build
+❯ export LD_LIBRARY_PATH="$(realpath ../../target/debug):$LD_LIBRARY_PATH"
+❯ export LD_LIBRARY_PATH="/path/to/onnxruntime/lib:$LD_LIBRARY_PATH"
+❯ ./gradlew build
 
 # または
 ❯ cp ../../target/debug/libvoicevox_core_java_api.so lib/src/main/resources/dll/[target]/libvoicevox_core_java_api.so
+❯ cp /path/to/onnxruntime/lib/libonnxruntime.so.1.14.0 lib/src/main/resources/dll/[target]/libonnxruntime.so.1.14.0
 ❯ ./gradlew build
 ```
 
 ## ビルド（リリース）
 
 `cargo build --release` で Rust 側を、`./gradlew build` で Java 側をビルドできます。
-パッケージ化する時は lib/src/main/resources/dll 内に dll をコピーしてください。
+パッケージ化する時は lib/src/main/resources/dll 内に DLL をコピーしてください。
 
 ```console
 ❯ cargo build --release
 ❯ cp ../../target/release/libvoicevox_core_java_api.so lib/src/main/resources/dll/[target]/libvoicevox_core_java_api.so
+❯ cp /path/to/onnxruntime/lib/libonnxruntime.so.1.14.0 lib/src/main/resources/dll/[target]/libonnxruntime.so.1.14.0
 ❯ ./gradlew build
 ```
 
@@ -85,12 +89,5 @@ Java プロジェクトを動かすには、
 
 Android では、jniLibs から System.loadLibrary で読み込みます。
 
-Android 以外では、src/main/resources/dll 内の適切な DLL を一時ディレクトリにコピーし、System.load で読み込みます。
-DLL の名前は、
-
-- Windows：voicevox_core_java_api.dll
-- Linux：libvoicevox_core_java_api.so
-- macOS：libvoicevox_core_java_api.dylib
-
-になります。
+Android 以外では、src/main/resources/dll 内の DLL を一時ディレクトリにコピーし、System.load で読み込みます。
 見付からなかった場合は、`System.loadLibrary` で読み込みます。これはデバッグ用です。

--- a/crates/voicevox_core_java_api/lib/build.gradle
+++ b/crates/voicevox_core_java_api/lib/build.gradle
@@ -13,6 +13,8 @@ plugins {
 
 version = '0.0.0'
 
+def String buildTarget = hasProperty('buildTarget') ? buildTarget : "cpu"
+
 repositories {
     // Use Maven Central for resolving dependencies.
     mavenCentral()
@@ -36,7 +38,9 @@ dependencies {
     // https://mvnrepository.com/artifact/jakarta.validation/jakarta.validation-api
     implementation group: 'jakarta.validation', name: 'jakarta.validation-api', version: '3.0.2'
 
-    implementation group: 'com.microsoft.onnxruntime', name: 'onnxruntime', version: '1.14.0'
+    if (buildTarget == "android") {
+      implementation group: 'com.microsoft.onnxruntime', name: 'onnxruntime_android', version: '1.14.0'
+    }
 }
 
 // Apply a specific Java toolchain to ease working on different environments.

--- a/crates/voicevox_core_java_api/lib/build.gradle
+++ b/crates/voicevox_core_java_api/lib/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     implementation group: 'jakarta.validation', name: 'jakarta.validation-api', version: '3.0.2'
 
     if (buildTarget == "android") {
-      implementation group: 'com.microsoft.onnxruntime', name: 'onnxruntime_android', version: '1.14.0'
+      implementation group: 'com.microsoft.onnxruntime', name: 'onnxruntime-android', version: '1.14.0'
     }
 }
 

--- a/crates/voicevox_core_java_api/lib/src/test/java/jp/hiroshiba/voicevoxcore/SynthesizerTest.java
+++ b/crates/voicevox_core_java_api/lib/src/test/java/jp/hiroshiba/voicevoxcore/SynthesizerTest.java
@@ -4,7 +4,6 @@
  */
 package jp.hiroshiba.voicevoxcore;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -37,19 +36,19 @@ class SynthesizerTest extends TestUtils {
   void checkModel() {
     VoiceModel model = loadModel();
     OpenJtalk openJtalk = loadOpenJtalk();
-    Synthesizer synthesizer = Synthesizer.builder(openJtalk).build();
+    Synthesizer synthesizer =
+        Synthesizer.builder(openJtalk).accelerationMode(Synthesizer.AccelerationMode.CPU).build();
+
     synthesizer.loadVoiceModel(model);
+
     assertTrue(synthesizer.isLoadedVoiceModel(model.id));
-    synthesizer.unloadVoiceModel(model.id);
-    assertFalse(synthesizer.isLoadedVoiceModel(model.id));
   }
 
   @Test
   void checkAudioQuery() {
     VoiceModel model = loadModel();
-    OpenJtalk openJtalk = loadOpenJtalk();
-    Synthesizer synthesizer = Synthesizer.builder(openJtalk).build();
-    synthesizer.loadVoiceModel(model);
+    Synthesizer synthesizer = createSynthesizer();
+
     AudioQuery query = synthesizer.createAudioQuery("こんにちは", model.metas[0].styles[0].id).execute();
 
     synthesizer.synthesis(query, model.metas[0].styles[0].id).execute();
@@ -58,9 +57,8 @@ class SynthesizerTest extends TestUtils {
   @Test
   void checkAccentPhrases() {
     VoiceModel model = loadModel();
-    OpenJtalk openJtalk = loadOpenJtalk();
-    Synthesizer synthesizer = Synthesizer.builder(openJtalk).build();
-    synthesizer.loadVoiceModel(model);
+    Synthesizer synthesizer = createSynthesizer();
+
     List<AccentPhrase> accentPhrases =
         synthesizer.createAccentPhrases("こんにちは", model.metas[0].styles[0].id).execute();
     List<AccentPhrase> accentPhrases2 =
@@ -88,9 +86,7 @@ class SynthesizerTest extends TestUtils {
   @Test
   void checkTts() {
     VoiceModel model = loadModel();
-    OpenJtalk openJtalk = loadOpenJtalk();
-    Synthesizer synthesizer = Synthesizer.builder(openJtalk).build();
-    synthesizer.loadVoiceModel(model);
+    Synthesizer synthesizer = createSynthesizer();
     synthesizer.tts("こんにちは", model.metas[0].styles[0].id).execute();
   }
 }

--- a/crates/voicevox_core_java_api/lib/src/test/java/jp/hiroshiba/voicevoxcore/TestUtils.java
+++ b/crates/voicevox_core_java_api/lib/src/test/java/jp/hiroshiba/voicevoxcore/TestUtils.java
@@ -3,7 +3,14 @@ package jp.hiroshiba.voicevoxcore;
 import java.io.File;
 
 class TestUtils {
+  VoiceModel voiceModel = null;
+  OpenJtalk openJtalk = null;
+  Synthesizer synthesizer = null;
+
   VoiceModel loadModel() {
+    if (voiceModel != null) {
+      return voiceModel;
+    }
     // cwdはvoicevox_core/crates/voicevox_core_java_api/lib
     String cwd = System.getProperty("user.dir");
     File path = new File(cwd + "/../../../model/sample.vvm");
@@ -16,6 +23,9 @@ class TestUtils {
   }
 
   OpenJtalk loadOpenJtalk() {
+    if (openJtalk != null) {
+      return openJtalk;
+    }
     String cwd = System.getProperty("user.dir");
     File path = new File(cwd + "/../../test_util/data/open_jtalk_dic_utf_8-1.11");
 
@@ -24,5 +34,16 @@ class TestUtils {
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
+  }
+
+  Synthesizer createSynthesizer() {
+    if (synthesizer != null) {
+      return synthesizer;
+    }
+    OpenJtalk openJtalk = loadOpenJtalk();
+    Synthesizer synthesizer =
+        Synthesizer.builder(openJtalk).accelerationMode(Synthesizer.AccelerationMode.CPU).build();
+    synthesizer.loadVoiceModel(loadModel());
+    return synthesizer;
   }
 }


### PR DESCRIPTION
## 内容

onnxruntime周りを自前で用意するようにします。

### 理由

パッケージをvoicevox、voicevox-cuda、voicevox-directml、voicevox-androidと用意しようと思ってます。
voicevox-androidとvoicevoxで分けてるのは容量の関係です（スマホアプリは容量をそこそこ気にする必要があると思うので）
で、問題になってくるのは`OrtEnvironment.getEnvironment();`で、onnxruntime-androidは普通のgradleだと読み込めない（多分）のでAndroid版がビルドできなくなります。
ので、こうなりました。（Cの`#if`とかがあればいいのに）

## 関連 Issue

- ref: #558 

## その他

（なし）