### PR TITLE
download_testを最新のもので通るように変更

### DIFF
--- a/.github/workflows/download_test.yml
+++ b/.github/workflows/download_test.yml
@@ -35,7 +35,7 @@ jobs:
             download_dir: voicevox_core
             check_items: |
               voicevox_core.dll
-              model/metas.json
+              model/README.*
               open_jtalk_dic_utf_8-1.11
               README.txt
             # https://github.com/VOICEVOX/voicevox_core/pull/411#issuecomment-1412457592
@@ -53,7 +53,7 @@ jobs:
             download_dir: voicevox_core
             check_items: |
               voicevox_core.dll
-              model/metas.json
+              model/README.*
               open_jtalk_dic_utf_8-1.11
               README.txt
             check_not_exists_items: |
@@ -70,7 +70,7 @@ jobs:
             download_dir: other_output
             check_items: |
               voicevox_core.dll
-              model/metas.json
+              model/README.*
               open_jtalk_dic_utf_8-1.11
               README.txt
             check_not_exists_items: |
@@ -87,7 +87,7 @@ jobs:
             download_dir: voicevox_core
             check_items: |
               voicevox_core.dll
-              model/metas.json
+              model/README.*
               README.txt
             check_not_exists_items: |
               *directml*
@@ -104,7 +104,7 @@ jobs:
             download_dir: voicevox_core
             check_items: |
               voicevox_core.dll
-              model/metas.json
+              model/README.*
               open_jtalk_dic_utf_8-1.11
               README.txt
               DirectML.dll
@@ -123,7 +123,7 @@ jobs:
             download_dir: voicevox_core
             check_items: |
               voicevox_core.dll
-              model/metas.json
+              model/README.*
               README.txt
             check_not_exists_items: |
               *cuda*
@@ -141,7 +141,7 @@ jobs:
             download_dir: voicevox_core
             check_items: |
               voicevox_core.dll
-              model/metas.json
+              model/README.*
               open_jtalk_dic_utf_8-1.11
               README.txt
               EULA.txt
@@ -163,7 +163,7 @@ jobs:
             download_dir: voicevox_core
             check_items: |
               voicevox_core.dll
-              model/metas.json
+              model/README.*
               README.txt
             check_not_exists_items: |
               *directml*


### PR DESCRIPTION
## 内容

最新のmainブランチでビルドした結果をdownload_testすると落ちるようになっていたので修正です。

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_core/pull/609

## その他
