### PR TITLE
古いpoetry.lockを弾く

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -25,15 +25,16 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
+      - name: Install Poetry
+        run: |
+          python -m pip install --upgrade poetry
+          poetry config virtualenvs.create false
       - name: Validate poetry.lock
         run: |
           poetry lock --no-update
           git diff
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade poetry
-          poetry config virtualenvs.create false
-          poetry install --with test
+        run: poetry install --with test
       - name: Check code style for voicevox_core_python_api
         run: |
           black --check .

--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -25,6 +25,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
+      - name: Validate poetry.lock
+        run: |
+          poetry lock --no-update
+          git diff
       - name: Install dependencies
         run: |
           python -m pip install --upgrade poetry

--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Validate poetry.lock
         run: |
           poetry lock --no-update
-          git diff
+          git diff --exit-code
       - name: Install dependencies
         run: poetry install --with test
       - name: Check code style for voicevox_core_python_api


### PR DESCRIPTION
## 内容

poetry.lockに対し、<https://github.com/VOICEVOX/voicevox_core/pull/357>と同等のことをします。

Rustのときと比べ、どちらかというと<https://github.com/VOICEVOX/voicevox_engine/issues/750>の対策です。

## 関連 Issue

## その他

ちなみに`poetry check (--lock)`は古いpoetry.lockを素通ししました。
