### PR TITLE
Python APIに`NewType`を導入

### DIFF
--- a/crates/voicevox_core_python_api/python/voicevox_core/__init__.py
+++ b/crates/voicevox_core_python_api/python/voicevox_core/__init__.py
@@ -7,9 +7,12 @@ from ._models import (  # noqa: F401
     AudioQuery,
     Mora,
     SpeakerMeta,
+    StyleId,
+    StyleVersion,
     SupportedDevices,
     UserDictWord,
     UserDictWordType,
+    VoiceModelId,
 )
 from ._rust import (  # noqa: F401
     ExtractFullContextLabelError,
@@ -61,7 +64,9 @@ __all__ = [
     "SaveUserDictError",
     "SpeakerMeta",
     "StyleAlreadyLoadedError",
+    "StyleId",
     "StyleNotFoundError",
+    "StyleVersion",
     "SupportedDevices",
     "Synthesizer",
     "VoiceModel",
@@ -70,5 +75,6 @@ __all__ = [
     "UserDict",
     "UserDictWord",
     "UserDictWordType",
+    "VoiceModelId",
     "WordNotFoundError",
 ]

--- a/crates/voicevox_core_python_api/python/voicevox_core/_models.py
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_models.py
@@ -1,10 +1,37 @@
 import dataclasses
 from enum import Enum
-from typing import List, Optional
+from typing import List, NewType, Optional
 
 import pydantic
 
 from ._rust import _to_zenkaku, _validate_pronunciation
+
+StyleId = NewType("StyleId", int)
+"""
+スタイルID。
+
+Parameters
+----------
+x : int
+"""
+
+StyleVersion = NewType("StyleVersion", str)
+"""
+スタイルのバージョン。
+
+Parameters
+----------
+x : str
+"""
+
+VoiceModelId = NewType("VoiceModelId", str)
+"""
+音声モデルID。
+
+Parameters
+----------
+x : str
+"""
 
 
 @pydantic.dataclasses.dataclass
@@ -14,7 +41,7 @@ class StyleMeta:
     name: str
     """スタイル名。"""
 
-    id: int
+    id: StyleId
     """スタイルID。"""
 
 
@@ -31,7 +58,7 @@ class SpeakerMeta:
     speaker_uuid: str
     """話者のバージョン。"""
 
-    version: str
+    version: StyleVersion
     """話者のUUID。"""
 
 

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust.pyi
@@ -8,9 +8,11 @@ if TYPE_CHECKING:
         AccentPhrase,
         AudioQuery,
         SpeakerMeta,
+        StyleId,
         SupportedDevices,
         UserDict,
         UserDictWord,
+        VoiceModelId,
     )
 
 __version__: str
@@ -43,7 +45,7 @@ class VoiceModel:
         """
         ...
     @property
-    def id(self) -> str:
+    def id(self) -> VoiceModelId:
         """ID。"""
         ...
     @property
@@ -118,7 +120,7 @@ class Synthesizer:
             読み込むモデルのスタイルID。
         """
         ...
-    def unload_voice_model(self, voice_model_id: str) -> None:
+    def unload_voice_model(self, voice_model_id: Union[VoiceModelId, str]) -> None:
         """
         音声モデルの読み込みを解除する。
 
@@ -128,7 +130,7 @@ class Synthesizer:
             音声モデルID。
         """
         ...
-    def is_loaded_voice_model(self, voice_model_id: str) -> bool:
+    def is_loaded_voice_model(self, voice_model_id: Union[VoiceModelId, str]) -> bool:
         """
         指定したvoice_model_idのモデルが読み込まれているか判定する。
 
@@ -145,7 +147,7 @@ class Synthesizer:
     async def audio_query_from_kana(
         self,
         kana: str,
-        style_id: int,
+        style_id: Union[StyleId, int],
     ) -> AudioQuery:
         """
         AquesTalk風記法から :class:`AudioQuery` を生成する。
@@ -165,7 +167,7 @@ class Synthesizer:
     async def audio_query(
         self,
         text: str,
-        style_id: int,
+        style_id: Union[StyleId, int],
     ) -> AudioQuery:
         """
         日本語のテキストから :class:`AudioQuery` を生成する。
@@ -185,7 +187,7 @@ class Synthesizer:
     async def create_accent_phrases_from_kana(
         self,
         kana: str,
-        style_id: int,
+        style_id: Union[StyleId, int],
     ) -> List[AccentPhrase]:
         """
         AquesTalk風記法からAccentPhrase（アクセント句）の配列を生成する。
@@ -205,7 +207,7 @@ class Synthesizer:
     async def create_accent_phrases(
         self,
         text: str,
-        style_id: int,
+        style_id: Union[StyleId, int],
     ) -> List[AccentPhrase]:
         """
         日本語のテキストからAccentPhrase（アクセント句）の配列を生成する。
@@ -225,7 +227,7 @@ class Synthesizer:
     async def replace_mora_data(
         self,
         accent_phrases: List[AccentPhrase],
-        style_id: int,
+        style_id: Union[StyleId, int],
     ) -> List[AccentPhrase]:
         """
         アクセント句の音高・音素長を変更した新しいアクセント句の配列を生成する。
@@ -247,7 +249,7 @@ class Synthesizer:
     async def replace_phoneme_length(
         self,
         accent_phrases: List[AccentPhrase],
-        style_id: int,
+        style_id: Union[StyleId, int],
     ) -> List[AccentPhrase]:
         """
         アクセント句の音素長を変更した新しいアクセント句の配列を生成する。
@@ -265,7 +267,7 @@ class Synthesizer:
     async def replace_mora_pitch(
         self,
         accent_phrases: List[AccentPhrase],
-        style_id: int,
+        style_id: Union[StyleId, int],
     ) -> List[AccentPhrase]:
         """
         アクセント句の音高を変更した新しいアクセント句の配列を生成する。
@@ -283,7 +285,7 @@ class Synthesizer:
     async def synthesis(
         self,
         audio_query: AudioQuery,
-        style_id: int,
+        style_id: Union[StyleId, int],
         enable_interrogative_upspeak: bool = True,
     ) -> bytes:
         """
@@ -306,7 +308,7 @@ class Synthesizer:
     async def tts_from_kana(
         self,
         kana: str,
-        style_id: int,
+        style_id: Union[StyleId, int],
         enable_interrogative_upspeak: bool = True,
     ) -> bytes:
         """
@@ -325,7 +327,7 @@ class Synthesizer:
     async def tts(
         self,
         text: str,
-        style_id: int,
+        style_id: Union[StyleId, int],
         enable_interrogative_upspeak: bool = True,
     ) -> bytes:
         """


### PR DESCRIPTION
## 内容

Python APIに以下の`NewType`を追加します。

```python
StyleId = NewType("StyleId", int)
StyleVersion = NewType("StyleVersion", str)
VoiceModelId = NewType("VoiceModelId", str)
```

`Synthesizer`のメソッドの引数では`style_id: StyleId | int`のようにし、`int`も型チェックが通るようにします。

## 関連 Issue

#545

## その他

Javaには手を付けていません。
(GSONがこの手のものを扱えるか未検証)