### PR TITLE
ビルド周りのGithub Workflowのリファクタリング

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -31,7 +31,7 @@ env:
   VOICEVOX_RESOURCE_VERSION: "0.15.0-preview.3"
   VOICEVOX_FAT_RESOURCE_VERSION: "0.15.0-preview.3"
   # releaseタグ名か、workflow_dispatchでのバージョン名か、'0.0.0'が入る
-  VERSION: ${{ github.event.release.tag_name || github.event.inputs.version || '0.0.0' }}
+  VERSION: ${{ github.event.release.tag_name || inputs.version || '0.0.0' }}
   PRODUCTION_REPOSITORY_TAG: "0.15.0-preview.2" # 製品版のタグ名
   # 簡易テストとするかどうか。releaseとworkflow_dispatch以外は簡易テストとする
   IS_SIMPLE_TEST: ${{ github.event_name != 'release' && github.event_name != 'workflow_dispatch' }}
@@ -46,6 +46,7 @@ jobs:
     outputs:
       includes: ${{ steps.strategy_matrix.outputs.includes }}
       deploy: ${{ env.VERSION != '0.0.0' }}
+      version: ${{ env.VERSION }}
     steps:
       - name: declare strategy matrix
         id: strategy_matrix
@@ -183,21 +184,23 @@ jobs:
 
   build_and_deploy:
     needs: config
-    environment: ${{ github.event.inputs.is_production == 'true' && 'production' || '' }} # 製品版のenvironment
+    environment: ${{ inputs.is_production == 'true' && 'production' || '' }} # 製品版のenvironment
     strategy:
       matrix:
         include: ${{ fromJson(needs.config.outputs.includes) }}
     runs-on: ${{ matrix.os }}
+    env:
+      ASSET_NAME: voicevox_core-${{ matrix.artifact_name }}-${{ needs.config.outputs.version }}
     steps:
       - uses: actions/checkout@v3 # 製品版ではない場合
-        if: ${{ github.event.inputs.is_production != 'true' }}
+        if: ${{ inputs.is_production != 'true' }}
       - uses: actions/checkout@v3 # 製品版の場合
-        if: ${{ github.event.inputs.is_production == 'true' }}
+        if: ${{ inputs.is_production == 'true' }}
         with:
           fetch-depth: 0 # 全履歴取得
           token: ${{ secrets.PRODUCTION_GITHUB_TOKEN }}
       - name: Merge production branch
-        if: github.event.inputs.is_production == 'true'
+        if: inputs.is_production == 'true'
         shell: bash
         run: |
           (
@@ -230,21 +233,21 @@ jobs:
           echo "$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/bin" >> "$GITHUB_PATH"
           echo "AR_${{ matrix.target }}=llvm-ar" >> "$GITHUB_ENV"
       - name: Checkout VOICEVOX RESOURCE
-        if: github.event.inputs.is_production == 'true'
+        if: inputs.is_production == 'true'
         uses: actions/checkout@v3
         with:
           repository: VOICEVOX/voicevox_resource
           ref: ${{ env.VOICEVOX_RESOURCE_VERSION }}
           path: download/resource
       - name: Checkout VOICEVOX FAT RESOURCE
-        if: github.event.inputs.is_production == 'true'
+        if: inputs.is_production == 'true'
         uses: actions/checkout@v3
         with:
           repository: VOICEVOX/voicevox_fat_resource
           ref: ${{ env.VOICEVOX_FAT_RESOURCE_VERSION }}
           path: download/fat_resource
       - name: Raplace resource
-        if: github.event.inputs.is_production == 'true'
+        if: inputs.is_production == 'true'
         shell: bash
         run: |
           mv -f download/resource/core/README.md ./README.md
@@ -259,14 +262,14 @@ jobs:
           if ${{ !!matrix.whl_local_version }}; then cargo set-version "$VERSION+"${{ matrix.whl_local_version }} -p voicevox_core_python_api; fi
       - name: cache target
         uses: Swatinem/rust-cache@v2
-        if: github.event.inputs.is_production != 'true'
+        if: inputs.is_production != 'true'
       - name: build voicevox_core_c_api
         shell: bash
         run: |
           function build() {
             cargo build -p voicevox_core_c_api -vv --features ${{ matrix.features }}, --target ${{ matrix.target }} --release
           }
-          if ${{ github.event.inputs.is_production != 'true' }}; then
+          if ${{ inputs.is_production != 'true' }}; then
             build
           else
             build > /dev/null 2>&1
@@ -283,7 +286,7 @@ jobs:
           function build() {
             maturin build --manifest-path ./crates/voicevox_core_python_api/Cargo.toml --features ${{ matrix.features }}, --target ${{ matrix.target }} --release
           }
-          if ${{ github.event.inputs.is_production != 'true' }}; then
+          if ${{ inputs.is_production != 'true' }}; then
             build
           else
             build > /dev/null 2>&1
@@ -292,18 +295,16 @@ jobs:
         env:
           ORT_USE_CUDA: ${{ matrix.use_cuda }}
       - name: build voicevox_core_java_api
-        if: "contains(matrix.target, 'android')"
+        if: contains(matrix.target, 'android')
         run: |
           function build() {
             cargo build -p voicevox_core_java_api -vv --features ${{ matrix.features }}, --target ${{ matrix.target }} --release
           }
-          if ${{ github.event.inputs.is_production != 'true' }}; then
+          if ${{ inputs.is_production != 'true' }}; then
             build
           else
             build > /dev/null 2>&1
           fi
-      - name: Set ASSET_NAME env var
-        run: echo "ASSET_NAME=voicevox_core-${{ matrix.artifact_name }}-${{ env.VERSION }}" >> "$GITHUB_ENV"
       - name: Organize artifact
         run: |
           mkdir -p "artifact/${{ env.ASSET_NAME }}"
@@ -320,7 +321,7 @@ jobs:
           mkdir java_artifact
           cp -v target/${{ matrix.target }}/release/libvoicevox_core_java_api.so java_artifact/ || true
       - name: Code signing (Windows)
-        if: startsWith(matrix.os, 'windows') && github.event.inputs.code_signing == 'true'
+        if: startsWith(matrix.os, 'windows') && inputs.code_signing == 'true'
         run: |
           bash build_util/codesign.bash "artifact/${{ env.ASSET_NAME }}/voicevox_core.dll"
         env:
@@ -338,7 +339,7 @@ jobs:
           cd artifact
           7z a "../${{ env.ASSET_NAME }}.zip" "${{ env.ASSET_NAME }}"
       - name: Upload to Release
-        if: needs.config.outputs.deploy == 'true' && env.SKIP_UPLOADING_RELEASE_ASSET == '0' && !contains(matrix.target, 'ios')
+        if: needs.config.outputs.deploy == 'true' && !contains(matrix.target, 'ios')
         uses: softprops/action-gh-release@v1
         with:
           prerelease: true
@@ -356,7 +357,7 @@ jobs:
             ${{ steps.build-voicevox-core-python-api.outputs.whl }}
           target_commitish: ${{ github.sha }}
       - name: Upload voicevox_core_java_api artifact
-        if: env.VERSION != '0.0.0' && contains(matrix.target, 'android')
+        if: needs.config.outputs.deploy == 'true' && contains(matrix.target, 'android')
         uses: actions/upload-artifact@v3
         with:
           name: voicevox_core_java_api-${{ matrix.artifact_name }}
@@ -366,10 +367,10 @@ jobs:
     if: ${{ !(github.event_name != 'release' && github.event_name != 'workflow_dispatch') }} # !env.IS_SIMPLE_TEST と同じ
     needs: [config, build_and_deploy]
     runs-on: macos-12
+    env:
+      ASSET_NAME: voicevox_core-ios-xcframework-cpu-${{ needs.config.outputs.version }}
     steps:
       - uses: actions/checkout@v3
-      - name: Set ASSET_NAME env var
-        run: echo "ASSET_NAME=voicevox_core-ios-xcframework-cpu-${{ env.VERSION }}" >> "$GITHUB_ENV"
       - uses: actions/download-artifact@v2
         with:
           name: voicevox_core-x86_64-apple-ios
@@ -407,7 +408,7 @@ jobs:
           cd artifact/${{ env.ASSET_NAME }}
           7z a "../../${{ env.ASSET_NAME }}.zip" "voicevox_core.xcframework"
       - name: Upload to Release
-        if: needs.config.outputs.deploy == 'true' && env.SKIP_UPLOADING_RELEASE_ASSET == '0'
+        if: needs.config.outputs.deploy == 'true'
         uses: softprops/action-gh-release@v1
         with:
           prerelease: true
@@ -419,8 +420,7 @@ jobs:
   build_java_package:
     runs-on: ubuntu-latest
     if: ${{ !(github.event_name != 'release' && github.event_name != 'workflow_dispatch') }} # !env.IS_SIMPLE_TEST と同じ
-    needs:
-      - build_and_deploy
+    needs: [config, build_and_deploy]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Rust
@@ -482,7 +482,7 @@ jobs:
           zip -r /tmp/java_packages.zip .
 
       - name: Upload to Release
-        if: env.VERSION != '0.0.0' && env.SKIP_UPLOADING_RELEASE_ASSET == '0'
+        if: needs.config.outputs.deploy == 'true'
         uses: softprops/action-gh-release@v1
         with:
           prerelease: true

--- a/.github/workflows/build_and_deploy_downloader.yml
+++ b/.github/workflows/build_and_deploy_downloader.yml
@@ -34,7 +34,7 @@ on:
 
 env:
   # releaseタグ名か、workflow_dispatchでのバージョン名か、'0.0.0'が入る
-  VERSION: ${{ github.event.release.tag_name || github.event.inputs.version || '0.0.0' }}
+  VERSION: ${{ github.event.release.tag_name || inputs.version || '0.0.0' }}
 
 defaults:
   run:
@@ -42,7 +42,7 @@ defaults:
 
 jobs:
   deploy_and_deploy_downloader:
-    environment: ${{ github.event.inputs.is_production == 'true' && 'production' || '' }} # コード署名用のenvironment
+    environment: ${{ inputs.is_production == 'true' && 'production' || '' }} # コード署名用のenvironment
     strategy:
       matrix:
         include:
@@ -94,7 +94,7 @@ jobs:
           mv $"target/${{ matrix.target }}/release/download$exe_suffix" ./${{ matrix.name }}
 
       - name: Code signing (Windows)
-        if: startsWith(matrix.os, 'windows') && github.event.inputs.code_signing == 'true'
+        if: startsWith(matrix.os, 'windows') && inputs.code_signing == 'true'
         run: |
           bash build_util/codesign.bash ./${{ matrix.name }}
         env:


### PR DESCRIPTION
## 内容

ビルド周りのgithubワークフローで、若干統一性がなかったのといくつか気になった点があったのでファクタリングしてみました。

* `github.event.inputs`は`inputs`にできるので短くした
* `ASSET_NAME`をステップ動的に定義するのではなく静的に定義できるようにした
	* VSCodeだとステップ内で定義された環境変数は認識されなくてワーニングが出る
* `"contains(matrix.target, 'android')"`がエラーになっていたので直した
* `SKIP_UPLOADING_RELEASE_ASSET`はもう存在しないのでコード中から消した
* `env.VERSION != '0.0.0'`はリリース判定に使わなくなったので変更した

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他

- https://github.com/VOICEVOX/voicevox_core/pull/603

の前作業です。
