### PR TITLE
`workspace.resolver`を設定

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/voicevox_core_python_api",
     "crates/xtask"
 ]
+resolver = "2"
 
 [workspace.dependencies]
 anyhow = "1.0.65"


### PR DESCRIPTION
## 内容

workspace rootでClippyなどを動かそうとしたときに出るこれを解消します。

```console
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```

`2`で揃える利点としては、再ビルドの発生が減ることが期待できる点です。
(特に今の/crates/test_utilは問答無用で辞書(100MB)を再ダウンロードしたりするので)

## 関連 Issue

## その他
