### PR TITLE
[docs] Python版exampleで、asyncやawaitは必須であることをコメントで書いておく

### DIFF
--- a/example/python/run.py
+++ b/example/python/run.py
@@ -16,6 +16,7 @@ from voicevox_core import (
 )
 
 
+# asyncやawaitは必須です。
 async def main() -> None:
     logging.basicConfig(format="[%(levelname)s] %(name)s: %(message)s")
     logger = logging.getLogger(__name__)


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/voicevox_core/issues/662

にて気づいたPython版の難しさを少しでも低減するために、一番最初のトラップになり得るであろう「asyncを外して書く」や「def mainを書かない」人を少しでも少なくするためのコメントを追記してみました。

他にも必要な案内などがあれば言っていただければ書こうと思います。

## 関連 Issue

#662

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他
