### PR TITLE
"new_with_initialize" → "new"

### DIFF
--- a/crates/voicevox_core/src/engine/open_jtalk.rs
+++ b/crates/voicevox_core/src/engine/open_jtalk.rs
@@ -35,6 +35,7 @@ struct Resources {
 unsafe impl Send for Resources {}
 
 impl OpenJtalk {
+    // FIXME: この関数は廃止し、`Synthesizer`は`Option<OpenJtalk>`という形でこの構造体を持つ
     pub fn new_without_dic() -> Self {
         Self {
             resources: Mutex::new(Resources {
@@ -45,9 +46,7 @@ impl OpenJtalk {
             dict_dir: None,
         }
     }
-    pub fn new_with_initialize(
-        open_jtalk_dict_dir: impl AsRef<Path>,
-    ) -> crate::result::Result<Self> {
+    pub fn new(open_jtalk_dict_dir: impl AsRef<Path>) -> crate::result::Result<Self> {
         let mut s = Self::new_without_dic();
         s.load(open_jtalk_dict_dir).map_err(|()| {
             // FIXME: 「システム辞書を読もうとしたけど読めなかった」というエラーをちゃんと用意する
@@ -274,7 +273,7 @@ mod tests {
         #[case] text: &str,
         #[case] expected: std::result::Result<Vec<String>, OpenjtalkFunctionError>,
     ) {
-        let open_jtalk = OpenJtalk::new_with_initialize(OPEN_JTALK_DIC_DIR).unwrap();
+        let open_jtalk = OpenJtalk::new(OPEN_JTALK_DIC_DIR).unwrap();
         let result = open_jtalk.extract_fullcontext(text);
         assert_debug_fmt_eq!(expected, result);
     }
@@ -285,7 +284,7 @@ mod tests {
         #[case] text: &str,
         #[case] expected: std::result::Result<Vec<String>, OpenjtalkFunctionError>,
     ) {
-        let open_jtalk = OpenJtalk::new_with_initialize(OPEN_JTALK_DIC_DIR).unwrap();
+        let open_jtalk = OpenJtalk::new(OPEN_JTALK_DIC_DIR).unwrap();
         for _ in 0..10 {
             let result = open_jtalk.extract_fullcontext(text);
             assert_debug_fmt_eq!(expected, result);

--- a/crates/voicevox_core/src/engine/synthesis_engine.rs
+++ b/crates/voicevox_core/src/engine/synthesis_engine.rs
@@ -652,13 +652,9 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn is_openjtalk_dict_loaded_works() {
-        let core = InferenceCore::new_with_initialize(false, 0).await.unwrap();
-        let synthesis_engine = SynthesisEngine::new(
-            core,
-            OpenJtalk::new_with_initialize(OPEN_JTALK_DIC_DIR)
-                .unwrap()
-                .into(),
-        );
+        let core = InferenceCore::new(false, 0).await.unwrap();
+        let synthesis_engine =
+            SynthesisEngine::new(core, OpenJtalk::new(OPEN_JTALK_DIC_DIR).unwrap().into());
 
         assert_eq!(synthesis_engine.is_openjtalk_dict_loaded(), true);
     }
@@ -666,17 +662,13 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn create_accent_phrases_works() {
-        let core = InferenceCore::new_with_initialize(false, 0).await.unwrap();
+        let core = InferenceCore::new(false, 0).await.unwrap();
 
         let model = &VoiceModel::sample().await.unwrap();
         core.load_model(model).await.unwrap();
 
-        let synthesis_engine = SynthesisEngine::new(
-            core,
-            OpenJtalk::new_with_initialize(OPEN_JTALK_DIC_DIR)
-                .unwrap()
-                .into(),
-        );
+        let synthesis_engine =
+            SynthesisEngine::new(core, OpenJtalk::new(OPEN_JTALK_DIC_DIR).unwrap().into());
 
         let accent_phrases = synthesis_engine
             .create_accent_phrases("同じ、文章、です。完全に、同一です。", StyleId::new(1))

--- a/crates/voicevox_core/src/inference_core.rs
+++ b/crates/voicevox_core/src/inference_core.rs
@@ -9,7 +9,7 @@ pub struct InferenceCore {
 }
 
 impl InferenceCore {
-    pub(crate) async fn new_with_initialize(use_gpu: bool, cpu_num_threads: u16) -> Result<Self> {
+    pub(crate) async fn new(use_gpu: bool, cpu_num_threads: u16) -> Result<Self> {
         if !use_gpu || Self::can_support_gpu_feature()? {
             let status = Status::new(use_gpu, cpu_num_threads);
             Ok(Self { status })

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -58,9 +58,9 @@ pub enum AccelerationMode {
     Gpu,
 }
 
-/// [`Synthesizer::new_with_initialize`]のオプション。
+/// [`Synthesizer::new`]のオプション。
 ///
-/// [`Synthesizer::new_with_initialize`]: Synthesizer::new_with_initialize
+/// [`Synthesizer::new`]: Synthesizer::new
 #[derive(Default)]
 pub struct InitializeOptions {
     pub acceleration_mode: AccelerationMode,
@@ -90,8 +90,8 @@ impl Synthesizer {
     ///
     /// use voicevox_core::{AccelerationMode, InitializeOptions, OpenJtalk, Synthesizer};
     ///
-    /// let mut syntesizer = Synthesizer::new_with_initialize(
-    ///     Arc::new(OpenJtalk::new_with_initialize(OPEN_JTALK_DIC_DIR).unwrap()),
+    /// let mut syntesizer = Synthesizer::new(
+    ///     Arc::new(OpenJtalk::new(OPEN_JTALK_DIC_DIR).unwrap()),
     ///     &InitializeOptions {
     ///         acceleration_mode: ACCELERATION_MODE,
     ///         ..Default::default()
@@ -102,10 +102,7 @@ impl Synthesizer {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn new_with_initialize(
-        open_jtalk: Arc<OpenJtalk>,
-        options: &InitializeOptions,
-    ) -> Result<Self> {
+    pub async fn new(open_jtalk: Arc<OpenJtalk>, options: &InitializeOptions) -> Result<Self> {
         #[cfg(windows)]
         list_windows_video_cards();
         let use_gpu = match options.acceleration_mode {
@@ -127,7 +124,7 @@ impl Synthesizer {
 
         Ok(Self {
             synthesis_engine: SynthesisEngine::new(
-                InferenceCore::new_with_initialize(use_gpu, options.cpu_num_threads).await?,
+                InferenceCore::new(use_gpu, options.cpu_num_threads).await?,
                 open_jtalk,
             ),
             use_gpu,
@@ -256,8 +253,8 @@ impl Synthesizer {
     /// #         AccelerationMode, InitializeOptions, OpenJtalk, Synthesizer, VoiceModel,
     /// #     };
     /// #
-    /// #     let mut syntesizer = Synthesizer::new_with_initialize(
-    /// #         Arc::new(OpenJtalk::new_with_initialize(OPEN_JTALK_DIC_DIR).unwrap()),
+    /// #     let mut syntesizer = Synthesizer::new(
+    /// #         Arc::new(OpenJtalk::new(OPEN_JTALK_DIC_DIR).unwrap()),
     /// #         &InitializeOptions {
     /// #             acceleration_mode: AccelerationMode::Cpu,
     /// #             ..Default::default()
@@ -310,8 +307,8 @@ impl Synthesizer {
     /// #         AccelerationMode, InitializeOptions, OpenJtalk, Synthesizer, VoiceModel,
     /// #     };
     /// #
-    /// #     let mut syntesizer = Synthesizer::new_with_initialize(
-    /// #         Arc::new(OpenJtalk::new_with_initialize(OPEN_JTALK_DIC_DIR).unwrap()),
+    /// #     let mut syntesizer = Synthesizer::new(
+    /// #         Arc::new(OpenJtalk::new(OPEN_JTALK_DIC_DIR).unwrap()),
     /// #         &InitializeOptions {
     /// #             acceleration_mode: AccelerationMode::Cpu,
     /// #             ..Default::default()
@@ -400,8 +397,8 @@ impl Synthesizer {
     /// #         AccelerationMode, InitializeOptions, OpenJtalk, Synthesizer, VoiceModel,
     /// #     };
     /// #
-    /// #     let mut syntesizer = Synthesizer::new_with_initialize(
-    /// #         Arc::new(OpenJtalk::new_with_initialize(OPEN_JTALK_DIC_DIR).unwrap()),
+    /// #     let mut syntesizer = Synthesizer::new(
+    /// #         Arc::new(OpenJtalk::new(OPEN_JTALK_DIC_DIR).unwrap()),
     /// #         &InitializeOptions {
     /// #             acceleration_mode: AccelerationMode::Cpu,
     /// #             ..Default::default()
@@ -455,8 +452,8 @@ impl Synthesizer {
     /// #         AccelerationMode, InitializeOptions, OpenJtalk, Synthesizer, VoiceModel,
     /// #     };
     /// #
-    /// #     let mut syntesizer = Synthesizer::new_with_initialize(
-    /// #         Arc::new(OpenJtalk::new_with_initialize(OPEN_JTALK_DIC_DIR).unwrap()),
+    /// #     let mut syntesizer = Synthesizer::new(
+    /// #         Arc::new(OpenJtalk::new(OPEN_JTALK_DIC_DIR).unwrap()),
     /// #         &InitializeOptions {
     /// #             acceleration_mode: AccelerationMode::Cpu,
     /// #             ..Default::default()
@@ -582,7 +579,7 @@ mod tests {
     #[case(Ok(()))]
     #[tokio::test]
     async fn load_model_works(#[case] expected_result_at_initialized: Result<()>) {
-        let syntesizer = Synthesizer::new_with_initialize(
+        let syntesizer = Synthesizer::new(
             Arc::new(OpenJtalk::new_without_dic()),
             &InitializeOptions {
                 acceleration_mode: AccelerationMode::Cpu,
@@ -606,7 +603,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn is_use_gpu_works() {
-        let syntesizer = Synthesizer::new_with_initialize(
+        let syntesizer = Synthesizer::new(
             Arc::new(OpenJtalk::new_without_dic()),
             &InitializeOptions {
                 acceleration_mode: AccelerationMode::Cpu,
@@ -623,7 +620,7 @@ mod tests {
     #[tokio::test]
     async fn is_loaded_model_by_style_id_works(#[case] style_id: u32, #[case] expected: bool) {
         let style_id = StyleId::new(style_id);
-        let syntesizer = Synthesizer::new_with_initialize(
+        let syntesizer = Synthesizer::new(
             Arc::new(OpenJtalk::new_without_dic()),
             &InitializeOptions {
                 acceleration_mode: AccelerationMode::Cpu,
@@ -652,7 +649,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn predict_duration_works() {
-        let syntesizer = Synthesizer::new_with_initialize(
+        let syntesizer = Synthesizer::new(
             Arc::new(OpenJtalk::new_without_dic()),
             &InitializeOptions {
                 acceleration_mode: AccelerationMode::Cpu,
@@ -684,7 +681,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn predict_intonation_works() {
-        let syntesizer = Synthesizer::new_with_initialize(
+        let syntesizer = Synthesizer::new(
             Arc::new(OpenJtalk::new_without_dic()),
             &InitializeOptions {
                 acceleration_mode: AccelerationMode::Cpu,
@@ -726,7 +723,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn decode_works() {
-        let syntesizer = Synthesizer::new_with_initialize(
+        let syntesizer = Synthesizer::new(
             Arc::new(OpenJtalk::new_without_dic()),
             &InitializeOptions {
                 acceleration_mode: AccelerationMode::Cpu,
@@ -819,8 +816,8 @@ mod tests {
         #[case] expected_text_consonant_vowel_data: &TextConsonantVowelData,
         #[case] expected_kana_text: &str,
     ) {
-        let syntesizer = Synthesizer::new_with_initialize(
-            Arc::new(OpenJtalk::new_with_initialize(OPEN_JTALK_DIC_DIR).unwrap()),
+        let syntesizer = Synthesizer::new(
+            Arc::new(OpenJtalk::new(OPEN_JTALK_DIC_DIR).unwrap()),
             &InitializeOptions {
                 acceleration_mode: AccelerationMode::Cpu,
                 ..Default::default()
@@ -888,8 +885,8 @@ mod tests {
         #[case] input: Input,
         #[case] expected_text_consonant_vowel_data: &TextConsonantVowelData,
     ) {
-        let syntesizer = Synthesizer::new_with_initialize(
-            Arc::new(OpenJtalk::new_with_initialize(OPEN_JTALK_DIC_DIR).unwrap()),
+        let syntesizer = Synthesizer::new(
+            Arc::new(OpenJtalk::new(OPEN_JTALK_DIC_DIR).unwrap()),
             &InitializeOptions {
                 acceleration_mode: AccelerationMode::Cpu,
                 ..Default::default()
@@ -954,8 +951,8 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn mora_length_works() {
-        let syntesizer = Synthesizer::new_with_initialize(
-            Arc::new(OpenJtalk::new_with_initialize(OPEN_JTALK_DIC_DIR).unwrap()),
+        let syntesizer = Synthesizer::new(
+            Arc::new(OpenJtalk::new(OPEN_JTALK_DIC_DIR).unwrap()),
             &InitializeOptions {
                 acceleration_mode: AccelerationMode::Cpu,
                 ..Default::default()
@@ -991,8 +988,8 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn mora_pitch_works() {
-        let syntesizer = Synthesizer::new_with_initialize(
-            Arc::new(OpenJtalk::new_with_initialize(OPEN_JTALK_DIC_DIR).unwrap()),
+        let syntesizer = Synthesizer::new(
+            Arc::new(OpenJtalk::new(OPEN_JTALK_DIC_DIR).unwrap()),
             &InitializeOptions {
                 acceleration_mode: AccelerationMode::Cpu,
                 ..Default::default()
@@ -1024,8 +1021,8 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn mora_data_works() {
-        let syntesizer = Synthesizer::new_with_initialize(
-            Arc::new(OpenJtalk::new_with_initialize(OPEN_JTALK_DIC_DIR).unwrap()),
+        let syntesizer = Synthesizer::new(
+            Arc::new(OpenJtalk::new(OPEN_JTALK_DIC_DIR).unwrap()),
             &InitializeOptions {
                 acceleration_mode: AccelerationMode::Cpu,
                 ..Default::default()

--- a/crates/voicevox_core_c_api/include/voicevox_core.h
+++ b/crates/voicevox_core_c_api/include/voicevox_core.h
@@ -222,7 +222,7 @@ typedef int32_t VoicevoxUserDictWordType;
  * <b>構築</b>(_construction_)は ::voicevox_open_jtalk_rc_new で行い、<b>破棄</b>(_destruction_)は ::voicevox_open_jtalk_rc_delete で行う。
  *
  * 参照カウント方式のスマートポインタ(reference-counted smart pointer)であり、
- * ::voicevox_synthesizer_new_with_initialize に渡されるときには参照カウンタがインクリメントされる形でオブジェクトの共有が行われる。
+ * ::voicevox_synthesizer_new に渡されるときには参照カウンタがインクリメントされる形でオブジェクトの共有が行われる。
  *
  * \example{
  * ```c
@@ -238,7 +238,7 @@ typedef struct OpenJtalkRc OpenJtalkRc;
 /**
  * 音声シンセサイザ。
  *
- * <b>構築</b>(_construction_)は ::voicevox_synthesizer_new_with_initialize で行い、<b>破棄</b>(_destruction_)は ::voicevox_synthesizer_delete で行う。
+ * <b>構築</b>(_construction_)は ::voicevox_synthesizer_new で行い、<b>破棄</b>(_destruction_)は ::voicevox_synthesizer_delete で行う。
  */
 typedef struct VoicevoxSynthesizer VoicevoxSynthesizer;
 
@@ -256,7 +256,7 @@ typedef struct VoicevoxUserDict VoicevoxUserDict;
 typedef struct VoicevoxVoiceModel VoicevoxVoiceModel;
 
 /**
- * ::voicevox_synthesizer_new_with_initialize のオプション。
+ * ::voicevox_synthesizer_new のオプション。
  */
 typedef struct VoicevoxInitializeOptions {
   /**
@@ -502,9 +502,9 @@ void voicevox_voice_model_delete(struct VoicevoxVoiceModel *model);
 #ifdef _WIN32
 __declspec(dllimport)
 #endif
-VoicevoxResultCode voicevox_synthesizer_new_with_initialize(const struct OpenJtalkRc *open_jtalk,
-                                                            struct VoicevoxInitializeOptions options,
-                                                            struct VoicevoxSynthesizer **out_synthesizer);
+VoicevoxResultCode voicevox_synthesizer_new(const struct OpenJtalkRc *open_jtalk,
+                                            struct VoicevoxInitializeOptions options,
+                                            struct VoicevoxSynthesizer **out_synthesizer);
 
 /**
  * ::VoicevoxSynthesizer を<b>破棄</b>(_destruct_)する。
@@ -512,7 +512,7 @@ VoicevoxResultCode voicevox_synthesizer_new_with_initialize(const struct OpenJta
  * @param [in] synthesizer 破棄対象
  *
  * \safety{
- * - `synthesizer`は ::voicevox_synthesizer_new_with_initialize で得たものでなければならず、また既にこの関数で解放されていてはいけない。
+ * - `synthesizer`は ::voicevox_synthesizer_new で得たものでなければならず、また既にこの関数で解放されていてはいけない。
  * - `synthesizer`は以後<b>ダングリングポインタ</b>(_dangling pointer_)として扱われなくてはならない。
  * }
  */
@@ -530,7 +530,7 @@ void voicevox_synthesizer_delete(struct VoicevoxSynthesizer *synthesizer);
  * @returns 結果コード
  *
  * \safety{
- * - `synthesizer`は ::voicevox_synthesizer_new_with_initialize で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
+ * - `synthesizer`は ::voicevox_synthesizer_new で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
  * - `model`は ::voicevox_voice_model_new_from_path で得たものでなければならず、また ::voicevox_voice_model_delete で解放されていてはいけない。
  * }
  */
@@ -549,7 +549,7 @@ VoicevoxResultCode voicevox_synthesizer_load_voice_model(const struct VoicevoxSy
  * @returns 結果コード
  *
  * \safety{
- * - `synthesizer`は ::voicevox_synthesizer_new_with_initialize で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
+ * - `synthesizer`は ::voicevox_synthesizer_new で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
  * - `model_id`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * }
  */
@@ -567,7 +567,7 @@ VoicevoxResultCode voicevox_synthesizer_unload_voice_model(const struct Voicevox
  * @returns GPUモードかどうか
  *
  * \safety{
- * - `synthesizer`は ::voicevox_synthesizer_new_with_initialize で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
+ * - `synthesizer`は ::voicevox_synthesizer_new で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
  * }
  */
 #ifdef _WIN32
@@ -584,7 +584,7 @@ bool voicevox_synthesizer_is_gpu_mode(const struct VoicevoxSynthesizer *synthesi
  * @returns モデルが読み込まれているかどうか
  *
  * \safety{
- * - `synthesizer`は ::voicevox_synthesizer_new_with_initialize で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
+ * - `synthesizer`は ::voicevox_synthesizer_new で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
  * - `model_id`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * }
  */
@@ -604,7 +604,7 @@ bool voicevox_synthesizer_is_loaded_voice_model(const struct VoicevoxSynthesizer
  * @return メタ情報のJSON文字列
  *
  * \safety{
- * - `synthesizer`は ::voicevox_synthesizer_new_with_initialize で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
+ * - `synthesizer`は ::voicevox_synthesizer_new で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
  * }
  */
 #ifdef _WIN32
@@ -661,7 +661,7 @@ VoicevoxResultCode voicevox_create_supported_devices_json(char **output_supporte
  * }
  *
  * \safety{
- * - `synthesizer`は ::voicevox_synthesizer_new_with_initialize で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
+ * - `synthesizer`は ::voicevox_synthesizer_new で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
  * - `kana`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * - `output_audio_query_json`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * }
@@ -696,7 +696,7 @@ VoicevoxResultCode voicevox_synthesizer_create_audio_query_from_kana(const struc
  * }
  *
  * \safety{
- * - `synthesizer`は ::voicevox_synthesizer_new_with_initialize で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
+ * - `synthesizer`は ::voicevox_synthesizer_new で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
  * - `text`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * - `output_audio_query_json`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * }
@@ -732,7 +732,7 @@ VoicevoxResultCode voicevox_synthesizer_create_audio_query(const struct Voicevox
  * }
  *
  * \safety{
- * - `synthesizer`は ::voicevox_synthesizer_new_with_initialize で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
+ * - `synthesizer`は ::voicevox_synthesizer_new で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
  * - `kana`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * - `output_audio_query_json`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * }
@@ -767,7 +767,7 @@ VoicevoxResultCode voicevox_synthesizer_create_accent_phrases_from_kana(const st
  * }
  *
  * \safety{
- * - `synthesizer`は ::voicevox_synthesizer_new_with_initialize で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
+ * - `synthesizer`は ::voicevox_synthesizer_new で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
  * - `text`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * - `output_audio_query_json`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * }
@@ -793,7 +793,7 @@ VoicevoxResultCode voicevox_synthesizer_create_accent_phrases(const struct Voice
  * @returns 結果コード
  *
  * \safety{
- * - `synthesizer`は ::voicevox_synthesizer_new_with_initialize で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
+ * - `synthesizer`は ::voicevox_synthesizer_new で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
  * - `accent_phrases_json`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * - `output_audio_query_json`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * }
@@ -819,7 +819,7 @@ VoicevoxResultCode voicevox_synthesizer_replace_mora_data(const struct VoicevoxS
  * @returns 結果コード
  *
  * \safety{
- * - `synthesizer`は ::voicevox_synthesizer_new_with_initialize で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
+ * - `synthesizer`は ::voicevox_synthesizer_new で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
  * - `accent_phrases_json`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * - `output_audio_query_json`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * }
@@ -845,7 +845,7 @@ VoicevoxResultCode voicevox_synthesizer_replace_phoneme_length(const struct Voic
  * @returns 結果コード
  *
  * \safety{
- * - `synthesizer`は ::voicevox_synthesizer_new_with_initialize で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
+ * - `synthesizer`は ::voicevox_synthesizer_new で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
  * - `accent_phrases_json`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * - `output_audio_query_json`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * }
@@ -882,7 +882,7 @@ struct VoicevoxSynthesisOptions voicevox_make_default_synthesis_options(void);
  * @returns 結果コード
  *
  * \safety{
- * - `synthesizer`は ::voicevox_synthesizer_new_with_initialize で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
+ * - `synthesizer`は ::voicevox_synthesizer_new で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
  * - `audio_query_json`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * - `output_wav_length`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * - `output_wav`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
@@ -922,7 +922,7 @@ struct VoicevoxTtsOptions voicevox_make_default_tts_options(void);
  * @returns 結果コード
  *
  * \safety{
- * - `synthesizer`は ::voicevox_synthesizer_new_with_initialize で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
+ * - `synthesizer`は ::voicevox_synthesizer_new で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
  * - `kana`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * - `output_wav_length`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * - `output_wav`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
@@ -953,7 +953,7 @@ VoicevoxResultCode voicevox_synthesizer_tts_from_kana(const struct VoicevoxSynth
  * @returns 結果コード
  *
  * \safety{
- * - `synthesizer`は ::voicevox_synthesizer_new_with_initialize で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
+ * - `synthesizer`は ::voicevox_synthesizer_new で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
  * - `text`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * - `output_wav_length`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * - `output_wav`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。

--- a/crates/voicevox_core_c_api/src/c_impls.rs
+++ b/crates/voicevox_core_c_api/src/c_impls.rs
@@ -5,20 +5,16 @@ use voicevox_core::{InitializeOptions, OpenJtalk, Result, Synthesizer, VoiceMode
 use crate::{CApiResult, OpenJtalkRc, VoicevoxSynthesizer, VoicevoxVoiceModel};
 
 impl OpenJtalkRc {
-    pub(crate) fn new_with_initialize(open_jtalk_dic_dir: impl AsRef<Path>) -> Result<Self> {
+    pub(crate) fn new(open_jtalk_dic_dir: impl AsRef<Path>) -> Result<Self> {
         Ok(Self {
-            open_jtalk: Arc::new(OpenJtalk::new_with_initialize(open_jtalk_dic_dir)?),
+            open_jtalk: Arc::new(OpenJtalk::new(open_jtalk_dic_dir)?),
         })
     }
 }
 
 impl VoicevoxSynthesizer {
-    pub(crate) async fn new_with_initialize(
-        open_jtalk: &OpenJtalkRc,
-        options: &InitializeOptions,
-    ) -> Result<Self> {
-        let synthesizer =
-            Synthesizer::new_with_initialize(open_jtalk.open_jtalk.clone(), options).await?;
+    pub(crate) async fn new(open_jtalk: &OpenJtalkRc, options: &InitializeOptions) -> Result<Self> {
+        let synthesizer = Synthesizer::new(open_jtalk.open_jtalk.clone(), options).await?;
         Ok(Self { synthesizer })
     }
 

--- a/crates/voicevox_core_c_api/src/compatible_engine.rs
+++ b/crates/voicevox_core_c_api/src/compatible_engine.rs
@@ -105,7 +105,7 @@ fn set_message(message: &str) {
 #[no_mangle]
 pub extern "C" fn initialize(use_gpu: bool, cpu_num_threads: c_int, load_all_models: bool) -> bool {
     let result = RUNTIME.block_on(async {
-        let synthesizer = voicevox_core::Synthesizer::new_with_initialize(
+        let synthesizer = voicevox_core::Synthesizer::new(
             Arc::new(OpenJtalk::new_without_dic()),
             &voicevox_core::InitializeOptions {
                 acceleration_mode: if use_gpu {

--- a/crates/voicevox_core_c_api/tests/e2e/snapshots.toml
+++ b/crates/voicevox_core_c_api/tests/e2e/snapshots.toml
@@ -81,7 +81,7 @@ stderr.windows = '''
 '''
 stderr.unix = ""
 
-[synthesizer_new_with_initialize_output_json]
+[synthesizer_new_output_json]
 metas = '''
 [
   {

--- a/crates/voicevox_core_c_api/tests/e2e/symbols.rs
+++ b/crates/voicevox_core_c_api/tests/e2e/symbols.rs
@@ -28,7 +28,7 @@ pub(crate) struct Symbols<'lib> {
         Symbol<'lib, unsafe extern "C" fn(*const VoicevoxVoiceModel) -> *const c_char>,
     pub(crate) voicevox_voice_model_delete:
         Symbol<'lib, unsafe extern "C" fn(*mut VoicevoxVoiceModel)>,
-    pub(crate) voicevox_synthesizer_new_with_initialize: Symbol<
+    pub(crate) voicevox_synthesizer_new: Symbol<
         'lib,
         unsafe extern "C" fn(
             *const OpenJtalkRc,
@@ -214,7 +214,7 @@ impl<'lib> Symbols<'lib> {
             voicevox_voice_model_id,
             voicevox_voice_model_get_metas_json,
             voicevox_voice_model_delete,
-            voicevox_synthesizer_new_with_initialize,
+            voicevox_synthesizer_new,
             voicevox_synthesizer_delete,
             voicevox_synthesizer_load_voice_model,
             voicevox_synthesizer_unload_voice_model,

--- a/crates/voicevox_core_c_api/tests/e2e/testcases.rs
+++ b/crates/voicevox_core_c_api/tests/e2e/testcases.rs
@@ -2,7 +2,7 @@ mod compatible_engine;
 mod compatible_engine_load_model_before_initialize;
 mod global_info;
 mod simple_tts;
-mod synthesizer_new_with_initialize_output_json;
+mod synthesizer_new_output_json;
 mod tts_via_audio_query;
 mod user_dict_load;
 mod user_dict_manipulate;

--- a/crates/voicevox_core_c_api/tests/e2e/testcases/simple_tts.rs
+++ b/crates/voicevox_core_c_api/tests/e2e/testcases/simple_tts.rs
@@ -31,7 +31,7 @@ impl assert_cdylib::TestCase for TestCase {
             voicevox_make_default_initialize_options,
             voicevox_voice_model_new_from_path,
             voicevox_voice_model_delete,
-            voicevox_synthesizer_new_with_initialize,
+            voicevox_synthesizer_new,
             voicevox_synthesizer_delete,
             voicevox_synthesizer_load_voice_model,
             voicevox_make_default_tts_options,
@@ -61,7 +61,7 @@ impl assert_cdylib::TestCase for TestCase {
 
         let synthesizer = {
             let mut synthesizer = MaybeUninit::uninit();
-            assert_ok(voicevox_synthesizer_new_with_initialize(
+            assert_ok(voicevox_synthesizer_new(
                 openjtalk,
                 VoicevoxInitializeOptions {
                     acceleration_mode: VoicevoxAccelerationMode::VOICEVOX_ACCELERATION_MODE_CPU,

--- a/crates/voicevox_core_c_api/tests/e2e/testcases/synthesizer_new_output_json.rs
+++ b/crates/voicevox_core_c_api/tests/e2e/testcases/synthesizer_new_output_json.rs
@@ -22,7 +22,7 @@ case!(TestCase);
 #[derive(Serialize, Deserialize)]
 struct TestCase;
 
-#[typetag::serde(name = "synthesizer_new_with_initialize_output_json")]
+#[typetag::serde(name = "synthesizer_new_output_json")]
 impl assert_cdylib::TestCase for TestCase {
     unsafe fn exec(&self, lib: &Library) -> anyhow::Result<()> {
         let Symbols {
@@ -30,7 +30,7 @@ impl assert_cdylib::TestCase for TestCase {
             voicevox_voice_model_new_from_path,
             voicevox_open_jtalk_rc_new,
             voicevox_open_jtalk_rc_delete,
-            voicevox_synthesizer_new_with_initialize,
+            voicevox_synthesizer_new,
             voicevox_synthesizer_delete,
             voicevox_synthesizer_create_metas_json,
             voicevox_synthesizer_load_voice_model,
@@ -50,7 +50,7 @@ impl assert_cdylib::TestCase for TestCase {
 
         let synthesizer = {
             let mut synthesizer = MaybeUninit::uninit();
-            assert_ok(voicevox_synthesizer_new_with_initialize(
+            assert_ok(voicevox_synthesizer_new(
                 openjtalk,
                 VoicevoxInitializeOptions {
                     acceleration_mode: VoicevoxAccelerationMode::VOICEVOX_ACCELERATION_MODE_CPU,
@@ -103,8 +103,7 @@ impl assert_cdylib::TestCase for TestCase {
     }
 }
 
-static SNAPSHOTS: Lazy<Snapshots> =
-    snapshots::section!(synthesizer_new_with_initialize_output_json);
+static SNAPSHOTS: Lazy<Snapshots> = snapshots::section!(synthesizer_new_output_json);
 
 #[derive(Deserialize)]
 struct Snapshots {

--- a/crates/voicevox_core_c_api/tests/e2e/testcases/tts_via_audio_query.rs
+++ b/crates/voicevox_core_c_api/tests/e2e/testcases/tts_via_audio_query.rs
@@ -31,7 +31,7 @@ impl assert_cdylib::TestCase for TestCase {
             voicevox_make_default_initialize_options,
             voicevox_voice_model_new_from_path,
             voicevox_voice_model_delete,
-            voicevox_synthesizer_new_with_initialize,
+            voicevox_synthesizer_new,
             voicevox_synthesizer_delete,
             voicevox_synthesizer_load_voice_model,
             voicevox_synthesizer_create_audio_query,
@@ -63,7 +63,7 @@ impl assert_cdylib::TestCase for TestCase {
 
         let synthesizer = {
             let mut synthesizer = MaybeUninit::uninit();
-            assert_ok(voicevox_synthesizer_new_with_initialize(
+            assert_ok(voicevox_synthesizer_new(
                 openjtalk,
                 VoicevoxInitializeOptions {
                     acceleration_mode: VoicevoxAccelerationMode::VOICEVOX_ACCELERATION_MODE_CPU,

--- a/crates/voicevox_core_c_api/tests/e2e/testcases/user_dict_load.rs
+++ b/crates/voicevox_core_c_api/tests/e2e/testcases/user_dict_load.rs
@@ -37,7 +37,7 @@ impl assert_cdylib::TestCase for TestCase {
             voicevox_open_jtalk_rc_delete,
             voicevox_voice_model_new_from_path,
             voicevox_voice_model_delete,
-            voicevox_synthesizer_new_with_initialize,
+            voicevox_synthesizer_new,
             voicevox_synthesizer_delete,
             voicevox_synthesizer_load_voice_model,
             voicevox_synthesizer_create_audio_query,
@@ -82,7 +82,7 @@ impl assert_cdylib::TestCase for TestCase {
 
         let synthesizer = {
             let mut synthesizer = MaybeUninit::uninit();
-            assert_ok(voicevox_synthesizer_new_with_initialize(
+            assert_ok(voicevox_synthesizer_new(
                 openjtalk,
                 VoicevoxInitializeOptions {
                     acceleration_mode: VoicevoxAccelerationMode::VOICEVOX_ACCELERATION_MODE_CPU,

--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/OpenJtalk.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/OpenJtalk.java
@@ -9,7 +9,7 @@ public class OpenJtalk extends Dll {
    * @param openJtalkDictDir 辞書のディレクトリ。
    */
   public OpenJtalk(String openJtalkDictDir) {
-    rsNewWithInitialize(openJtalkDictDir);
+    rsNew(openJtalkDictDir);
   }
 
   protected void finalize() throws Throwable {
@@ -28,9 +28,7 @@ public class OpenJtalk extends Dll {
     rsUseUserDict(userDict);
   }
 
-  private native void rsNewWithoutDic();
-
-  private native void rsNewWithInitialize(String openJtalkDictDir);
+  private native void rsNew(String openJtalkDictDir);
 
   private native void rsUseUserDict(UserDict userDict);
 

--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/Synthesizer.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/Synthesizer.java
@@ -17,7 +17,7 @@ public class Synthesizer extends Dll {
   private long handle;
 
   private Synthesizer(OpenJtalk openJtalk, Builder builder) {
-    rsNewWithInitialize(openJtalk, builder);
+    rsNew(openJtalk, builder);
   }
 
   protected void finalize() throws Throwable {
@@ -232,7 +232,7 @@ public class Synthesizer extends Dll {
     return new TtsConfigurator(this, text, styleId);
   }
 
-  private native void rsNewWithInitialize(OpenJtalk openJtalk, Builder builder);
+  private native void rsNew(OpenJtalk openJtalk, Builder builder);
 
   private native void rsLoadVoiceModel(VoiceModel voiceModel) throws InvalidModelDataException;
 

--- a/crates/voicevox_core_java_api/src/open_jtalk.rs
+++ b/crates/voicevox_core_java_api/src/open_jtalk.rs
@@ -8,21 +8,9 @@ use jni::{
     objects::{JObject, JString},
     JNIEnv,
 };
-#[no_mangle]
-unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_OpenJtalk_rsNewWithoutDic<'local>(
-    env: JNIEnv<'local>,
-    this: JObject<'local>,
-) {
-    throw_if_err(env, (), |env| {
-        let internal = voicevox_core::OpenJtalk::new_without_dic();
-
-        env.set_rust_field(&this, "handle", Arc::new(internal))?;
-        Ok(())
-    })
-}
 
 #[no_mangle]
-unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_OpenJtalk_rsNewWithInitialize<'local>(
+unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_OpenJtalk_rsNew<'local>(
     env: JNIEnv<'local>,
     this: JObject<'local>,
     open_jtalk_dict_dir: JString<'local>,
@@ -31,7 +19,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_OpenJtalk_rsNewWithInit
         let open_jtalk_dict_dir = env.get_string(&open_jtalk_dict_dir)?;
         let open_jtalk_dict_dir = &*Cow::from(&open_jtalk_dict_dir);
 
-        let internal = voicevox_core::OpenJtalk::new_with_initialize(open_jtalk_dict_dir)?;
+        let internal = voicevox_core::OpenJtalk::new(open_jtalk_dict_dir)?;
         env.set_rust_field(&this, "handle", Arc::new(internal))?;
 
         Ok(())

--- a/crates/voicevox_core_java_api/src/synthesizer.rs
+++ b/crates/voicevox_core_java_api/src/synthesizer.rs
@@ -11,7 +11,7 @@ use jni::{
 use std::sync::Arc;
 
 #[no_mangle]
-unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsNewWithInitialize<'local>(
+unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsNew<'local>(
     env: JNIEnv<'local>,
     this: JObject<'local>,
     open_jtalk: JObject<'local>,
@@ -48,7 +48,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsNewWithIn
         let open_jtalk = env
             .get_rust_field::<_, _, Arc<voicevox_core::OpenJtalk>>(&open_jtalk, "handle")?
             .clone();
-        let internal = RUNTIME.block_on(voicevox_core::Synthesizer::new_with_initialize(
+        let internal = RUNTIME.block_on(voicevox_core::Synthesizer::new(
             open_jtalk,
             Box::leak(Box::new(options)),
         ))?;

--- a/crates/voicevox_core_python_api/python/test/test_pseudo_raii_for_synthesizer.py
+++ b/crates/voicevox_core_python_api/python/test/test_pseudo_raii_for_synthesizer.py
@@ -37,7 +37,7 @@ def test_access_after_exit_denied(synthesizer: Synthesizer) -> None:
 
 @pytest_asyncio.fixture
 async def synthesizer(open_jtalk: OpenJtalk) -> Synthesizer:
-    return await Synthesizer.new_with_initialize(open_jtalk)
+    return await Synthesizer.new(open_jtalk)
 
 
 @pytest.fixture(scope="module")

--- a/crates/voicevox_core_python_api/python/test/test_user_dict_load.py
+++ b/crates/voicevox_core_python_api/python/test/test_user_dict_load.py
@@ -12,7 +12,7 @@ import voicevox_core  # noqa: F401
 async def test_user_dict_load() -> None:
     open_jtalk = voicevox_core.OpenJtalk(conftest.open_jtalk_dic_dir)
     model = await voicevox_core.VoiceModel.from_path(conftest.model_dir)
-    synthesizer = await voicevox_core.Synthesizer.new_with_initialize(
+    synthesizer = await voicevox_core.Synthesizer.new(
         open_jtalk=open_jtalk,
     )
 

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust.pyi
@@ -79,7 +79,7 @@ class Synthesizer:
     """音声シンセサイザ。"""
 
     @staticmethod
-    async def new_with_initialize(
+    async def new(
         open_jtalk: OpenJtalk,
         acceleration_mode: Union[
             AccelerationMode, Literal["AUTO", "CPU", "GPU"]

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -126,8 +126,7 @@ impl OpenJtalk {
     ) -> PyResult<Self> {
         Ok(Self {
             open_jtalk: Arc::new(
-                voicevox_core::OpenJtalk::new_with_initialize(open_jtalk_dict_dir)
-                    .into_py_result(py)?,
+                voicevox_core::OpenJtalk::new(open_jtalk_dict_dir).into_py_result(py)?,
             ),
         })
     }
@@ -146,20 +145,21 @@ struct Synthesizer {
 
 #[pymethods]
 impl Synthesizer {
+    #[allow(clippy::new_ret_no_self)]
     #[staticmethod]
     #[pyo3(signature =(
         open_jtalk,
         acceleration_mode = InitializeOptions::default().acceleration_mode,
         cpu_num_threads = InitializeOptions::default().cpu_num_threads,
     ))]
-    fn new_with_initialize(
+    fn new(
         py: Python,
         open_jtalk: OpenJtalk,
         #[pyo3(from_py_with = "from_acceleration_mode")] acceleration_mode: AccelerationMode,
         cpu_num_threads: u16,
     ) -> PyResult<&PyAny> {
         pyo3_asyncio::tokio::future_into_py(py, async move {
-            let synthesizer = voicevox_core::Synthesizer::new_with_initialize(
+            let synthesizer = voicevox_core::Synthesizer::new(
                 open_jtalk.open_jtalk.clone(),
                 &InitializeOptions {
                     acceleration_mode,

--- a/example/cpp/unix/simple_tts.cpp
+++ b/example/cpp/unix/simple_tts.cpp
@@ -27,7 +27,7 @@ int main(int argc, char *argv[]) {
     return 1;
   }
   VoicevoxSynthesizer* synthesizer;
-  result = voicevox_synthesizer_new_with_initialize(open_jtalk,initialize_options,&synthesizer);
+  result = voicevox_synthesizer_new(open_jtalk,initialize_options,&synthesizer);
   if (result != VOICEVOX_RESULT_OK) {
     std::cerr << voicevox_error_result_to_message(result) << std::endl;
     return 1;

--- a/example/cpp/windows/simple_tts/simple_tts.cpp
+++ b/example/cpp/windows/simple_tts/simple_tts.cpp
@@ -40,7 +40,7 @@ int main() {
     return 0;
   }
   VoicevoxSynthesizer* synthesizer;
-  result = voicevox_synthesizer_new_with_initialize(open_jtalk,initializeOptions,&synthesizer);
+  result = voicevox_synthesizer_new(open_jtalk,initializeOptions,&synthesizer);
   if (result != VoicevoxResultCode::VOICEVOX_RESULT_OK) {
     OutErrorMessage(result);
     return 0;

--- a/example/python/run.py
+++ b/example/python/run.py
@@ -36,7 +36,7 @@ async def main() -> None:
     logger.debug("%s", f"{voicevox_core.supported_devices()=}")
 
     logger.info("%s", f"Initializing ({acceleration_mode=}, {open_jtalk_dict_dir=})")
-    synthesizer = await Synthesizer.new_with_initialize(
+    synthesizer = await Synthesizer.new(
         OpenJtalk(open_jtalk_dict_dir), acceleration_mode=acceleration_mode
     )
 


### PR DESCRIPTION
## 内容

`Synthesizer::new_with_initialize`と`OpenJtalk::new_with_initialize`、およびそれに対応するFFIをすべてリネームします。

`Synthesizer`の方にはそもそも今は「initialize抜きのnew」が存在せず、`OpenJtalk`の方は`Option<OpenJtalk>`として運用すればよいです。
（このあたりの話はどこかでした気がするけど、見あたらない…）

## 関連 Issue

#545

## その他
