### PR TITLE
Cargoの`lints`設定を利用する

### DIFF
--- a/crates/downloader/Cargo.toml
+++ b/crates/downloader/Cargo.toml
@@ -32,3 +32,7 @@ zip = "0.6.3"
 
 [dev-dependencies]
 rstest.workspace = true
+
+[lints.rust]
+unsafe_code = "forbid"
+rust_2018_idioms = "warn"

--- a/crates/test_util/Cargo.toml
+++ b/crates/test_util/Cargo.toml
@@ -20,3 +20,7 @@ serde.workspace = true
 serde_json.workspace = true
 surf = "2.3.2"
 tar = "0.4.38"
+
+[lints.rust]
+unsafe_code = "forbid"
+rust_2018_idioms = "warn"

--- a/crates/voicevox_core/Cargo.toml
+++ b/crates/voicevox_core/Cargo.toml
@@ -53,3 +53,7 @@ test_util.workspace = true
 [target."cfg(windows)".dependencies]
 humansize = "2.1.2"
 windows = { version = "0.43.0", features = ["Win32_Foundation", "Win32_Graphics_Dxgi"] }
+
+[lints.rust]
+unsafe_code = "deny" # FIXME: あまり意味が無くなっているため潔く`allow`にする。あるいはunsafeを撲滅する
+rust_2018_idioms = "warn"

--- a/crates/voicevox_core/src/lib.rs
+++ b/crates/voicevox_core/src/lib.rs
@@ -1,7 +1,5 @@
 //! 無料で使える中品質なテキスト読み上げソフトウェア、VOICEVOXのコア。
 
-#![deny(unsafe_code)]
-
 mod devices;
 /// cbindgen:ignore
 mod engine;

--- a/crates/voicevox_core_c_api/Cargo.toml
+++ b/crates/voicevox_core_c_api/Cargo.toml
@@ -62,3 +62,7 @@ tempfile.workspace = true
 test_util.workspace = true
 toml = "0.7.2"
 typetag = "0.2.5"
+
+[lints.rust]
+unsafe_code = "allow" # C APIのための操作
+rust_2018_idioms = "warn"

--- a/crates/voicevox_core_java_api/Cargo.toml
+++ b/crates/voicevox_core_java_api/Cargo.toml
@@ -21,3 +21,7 @@ tokio.workspace = true
 tracing-subscriber.workspace = true
 uuid.workspace = true
 voicevox_core.workspace = true
+
+[lints.rust]
+unsafe_code = "allow" # jni-rsが要求
+rust_2018_idioms = "warn"

--- a/crates/voicevox_core_java_api/src/common.rs
+++ b/crates/voicevox_core_java_api/src/common.rs
@@ -86,9 +86,9 @@ macro_rules! enum_object {
     };
 }
 
-pub fn throw_if_err<T, F>(mut env: JNIEnv, fallback: T, inner: F) -> T
+pub fn throw_if_err<T, F>(mut env: JNIEnv<'_>, fallback: T, inner: F) -> T
 where
-    F: FnOnce(&mut JNIEnv) -> Result<T, JavaApiError>,
+    F: FnOnce(&mut JNIEnv<'_>) -> Result<T, JavaApiError>,
 {
     match inner(&mut env) {
         Ok(value) => value as _,

--- a/crates/voicevox_core_macros/Cargo.toml
+++ b/crates/voicevox_core_macros/Cargo.toml
@@ -13,3 +13,7 @@ indexmap.workspace = true
 proc-macro2 = "1.0.69"
 quote = "1.0.33"
 syn = { version = "2.0.38", features = ["extra-traits"] }
+
+[lints.rust]
+unsafe_code = "forbid"
+rust_2018_idioms = "warn"

--- a/crates/voicevox_core_python_api/Cargo.toml
+++ b/crates/voicevox_core_python_api/Cargo.toml
@@ -20,3 +20,7 @@ serde.workspace = true
 serde_json.workspace = true
 uuid.workspace = true
 voicevox_core.workspace = true
+
+[lints.rust]
+unsafe_code = "forbid"
+rust_2018_idioms = "warn"

--- a/crates/voicevox_core_python_api/src/convert.rs
+++ b/crates/voicevox_core_python_api/src/convert.rs
@@ -119,7 +119,7 @@ pub fn to_rust_uuid(ob: &PyAny) -> PyResult<Uuid> {
     let uuid = ob.getattr("hex")?.extract::<String>()?;
     uuid.parse::<Uuid>().into_py_value_result()
 }
-pub fn to_py_uuid(py: Python, uuid: Uuid) -> PyResult<PyObject> {
+pub fn to_py_uuid(py: Python<'_>, uuid: Uuid) -> PyResult<PyObject> {
     let uuid = uuid.hyphenated().to_string();
     let uuid = py.import("uuid")?.call_method1("UUID", (uuid,))?;
     Ok(uuid.to_object(py))

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -77,7 +77,7 @@ struct VoiceModel {
 }
 
 #[pyfunction]
-fn supported_devices(py: Python) -> PyResult<&PyAny> {
+fn supported_devices(py: Python<'_>) -> PyResult<&PyAny> {
     let class = py
         .import("voicevox_core")?
         .getattr("SupportedDevices")?
@@ -547,7 +547,7 @@ impl UserDict {
     fn add_word(
         &mut self,
         #[pyo3(from_py_with = "to_rust_user_dict_word")] word: UserDictWord,
-        py: Python,
+        py: Python<'_>,
     ) -> PyResult<PyObject> {
         let uuid = self.dict.add_word(word).into_py_result(py)?;
 

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -10,3 +10,7 @@ clap.workspace = true
 color-eyre = "0.6.2"
 eyre = "0.6.8"
 fs-err.workspace = true
+
+[lints.rust]
+unsafe_code = "forbid"
+rust_2018_idioms = "warn"


### PR DESCRIPTION
## 内容

Rust 1.74で追加された[Cargoの`lints`設定](https://blog.rust-lang.org/2023/11/16/Rust-1.74.0.html#lint-configuration-through-cargo)を利用します。

ついでに[`rust-2018-idioms`](https://doc.rust-lang.org/rustc/lints/groups.html)も有効化します。

## 関連 Issue

#681

## その他
