### PR TITLE
Sphinxをv6に上げる

### DIFF
--- a/crates/voicevox_core_python_api/requirements.txt
+++ b/crates/voicevox_core_python_api/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx>=5.3.0,<6
+Sphinx>=6.2.1,<7
 maturin>=0.13.2,<0.14
-pydata-sphinx-theme>=0.11.0,<0.12
-sphinx-autoapi>=2.0.0,<3
+pydata-sphinx-theme>=0.14.1,<0.15
+sphinx-autoapi>=3.0.0,<4


### PR DESCRIPTION
## 内容

Sphinxをv6に、他のプラグインを最新版に上げます。v7ではない理由は、Sphinx v7はPython 3.8を切っているからです。

<https://github.com/VOICEVOX/voicevox_core/pull/625#issuecomment-1741294505>の解決を目標にしています。

## 関連 Issue

## その他

うちでもそろそろPython 3.8は切ってもいい感じがしています。

あとですが、もうPoetry入れましょう!!!