### PR TITLE
エラーメッセージにおけるcontextとsourceを明確に区分する

### DIFF
--- a/crates/voicevox_core/src/devices.rs
+++ b/crates/voicevox_core/src/devices.rs
@@ -45,7 +45,7 @@ impl SupportedDevices {
         let mut cuda_support = false;
         let mut dml_support = false;
         for provider in onnxruntime::session::get_available_providers()
-            .map_err(|e| ErrorRepr::GetSupportedDevices(e.into()))?
+            .map_err(ErrorRepr::GetSupportedDevices)?
             .iter()
         {
             match provider.as_str() {

--- a/crates/voicevox_core/src/engine/kana_parser.rs
+++ b/crates/voicevox_core/src/engine/kana_parser.rs
@@ -10,16 +10,9 @@ const PAUSE_DELIMITER: char = '、';
 const WIDE_INTERROGATION_MARK: char = '？';
 const LOOP_LIMIT: usize = 300;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+#[error("入力テキストをAquesTalk風記法としてパースすることに失敗しました: {_0}")]
 pub(crate) struct KanaParseError(String);
-
-impl std::fmt::Display for KanaParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Parse Error: {}", self.0)
-    }
-}
-
-impl std::error::Error for KanaParseError {}
 
 type KanaParseResult<T> = std::result::Result<T, KanaParseError>;
 

--- a/crates/voicevox_core/src/engine/open_jtalk.rs
+++ b/crates/voicevox_core/src/engine/open_jtalk.rs
@@ -12,9 +12,9 @@ use ::open_jtalk::*;
 use crate::{error::ErrorRepr, UserDict};
 
 #[derive(thiserror::Error, Debug)]
-#[error("`{name}`の実行が失敗しました")]
+#[error("`{function}`の実行が失敗しました")]
 pub(crate) struct OpenjtalkFunctionError {
-    name: &'static str,
+    function: &'static str,
     #[source]
     source: Option<Text2MecabError>,
 }
@@ -118,13 +118,13 @@ impl OpenJtalk {
         mecab.refresh();
 
         let mecab_text = text2mecab(text.as_ref()).map_err(|e| OpenjtalkFunctionError {
-            name: "text2mecab",
+            function: "text2mecab",
             source: Some(e),
         })?;
         if mecab.analysis(mecab_text) {
             njd.mecab2njd(
                 mecab.get_feature().ok_or(OpenjtalkFunctionError {
-                    name: "Mecab_get_feature",
+                    function: "Mecab_get_feature",
                     source: None,
                 })?,
                 mecab.get_size(),
@@ -140,13 +140,13 @@ impl OpenJtalk {
             jpcommon
                 .get_label_feature_to_iter()
                 .ok_or(OpenjtalkFunctionError {
-                    name: "JPCommon_get_label_feature",
+                    function: "JPCommon_get_label_feature",
                     source: None,
                 })
                 .map(|iter| iter.map(|s| s.to_string()).collect())
         } else {
             Err(OpenjtalkFunctionError {
-                name: "Mecab_analysis",
+                function: "Mecab_analysis",
                 source: None,
             })
         }
@@ -268,7 +268,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case("", Err(OpenjtalkFunctionError { name: "Mecab_get_feature", source: None }))]
+    #[case("", Err(OpenjtalkFunctionError { function: "Mecab_get_feature", source: None }))]
     #[case("こんにちは、ヒホです。", Ok(testdata_hello_hiho()))]
     fn extract_fullcontext_works(
         #[case] text: &str,

--- a/crates/voicevox_core/src/engine/open_jtalk.rs
+++ b/crates/voicevox_core/src/engine/open_jtalk.rs
@@ -12,18 +12,12 @@ use ::open_jtalk::*;
 use crate::{error::ErrorRepr, UserDict};
 
 #[derive(thiserror::Error, Debug)]
-pub(crate) enum OpenJtalkError {
-    #[error("open_jtalk load error")]
-    Load { mecab_dict_dir: PathBuf },
-    #[error("open_jtalk extract_fullcontext error")]
-    ExtractFullContext {
-        text: String,
-        #[source]
-        source: Option<anyhow::Error>,
-    },
+#[error("`{name}`の実行が失敗しました")]
+pub(crate) struct OpenjtalkFunctionError {
+    name: &'static str,
+    #[source]
+    source: Option<Text2MecabError>,
 }
-
-type Result<T> = std::result::Result<T, OpenJtalkError>;
 
 /// テキスト解析器としてのOpen JTalk。
 pub struct OpenJtalk {
@@ -55,8 +49,10 @@ impl OpenJtalk {
         open_jtalk_dict_dir: impl AsRef<Path>,
     ) -> crate::result::Result<Self> {
         let mut s = Self::new_without_dic();
-        s.load(open_jtalk_dict_dir)
-            .map_err(|_| ErrorRepr::NotLoadedOpenjtalkDict)?;
+        s.load(open_jtalk_dict_dir).map_err(|()| {
+            // FIXME: 「システム辞書を読もうとしたけど読めなかった」というエラーをちゃんと用意する
+            ErrorRepr::NotLoadedOpenjtalkDict
+        })?;
         Ok(s)
     }
 
@@ -107,7 +103,10 @@ impl OpenJtalk {
         Ok(())
     }
 
-    pub(crate) fn extract_fullcontext(&self, text: impl AsRef<str>) -> Result<Vec<String>> {
+    pub(crate) fn extract_fullcontext(
+        &self,
+        text: impl AsRef<str>,
+    ) -> std::result::Result<Vec<String>, OpenjtalkFunctionError> {
         let Resources {
             mecab,
             njd,
@@ -118,19 +117,16 @@ impl OpenJtalk {
         njd.refresh();
         mecab.refresh();
 
-        let mecab_text =
-            text2mecab(text.as_ref()).map_err(|e| OpenJtalkError::ExtractFullContext {
-                text: text.as_ref().into(),
-                source: Some(e.into()),
-            })?;
+        let mecab_text = text2mecab(text.as_ref()).map_err(|e| OpenjtalkFunctionError {
+            name: "text2mecab",
+            source: Some(e),
+        })?;
         if mecab.analysis(mecab_text) {
             njd.mecab2njd(
-                mecab
-                    .get_feature()
-                    .ok_or(OpenJtalkError::ExtractFullContext {
-                        text: text.as_ref().into(),
-                        source: None,
-                    })?,
+                mecab.get_feature().ok_or(OpenjtalkFunctionError {
+                    name: "Mecab_get_feature",
+                    source: None,
+                })?,
                 mecab.get_size(),
             );
             njd.set_pronunciation();
@@ -143,20 +139,20 @@ impl OpenJtalk {
             jpcommon.make_label();
             jpcommon
                 .get_label_feature_to_iter()
-                .ok_or_else(|| OpenJtalkError::ExtractFullContext {
-                    text: text.as_ref().into(),
+                .ok_or(OpenjtalkFunctionError {
+                    name: "JPCommon_get_label_feature",
                     source: None,
                 })
                 .map(|iter| iter.map(|s| s.to_string()).collect())
         } else {
-            Err(OpenJtalkError::ExtractFullContext {
-                text: text.as_ref().into(),
+            Err(OpenjtalkFunctionError {
+                name: "Mecab_analysis",
                 source: None,
             })
         }
     }
 
-    fn load(&mut self, open_jtalk_dict_dir: impl AsRef<Path>) -> Result<()> {
+    fn load(&mut self, open_jtalk_dict_dir: impl AsRef<Path>) -> std::result::Result<(), ()> {
         let result = self
             .resources
             .lock()
@@ -168,9 +164,7 @@ impl OpenJtalk {
             Ok(())
         } else {
             self.dict_dir = None;
-            Err(OpenJtalkError::Load {
-                mecab_dict_dir: open_jtalk_dict_dir.as_ref().into(),
-            })
+            Err(())
         }
     }
 
@@ -274,9 +268,12 @@ mod tests {
     }
 
     #[rstest]
-    #[case("",Err(OpenJtalkError::ExtractFullContext{text:"".into(),source:None}))]
+    #[case("", Err(OpenjtalkFunctionError { name: "Mecab_get_feature", source: None }))]
     #[case("こんにちは、ヒホです。", Ok(testdata_hello_hiho()))]
-    fn extract_fullcontext_works(#[case] text: &str, #[case] expected: super::Result<Vec<String>>) {
+    fn extract_fullcontext_works(
+        #[case] text: &str,
+        #[case] expected: std::result::Result<Vec<String>, OpenjtalkFunctionError>,
+    ) {
         let open_jtalk = OpenJtalk::new_with_initialize(OPEN_JTALK_DIC_DIR).unwrap();
         let result = open_jtalk.extract_fullcontext(text);
         assert_debug_fmt_eq!(expected, result);
@@ -286,7 +283,7 @@ mod tests {
     #[case("こんにちは、ヒホです。", Ok(testdata_hello_hiho()))]
     fn extract_fullcontext_loop_works(
         #[case] text: &str,
-        #[case] expected: super::Result<Vec<String>>,
+        #[case] expected: std::result::Result<Vec<String>, OpenjtalkFunctionError>,
     ) {
         let open_jtalk = OpenJtalk::new_with_initialize(OPEN_JTALK_DIC_DIR).unwrap();
         for _ in 0..10 {

--- a/crates/voicevox_core/src/error.rs
+++ b/crates/voicevox_core/src/error.rs
@@ -87,8 +87,8 @@ pub(crate) enum ErrorRepr {
     #[error("入力テキストをAquesTalk風記法としてパースすることに失敗しました,{0}")]
     ParseKana(#[from] KanaParseError),
 
-    #[error("ユーザー辞書を読み込めませんでした: {0}")]
-    LoadUserDict(String),
+    #[error("ユーザー辞書を読み込めませんでした")]
+    LoadUserDict(#[source] anyhow::Error),
 
     #[error("ユーザー辞書を書き込めませんでした")]
     SaveUserDict(#[source] anyhow::Error),

--- a/crates/voicevox_core/src/error.rs
+++ b/crates/voicevox_core/src/error.rs
@@ -2,6 +2,7 @@ use self::engine::{FullContextLabelError, KanaParseError};
 use super::*;
 //use engine::
 use duplicate::duplicate_item;
+use onnxruntime::OrtError;
 use std::path::PathBuf;
 use thiserror::Error;
 use uuid::Uuid;
@@ -63,8 +64,8 @@ pub(crate) enum ErrorRepr {
     #[error(transparent)]
     LoadModel(#[from] LoadModelError),
 
-    #[error("サポートされているデバイス情報取得中にエラーが発生しました,{0}")]
-    GetSupportedDevices(#[source] anyhow::Error),
+    #[error("サポートされているデバイス情報取得中にエラーが発生しました")]
+    GetSupportedDevices(#[source] OrtError),
 
     #[error(
         "`{style_id}`に対するスタイルが見つかりませんでした。音声モデルが読み込まれていないか、読\

--- a/crates/voicevox_core/src/error.rs
+++ b/crates/voicevox_core/src/error.rs
@@ -90,8 +90,8 @@ pub(crate) enum ErrorRepr {
     #[error("ユーザー辞書を読み込めませんでした: {0}")]
     LoadUserDict(String),
 
-    #[error("ユーザー辞書を書き込めませんでした: {0}")]
-    SaveUserDict(String),
+    #[error("ユーザー辞書を書き込めませんでした")]
+    SaveUserDict(#[source] anyhow::Error),
 
     #[error("ユーザー辞書に単語が見つかりませんでした: {0}")]
     WordNotFound(Uuid),

--- a/crates/voicevox_core/src/error.rs
+++ b/crates/voicevox_core/src/error.rs
@@ -16,17 +16,11 @@ pub struct Error(#[from] ErrorRepr);
     [ LoadModelError ];
     [ FullContextLabelError ];
     [ KanaParseError ];
+    [ InvalidWordError ];
 )]
 impl From<E> for Error {
     fn from(err: E) -> Self {
         Self(err.into())
-    }
-}
-
-// FIXME: `ErrorRepr::InvalidWord`を`#[error(transparent)]`にする
-impl From<InvalidWordError> for Error {
-    fn from(err: InvalidWordError) -> Self {
-        ErrorRepr::InvalidWord(err).into()
     }
 }
 
@@ -105,8 +99,8 @@ pub(crate) enum ErrorRepr {
     #[error("OpenJTalkのユーザー辞書の設定に失敗しました: {0}")]
     UseUserDict(String),
 
-    #[error("ユーザー辞書の単語のバリデーションに失敗しました: {0}")]
-    InvalidWord(InvalidWordError),
+    #[error(transparent)]
+    InvalidWord(#[from] InvalidWordError),
 }
 
 /// エラーの種類。

--- a/crates/voicevox_core/src/error.rs
+++ b/crates/voicevox_core/src/error.rs
@@ -84,7 +84,7 @@ pub(crate) enum ErrorRepr {
     #[error("入力テキストからのフルコンテキストラベル抽出に失敗しました,{0}")]
     ExtractFullContextLabel(#[from] FullContextLabelError),
 
-    #[error("入力テキストをAquesTalk風記法としてパースすることに失敗しました,{0}")]
+    #[error(transparent)]
     ParseKana(#[from] KanaParseError),
 
     #[error("ユーザー辞書を読み込めませんでした")]

--- a/crates/voicevox_core/src/error.rs
+++ b/crates/voicevox_core/src/error.rs
@@ -96,8 +96,8 @@ pub(crate) enum ErrorRepr {
     #[error("ユーザー辞書に単語が見つかりませんでした: {0}")]
     WordNotFound(Uuid),
 
-    #[error("OpenJTalkのユーザー辞書の設定に失敗しました: {0}")]
-    UseUserDict(String),
+    #[error("OpenJTalkのユーザー辞書の設定に失敗しました")]
+    UseUserDict(#[source] anyhow::Error),
 
     #[error(transparent)]
     InvalidWord(#[from] InvalidWordError),

--- a/crates/voicevox_core/src/error.rs
+++ b/crates/voicevox_core/src/error.rs
@@ -149,10 +149,7 @@ pub(crate) type LoadModelResult<T> = std::result::Result<T, LoadModelError>;
 
 /// 音声モデル読み込みのエラー。
 #[derive(Error, Debug)]
-#[error(
-    "`{path}`の読み込みに失敗しました: {context}{}",
-    source.as_ref().map(|e| format!(": {e}")).unwrap_or_default())
-]
+#[error("`{path}`の読み込みに失敗しました: {context}")]
 pub(crate) struct LoadModelError {
     pub(crate) path: PathBuf,
     pub(crate) context: LoadModelErrorKind,

--- a/crates/voicevox_core/src/error.rs
+++ b/crates/voicevox_core/src/error.rs
@@ -81,7 +81,7 @@ pub(crate) enum ErrorRepr {
     #[error("推論に失敗しました")]
     InferenceFailed,
 
-    #[error("入力テキストからのフルコンテキストラベル抽出に失敗しました,{0}")]
+    #[error(transparent)]
     ExtractFullContextLabel(#[from] FullContextLabelError),
 
     #[error(transparent)]

--- a/crates/voicevox_core/src/user_dict/dict.rs
+++ b/crates/voicevox_core/src/user_dict/dict.rs
@@ -28,11 +28,10 @@ impl UserDict {
     pub fn load(&mut self, store_path: &str) -> Result<()> {
         let store_path = std::path::Path::new(store_path);
 
-        let store_file =
-            File::open(store_path).map_err(|e| ErrorRepr::LoadUserDict(e.to_string()))?;
+        let store_file = File::open(store_path).map_err(|e| ErrorRepr::LoadUserDict(e.into()))?;
 
-        let words: IndexMap<Uuid, UserDictWord> = serde_json::from_reader(store_file)
-            .map_err(|e| ErrorRepr::LoadUserDict(e.to_string()))?;
+        let words: IndexMap<Uuid, UserDictWord> =
+            serde_json::from_reader(store_file).map_err(|e| ErrorRepr::LoadUserDict(e.into()))?;
 
         self.words.extend(words);
         Ok(())

--- a/crates/voicevox_core/src/user_dict/dict.rs
+++ b/crates/voicevox_core/src/user_dict/dict.rs
@@ -72,10 +72,9 @@ impl UserDict {
 
     /// ユーザー辞書を保存する。
     pub fn save(&self, store_path: &str) -> Result<()> {
-        let mut file =
-            File::create(store_path).map_err(|e| ErrorRepr::SaveUserDict(e.to_string()))?;
+        let mut file = File::create(store_path).map_err(|e| ErrorRepr::SaveUserDict(e.into()))?;
         serde_json::to_writer(&mut file, &self.words)
-            .map_err(|e| ErrorRepr::SaveUserDict(e.to_string()))?;
+            .map_err(|e| ErrorRepr::SaveUserDict(e.into()))?;
         Ok(())
     }
 

--- a/crates/voicevox_core/src/user_dict/word.rs
+++ b/crates/voicevox_core/src/user_dict/word.rs
@@ -58,15 +58,23 @@ impl<'de> Deserialize<'de> for UserDictWord {
 #[allow(clippy::enum_variant_names)] // FIXME
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub(crate) enum InvalidWordError {
-    #[error("{BASE_ERROR_MESSAGE}: 無効な発音です({1}): {0:?}")]
+    #[error("{}: 無効な発音です({_1}): {_0:?}", Self::BASE_MSG)]
     InvalidPronunciation(String, &'static str),
-    #[error("{BASE_ERROR_MESSAGE}: 優先度は{MIN_PRIORITY}以上{MAX_PRIORITY}以下である必要があります: {0}")]
+    #[error(
+        "{}: 優先度は{MIN_PRIORITY}以上{MAX_PRIORITY}以下である必要があります: {_0}",
+        Self::BASE_MSG
+    )]
     InvalidPriority(u32),
-    #[error("{BASE_ERROR_MESSAGE}: 誤ったアクセント型です({1:?}の範囲から外れています): {0}")]
+    #[error(
+        "{}: 誤ったアクセント型です({1:?}の範囲から外れています): {_0}",
+        Self::BASE_MSG
+    )]
     InvalidAccentType(usize, RangeToInclusive<usize>),
 }
 
-const BASE_ERROR_MESSAGE: &str = "ユーザー辞書の単語のバリデーションに失敗しました";
+impl InvalidWordError {
+    const BASE_MSG: &str = "ユーザー辞書の単語のバリデーションに失敗しました";
+}
 
 type InvalidWordResult<T> = std::result::Result<T, InvalidWordError>;
 

--- a/crates/voicevox_core/src/user_dict/word.rs
+++ b/crates/voicevox_core/src/user_dict/word.rs
@@ -58,13 +58,16 @@ impl<'de> Deserialize<'de> for UserDictWord {
 #[allow(clippy::enum_variant_names)] // FIXME
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub(crate) enum InvalidWordError {
-    #[error("無効な発音です({1}): {0:?}")]
+    #[error("{BASE_ERROR_MESSAGE}: 無効な発音です({1}): {0:?}")]
     InvalidPronunciation(String, &'static str),
-    #[error("優先度は{MIN_PRIORITY}以上{MAX_PRIORITY}以下である必要があります: {0}")]
+    #[error("{BASE_ERROR_MESSAGE}: 優先度は{MIN_PRIORITY}以上{MAX_PRIORITY}以下である必要があります: {0}")]
     InvalidPriority(u32),
-    #[error("誤ったアクセント型です({1:?}の範囲から外れています): {0}")]
+    #[error("{BASE_ERROR_MESSAGE}: 誤ったアクセント型です({1:?}の範囲から外れています): {0}")]
     InvalidAccentType(usize, RangeToInclusive<usize>),
 }
+
+const BASE_ERROR_MESSAGE: &str = "ユーザー辞書の単語のバリデーションに失敗しました";
+
 type InvalidWordResult<T> = std::result::Result<T, InvalidWordError>;
 
 static PRONUNCIATION_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[ァ-ヴー]+$").unwrap());

--- a/crates/voicevox_core/src/user_dict/word.rs
+++ b/crates/voicevox_core/src/user_dict/word.rs
@@ -108,9 +108,8 @@ impl UserDictWord {
         if MIN_PRIORITY > priority || priority > MAX_PRIORITY {
             return Err(ErrorRepr::InvalidWord(InvalidWordError::InvalidPriority(priority)).into());
         }
-        validate_pronunciation(&pronunciation).map_err(ErrorRepr::InvalidWord)?;
-        let mora_count =
-            calculate_mora_count(&pronunciation, accent_type).map_err(ErrorRepr::InvalidWord)?;
+        validate_pronunciation(&pronunciation)?;
+        let mora_count = calculate_mora_count(&pronunciation, accent_type)?;
         Ok(Self {
             surface: to_zenkaku(surface),
             pronunciation,


### PR DESCRIPTION
## 内容

#580 で宣言した以下のことをします。

> - `Display`実装には[`source`](https://doc.rust-lang.org/stable/std/error/trait.Error.html#method.source)の内容を含めない

## 関連 Issue

#580, #589, #600, #622, #623 の続きです。

ref #545

## その他

> (これは慣習としてどこかで明文化されていたはずですが、それがどこなのかを忘れました)

と書いてたのですが、これです。

- <https://blog.rust-lang.org/inside-rust/2021/07/01/What-the-error-handling-project-group-is-working-towards.html>

    > **An error type with a source error should either return that error via `source` or include that source's error message in its own `Display` output, but never both.**

- <https://github.com/rust-lang/project-error-handling/issues/27#issuecomment-763950178>

    > * **Return source errors via `Error::source` unless the source error's message is included in your own error message in `Display`.**