### PR TITLE
`JavaStr`の内容を直にUTF-8として読まない

### DIFF
--- a/crates/voicevox_core_java_api/src/open_jtalk.rs
+++ b/crates/voicevox_core_java_api/src/open_jtalk.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    borrow::Cow,
+    sync::{Arc, Mutex},
+};
 
 use crate::common::throw_if_err;
 use jni::{
@@ -26,7 +29,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_OpenJtalk_rsNewWithInit
 ) {
     throw_if_err(env, (), |env| {
         let open_jtalk_dict_dir = env.get_string(&open_jtalk_dict_dir)?;
-        let open_jtalk_dict_dir = open_jtalk_dict_dir.to_str()?;
+        let open_jtalk_dict_dir = &*Cow::from(&open_jtalk_dict_dir);
 
         let internal = voicevox_core::OpenJtalk::new_with_initialize(open_jtalk_dict_dir)?;
         env.set_rust_field(&this, "handle", Arc::new(internal))?;

--- a/crates/voicevox_core_java_api/src/user_dict.rs
+++ b/crates/voicevox_core_java_api/src/user_dict.rs
@@ -1,5 +1,8 @@
 use jni::objects::JClass;
-use std::sync::{Arc, Mutex};
+use std::{
+    borrow::Cow,
+    sync::{Arc, Mutex},
+};
 
 use crate::common::throw_if_err;
 use jni::{
@@ -34,7 +37,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_UserDict_rsAddWord<'loc
             .clone();
 
         let word_json = env.get_string(&word_json)?;
-        let word_json = word_json.to_str()?;
+        let word_json = &Cow::from(&word_json);
 
         let word: voicevox_core::UserDictWord = serde_json::from_str(word_json)?;
 
@@ -63,9 +66,9 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_UserDict_rsUpdateWord<'
             .clone();
 
         let uuid = env.get_string(&uuid)?;
-        let uuid = uuid.to_str()?.parse()?;
+        let uuid = Cow::from(&uuid).parse()?;
         let word_json = env.get_string(&word_json)?;
-        let word_json = word_json.to_str()?;
+        let word_json = &Cow::from(&word_json);
 
         let word: voicevox_core::UserDictWord = serde_json::from_str(word_json)?;
 
@@ -90,7 +93,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_UserDict_rsRemoveWord<'
             .clone();
 
         let uuid = env.get_string(&uuid)?;
-        let uuid = uuid.to_str()?.parse()?;
+        let uuid = Cow::from(&uuid).parse()?;
 
         {
             let mut internal = internal.lock().unwrap();
@@ -137,7 +140,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_UserDict_rsLoad<'local>
             .clone();
 
         let path = env.get_string(&path)?;
-        let path = path.to_str()?;
+        let path = &Cow::from(&path);
 
         {
             let mut internal = internal.lock().unwrap();
@@ -160,7 +163,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_UserDict_rsSave<'local>
             .clone();
 
         let path = env.get_string(&path)?;
-        let path = path.to_str()?;
+        let path = &Cow::from(&path);
 
         {
             let internal = internal.lock().unwrap();
@@ -211,7 +214,7 @@ extern "system" fn Java_jp_hiroshiba_voicevoxcore_UserDict_rsToZenkaku<'local>(
 ) -> jobject {
     throw_if_err(env, std::ptr::null_mut(), |env| {
         let text = env.get_string(&text)?;
-        let text = text.to_str()?;
+        let text = &Cow::from(&text);
 
         let text = voicevox_core::__internal::to_zenkaku(text);
 
@@ -228,7 +231,7 @@ extern "system" fn Java_jp_hiroshiba_voicevoxcore_UserDict_rsValidatePronunciati
 ) {
     throw_if_err(env, (), |env| {
         let text = env.get_string(&text)?;
-        let text = text.to_str()?;
+        let text = &Cow::from(&text);
 
         voicevox_core::__internal::validate_pronunciation(text)?;
 

--- a/crates/voicevox_core_java_api/src/voice_model.rs
+++ b/crates/voicevox_core_java_api/src/voice_model.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{borrow::Cow, sync::Arc};
 
 use crate::common::{throw_if_err, RUNTIME};
 use jni::{
@@ -15,7 +15,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_VoiceModel_rsFromPath<'
 ) {
     throw_if_err(env, (), |env| {
         let model_path = env.get_string(&model_path)?;
-        let model_path = model_path.to_str()?;
+        let model_path = &*Cow::from(&model_path);
 
         let internal = RUNTIME.block_on(voicevox_core::VoiceModel::from_path(model_path))?;
 


### PR DESCRIPTION
## 内容

> - `JavaApiError::Utf8`: `<JavaStr<'_, '_, '_> as Deref<Target = CStr>>::to_str`としているところをすべて`<Cow<'_, str> as From<&JavaStr<'_, '_, '_>>>::from`に変えることで、存在自体を消しました。

<https://github.com/VOICEVOX/voicevox_core/pull/640#discussion_r1367796728>

以上の内容を独立したPRにしました。

[`JavaStr`](https://docs.rs/jni/0.21/jni/strings/struct.JavaStr.html)の内容は、ドキュメントに書かれている通り"Modified UTF-8"であるため、[`<Cow<'_, str> as From<&JavaStr<'_, '_, '_>>>`](https://docs.rs/jni/0.21.1/jni/strings/struct.JavaStr.html#impl-From<%26'java_str+JavaStr<'local,+'other_local,+'obj_ref>>-for-Cow<'java_str,+str>)を利用するのが適切です。

[中の実装](https://docs.rs/jni/0.21.1/src/jni/wrapper/strings/ffi_str.rs.html#54-63)を見るとちゃんとinfallibleであるか不安にはなるのですが、それでも少なくとも[`Utf8Error`](https://doc.rust-lang.org/stable/std/str/struct.Utf8Error.html)ではなく[`cesu8::Cesu8DecodingError`](https://docs.rs/cesu8/1/cesu8/struct.Cesu8DecodingError.html)を発するような形になるべきだと思います。

## 関連 Issue

## その他
