### PR TITLE
test_utilクレートを`dev-dependencies`に

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -274,7 +274,7 @@ jobs:
       - run: |
           pip install --upgrade poetry
           poetry install --with dev --with test
-      - run: cargo build -p voicevox_core_c_api -vv
+      - run: cargo build -p test_util -vv # build scriptにより/crates/test_util/data/の生成
       - run: poetry run maturin build --locked
       - run: poetry run maturin develop --locked
       - name: 必要なDLLをコピーしてpytestを実行
@@ -305,7 +305,7 @@ jobs:
       - name: Build
         run: |
           cargo build -p voicevox_core_java_api -vv
-          cargo build -p test_util -vv
+          cargo build -p test_util -vv # build scriptにより/crates/test_util/data/の生成
       - name: 必要なDLLをコピーしてテストを実行
         working-directory: crates/voicevox_core_java_api
         run: |

--- a/crates/voicevox_core_python_api/Cargo.toml
+++ b/crates/voicevox_core_python_api/Cargo.toml
@@ -23,7 +23,9 @@ pyo3-asyncio = { version = "0.18.0", features = ["tokio-runtime"] }
 pyo3-log = "0.8.0"
 serde.workspace = true
 serde_json.workspace = true
-test_util.workspace = true # only for it's build script
 tokio.workspace = true
 uuid.workspace = true
 voicevox_core.workspace = true
+
+[dev-dependencies]
+test_util.workspace = true # only for its build script


### PR DESCRIPTION
## 内容

Python APIからのtest\_utilクレートの依存を、他に合わせて`dependencies`から`dev-dependencies`に移します。

<https://penguin.fanbox.cc/posts/6211928>

## 関連 Issue

## その他
