### PR TITLE
ANSI escape sequenceの出力の判断を完全にする

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bf0a05bbb2a83e5eb6fa36bb6e87baa08193c35ff52bbf6b38d8af2890e46"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +748,12 @@ dependencies = [
  "tracing-core",
  "tracing-error",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "combine"
@@ -4108,6 +4151,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "uuid"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4189,10 +4238,13 @@ dependencies = [
 name = "voicevox_core_c_api"
 version = "0.0.0"
 dependencies = [
+ "anstream",
+ "anstyle-query",
  "anyhow",
  "assert_cmd",
  "chrono",
  "clap 4.0.10",
+ "colorchoice",
  "cstr",
  "derive-getters",
  "duct",

--- a/crates/voicevox_core_c_api/Cargo.toml
+++ b/crates/voicevox_core_c_api/Cargo.toml
@@ -16,6 +16,9 @@ name = "e2e"
 directml = ["voicevox_core/directml"]
 
 [dependencies]
+anstream = { version = "0.5.0", default-features = false, features = ["auto"] }
+anstyle-query = "1.0.0"
+colorchoice = "1.0.0"
 cstr = "0.2.11"
 derive-getters.workspace = true
 itertools.workspace = true


### PR DESCRIPTION
## 内容

ANSI escape sequenceを出力すべきかどうかの判定に[rust-cli/anstyle](https://github.com/rust-cli/anstyle)を用いることで、 #386 を完全にします。

`ENABLE_VIRTUAL_TERMINAL_PROCESSING`がオフの場合でもオンにするようにしたので、これで古いコマンドプロンプトやPowerShellのターミナルでも色が出るようになるかと思います。
(前はPowerShellが壊れちゃってたはず)

## 関連 Issue

## その他

[clap](https://docs.rs/crate/clap)は半年前、ターミナルに色を出すためのライブラリを[anstream](https://docs.rs/crate/anstream)に切り替えました。
<https://github.com/clap-rs/clap/pull/4765>

ターミナルに色を出すべきかどうかの判断は今はanstyle(ファミリー)の判定がデファクトになりつつあることから、これを採用しました。[Rust CLI WG](https://github.com/rust-cli)が手がけているというのもあります。
