### PR TITLE
`Synthesizer::new`を非asyncにする

### DIFF
--- a/crates/voicevox_core/src/engine/synthesis_engine.rs
+++ b/crates/voicevox_core/src/engine/synthesis_engine.rs
@@ -652,7 +652,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn is_openjtalk_dict_loaded_works() {
-        let core = InferenceCore::new(false, 0).await.unwrap();
+        let core = InferenceCore::new(false, 0).unwrap();
         let synthesis_engine =
             SynthesisEngine::new(core, OpenJtalk::new(OPEN_JTALK_DIC_DIR).unwrap().into());
 
@@ -662,7 +662,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn create_accent_phrases_works() {
-        let core = InferenceCore::new(false, 0).await.unwrap();
+        let core = InferenceCore::new(false, 0).unwrap();
 
         let model = &VoiceModel::sample().await.unwrap();
         core.load_model(model).await.unwrap();

--- a/crates/voicevox_core/src/inference_core.rs
+++ b/crates/voicevox_core/src/inference_core.rs
@@ -9,7 +9,7 @@ pub struct InferenceCore {
 }
 
 impl InferenceCore {
-    pub(crate) async fn new(use_gpu: bool, cpu_num_threads: u16) -> Result<Self> {
+    pub(crate) fn new(use_gpu: bool, cpu_num_threads: u16) -> Result<Self> {
         if !use_gpu || Self::can_support_gpu_feature()? {
             let status = Status::new(use_gpu, cpu_num_threads);
             Ok(Self { status })

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -80,8 +80,7 @@ impl Synthesizer {
     ///
     #[cfg_attr(windows, doc = "```no_run")] // https://github.com/VOICEVOX/voicevox_core/issues/537
     #[cfg_attr(not(windows), doc = "```")]
-    /// # #[tokio::main]
-    /// # async fn main() -> anyhow::Result<()> {
+    /// # fn main() -> anyhow::Result<()> {
     /// # use test_util::OPEN_JTALK_DIC_DIR;
     /// #
     /// # const ACCELERATION_MODE: AccelerationMode = AccelerationMode::Cpu;
@@ -96,13 +95,12 @@ impl Synthesizer {
     ///         acceleration_mode: ACCELERATION_MODE,
     ///         ..Default::default()
     ///     },
-    /// )
-    /// .await?;
+    /// )?;
     /// #
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn new(open_jtalk: Arc<OpenJtalk>, options: &InitializeOptions) -> Result<Self> {
+    pub fn new(open_jtalk: Arc<OpenJtalk>, options: &InitializeOptions) -> Result<Self> {
         #[cfg(windows)]
         list_windows_video_cards();
         let use_gpu = match options.acceleration_mode {
@@ -124,7 +122,7 @@ impl Synthesizer {
 
         Ok(Self {
             synthesis_engine: SynthesisEngine::new(
-                InferenceCore::new(use_gpu, options.cpu_num_threads).await?,
+                InferenceCore::new(use_gpu, options.cpu_num_threads)?,
                 open_jtalk,
             ),
             use_gpu,
@@ -259,8 +257,7 @@ impl Synthesizer {
     /// #             acceleration_mode: AccelerationMode::Cpu,
     /// #             ..Default::default()
     /// #         },
-    /// #     )
-    /// #     .await?;
+    /// #     )?;
     /// #
     /// #     let model = &VoiceModel::from_path(concat!(
     /// #         env!("CARGO_MANIFEST_DIR"),
@@ -313,8 +310,7 @@ impl Synthesizer {
     /// #             acceleration_mode: AccelerationMode::Cpu,
     /// #             ..Default::default()
     /// #         },
-    /// #     )
-    /// #     .await?;
+    /// #     )?;
     /// #
     /// #     let model = &VoiceModel::from_path(concat!(
     /// #         env!("CARGO_MANIFEST_DIR"),
@@ -403,8 +399,7 @@ impl Synthesizer {
     /// #             acceleration_mode: AccelerationMode::Cpu,
     /// #             ..Default::default()
     /// #         },
-    /// #     )
-    /// #     .await?;
+    /// #     )?;
     /// #
     /// #     let model = &VoiceModel::from_path(concat!(
     /// #         env!("CARGO_MANIFEST_DIR"),
@@ -458,8 +453,7 @@ impl Synthesizer {
     /// #             acceleration_mode: AccelerationMode::Cpu,
     /// #             ..Default::default()
     /// #         },
-    /// #     )
-    /// #     .await?;
+    /// #     )?;
     /// #
     /// #     let model = &VoiceModel::from_path(concat!(
     /// #         env!("CARGO_MANIFEST_DIR"),
@@ -586,7 +580,6 @@ mod tests {
                 ..Default::default()
             },
         )
-        .await
         .unwrap();
 
         let result = syntesizer
@@ -610,7 +603,6 @@ mod tests {
                 ..Default::default()
             },
         )
-        .await
         .unwrap();
         assert!(!syntesizer.is_gpu_mode());
     }
@@ -627,7 +619,6 @@ mod tests {
                 ..Default::default()
             },
         )
-        .await
         .unwrap();
         assert!(
             !syntesizer.is_loaded_model_by_style_id(style_id),
@@ -656,7 +647,6 @@ mod tests {
                 ..Default::default()
             },
         )
-        .await
         .unwrap();
 
         syntesizer
@@ -688,7 +678,6 @@ mod tests {
                 ..Default::default()
             },
         )
-        .await
         .unwrap();
         syntesizer
             .load_voice_model(&open_default_vvm_file().await)
@@ -730,7 +719,6 @@ mod tests {
                 ..Default::default()
             },
         )
-        .await
         .unwrap();
         syntesizer
             .load_voice_model(&open_default_vvm_file().await)
@@ -823,7 +811,6 @@ mod tests {
                 ..Default::default()
             },
         )
-        .await
         .unwrap();
 
         let model = &VoiceModel::sample().await.unwrap();
@@ -892,7 +879,6 @@ mod tests {
                 ..Default::default()
             },
         )
-        .await
         .unwrap();
 
         let model = &VoiceModel::sample().await.unwrap();
@@ -958,7 +944,6 @@ mod tests {
                 ..Default::default()
             },
         )
-        .await
         .unwrap();
 
         let model = &VoiceModel::sample().await.unwrap();
@@ -995,7 +980,6 @@ mod tests {
                 ..Default::default()
             },
         )
-        .await
         .unwrap();
 
         let model = &VoiceModel::sample().await.unwrap();
@@ -1028,7 +1012,6 @@ mod tests {
                 ..Default::default()
             },
         )
-        .await
         .unwrap();
 
         let model = &VoiceModel::sample().await.unwrap();

--- a/crates/voicevox_core_c_api/src/c_impls.rs
+++ b/crates/voicevox_core_c_api/src/c_impls.rs
@@ -14,6 +14,10 @@ impl OpenJtalkRc {
 
 impl VoicevoxSynthesizer {
     pub(crate) fn new(open_jtalk: &OpenJtalkRc, options: &InitializeOptions) -> Result<Self> {
+        // ロガーを起動
+        // FIXME: `into_result_code_with_error`を`run`とかに改名し、`init_logger`をその中に移動
+        let _ = *crate::RUNTIME;
+
         let synthesizer = Synthesizer::new(open_jtalk.open_jtalk.clone(), options)?;
         Ok(Self { synthesizer })
     }

--- a/crates/voicevox_core_c_api/src/c_impls.rs
+++ b/crates/voicevox_core_c_api/src/c_impls.rs
@@ -13,8 +13,8 @@ impl OpenJtalkRc {
 }
 
 impl VoicevoxSynthesizer {
-    pub(crate) async fn new(open_jtalk: &OpenJtalkRc, options: &InitializeOptions) -> Result<Self> {
-        let synthesizer = Synthesizer::new(open_jtalk.open_jtalk.clone(), options).await?;
+    pub(crate) fn new(open_jtalk: &OpenJtalkRc, options: &InitializeOptions) -> Result<Self> {
+        let synthesizer = Synthesizer::new(open_jtalk.open_jtalk.clone(), options)?;
         Ok(Self { synthesizer })
     }
 

--- a/crates/voicevox_core_c_api/src/compatible_engine.rs
+++ b/crates/voicevox_core_c_api/src/compatible_engine.rs
@@ -115,8 +115,7 @@ pub extern "C" fn initialize(use_gpu: bool, cpu_num_threads: c_int, load_all_mod
                 },
                 cpu_num_threads: cpu_num_threads as u16,
             },
-        )
-        .await?;
+        )?;
 
         if load_all_models {
             for model in &voice_model_set().all_vvms {

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -343,9 +343,7 @@ pub unsafe extern "C" fn voicevox_synthesizer_new(
     into_result_code_with_error((|| {
         let options = options.into();
 
-        let synthesizer = RUNTIME
-            .block_on(VoicevoxSynthesizer::new(open_jtalk, &options))?
-            .into();
+        let synthesizer = VoicevoxSynthesizer::new(open_jtalk, &options)?.into();
         out_synthesizer.as_ptr().write_unaligned(synthesizer);
         Ok(())
     })())

--- a/crates/voicevox_core_java_api/src/synthesizer.rs
+++ b/crates/voicevox_core_java_api/src/synthesizer.rs
@@ -48,10 +48,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsNew<'loca
         let open_jtalk = env
             .get_rust_field::<_, _, Arc<voicevox_core::OpenJtalk>>(&open_jtalk, "handle")?
             .clone();
-        let internal = RUNTIME.block_on(voicevox_core::Synthesizer::new(
-            open_jtalk,
-            Box::leak(Box::new(options)),
-        ))?;
+        let internal = voicevox_core::Synthesizer::new(open_jtalk, Box::leak(Box::new(options)))?;
         env.set_rust_field(&this, "handle", Arc::new(internal))?;
         Ok(())
     })

--- a/crates/voicevox_core_java_api/src/synthesizer.rs
+++ b/crates/voicevox_core_java_api/src/synthesizer.rs
@@ -18,6 +18,10 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsNew<'loca
     builder: JObject<'local>,
 ) {
     throw_if_err(env, (), |env| {
+        // ロガーを起動
+        // FIXME: `throw_if_err`を`run`とかに改名し、`init_logger`をその中に移動
+        let _ = *RUNTIME;
+
         let mut options = voicevox_core::InitializeOptions::default();
 
         let acceleration_mode = env

--- a/crates/voicevox_core_python_api/python/test/test_pseudo_raii_for_synthesizer.py
+++ b/crates/voicevox_core_python_api/python/test/test_pseudo_raii_for_synthesizer.py
@@ -37,7 +37,7 @@ def test_access_after_exit_denied(synthesizer: Synthesizer) -> None:
 
 @pytest_asyncio.fixture
 async def synthesizer(open_jtalk: OpenJtalk) -> Synthesizer:
-    return await Synthesizer.new(open_jtalk)
+    return Synthesizer(open_jtalk)
 
 
 @pytest.fixture(scope="module")

--- a/crates/voicevox_core_python_api/python/test/test_user_dict_load.py
+++ b/crates/voicevox_core_python_api/python/test/test_user_dict_load.py
@@ -12,9 +12,7 @@ import voicevox_core  # noqa: F401
 async def test_user_dict_load() -> None:
     open_jtalk = voicevox_core.OpenJtalk(conftest.open_jtalk_dic_dir)
     model = await voicevox_core.VoiceModel.from_path(conftest.model_dir)
-    synthesizer = await voicevox_core.Synthesizer.new(
-        open_jtalk=open_jtalk,
-    )
+    synthesizer = voicevox_core.Synthesizer(open_jtalk)
 
     await synthesizer.load_voice_model(model)
 

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust.pyi
@@ -76,29 +76,27 @@ class OpenJtalk:
         ...
 
 class Synthesizer:
-    """音声シンセサイザ。"""
+    """
+    音声シンセサイザ。
 
-    @staticmethod
-    async def new(
+    Parameters
+    ----------
+    open_jtalk
+        Open JTalk。
+    acceleration_mode
+        ハードウェアアクセラレーションモード。
+    cpu_num_threads
+        CPU利用数を指定。0を指定すると環境に合わせたCPUが利用される。
+    """
+
+    def __init__(
+        self,
         open_jtalk: OpenJtalk,
         acceleration_mode: Union[
             AccelerationMode, Literal["AUTO", "CPU", "GPU"]
         ] = AccelerationMode.AUTO,
         cpu_num_threads: int = 0,
-    ) -> "Synthesizer":
-        """
-        :class:`Synthesizer` を生成する。
-
-        Parameters
-        ----------
-        open_jtalk
-            Open JTalk。
-        acceleration_mode
-            ハードウェアアクセラレーションモード。
-        cpu_num_threads
-            CPU利用数を指定。0を指定すると環境に合わせたCPUが利用される。
-        """
-        ...
+    ) -> None: ...
     def __repr__(self) -> str: ...
     def __enter__(self) -> "Synthesizer": ...
     def __exit__(self, exc_type, exc_value, traceback) -> None: ...

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -145,32 +145,27 @@ struct Synthesizer {
 
 #[pymethods]
 impl Synthesizer {
-    #[allow(clippy::new_ret_no_self)]
-    #[staticmethod]
+    #[new]
     #[pyo3(signature =(
         open_jtalk,
         acceleration_mode = InitializeOptions::default().acceleration_mode,
         cpu_num_threads = InitializeOptions::default().cpu_num_threads,
     ))]
     fn new(
-        py: Python,
         open_jtalk: OpenJtalk,
         #[pyo3(from_py_with = "from_acceleration_mode")] acceleration_mode: AccelerationMode,
         cpu_num_threads: u16,
-    ) -> PyResult<&PyAny> {
-        pyo3_asyncio::tokio::future_into_py(py, async move {
-            let synthesizer = voicevox_core::Synthesizer::new(
-                open_jtalk.open_jtalk.clone(),
-                &InitializeOptions {
-                    acceleration_mode,
-                    cpu_num_threads,
-                },
-            )
-            .await;
-            let synthesizer = Python::with_gil(|py| synthesizer.into_py_result(py))?.into();
-            let synthesizer = Closable::new(synthesizer);
-            Ok(Self { synthesizer })
-        })
+    ) -> PyResult<Self> {
+        let synthesizer = voicevox_core::Synthesizer::new(
+            open_jtalk.open_jtalk.clone(),
+            &InitializeOptions {
+                acceleration_mode,
+                cpu_num_threads,
+            },
+        );
+        let synthesizer = Python::with_gil(|py| synthesizer.into_py_result(py))?.into();
+        let synthesizer = Closable::new(synthesizer);
+        Ok(Self { synthesizer })
     }
 
     fn __repr__(&self) -> &'static str {

--- a/example/python/run.py
+++ b/example/python/run.py
@@ -36,7 +36,7 @@ async def main() -> None:
     logger.debug("%s", f"{voicevox_core.supported_devices()=}")
 
     logger.info("%s", f"Initializing ({acceleration_mode=}, {open_jtalk_dict_dir=})")
-    synthesizer = await Synthesizer.new(
+    synthesizer = Synthesizer(
         OpenJtalk(open_jtalk_dict_dir), acceleration_mode=acceleration_mode
     )
 


### PR DESCRIPTION
## 内容

`Synthesizer::new`にはもともと`load_all_models`というオプションがありましたが、今は #587 により無くなっています。なので今は`Synthesizer::new`は何のIOも重たい処理もせずに、数十μsで完了します (ちなみに数十μsの大部分は`SupportedDevices`を毎回作りなおしているところかと思われます)。

なのでもうasyncは不要でもあり、適切でもなくなっているかと思いました。

## 関連 Issue

#545

## その他
