### PR TITLE
クレートのversionはworkspace設定に、featureはpackage設定に

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,11 +599,8 @@ checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "time 0.1.45",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -3873,17 +3870,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
@@ -4399,6 +4385,7 @@ dependencies = [
  "once_cell",
  "serde_json",
  "tokio",
+ "tracing",
  "tracing-subscriber",
  "uuid",
  "voicevox_core",
@@ -4425,6 +4412,7 @@ dependencies = [
  "pyo3-log",
  "serde",
  "serde_json",
+ "tracing",
  "uuid",
  "voicevox_core",
 ]
@@ -4469,12 +4457,6 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,31 +3,96 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.dependencies]
+android_logger = "0.13.1"
+anstream = { version = "0.5.0", default-features = false }
+anstyle-query = "1.0.0"
 anyhow = "1.0.65"
-async_zip = { version = "0.0.11", features = ["full"] }
-clap = { version = "4.0.10", features = ["derive"] }
+assert_cmd = "2.0.8"
+async-std = "1.12.0"
+async_zip = "0.0.11"
+binstall-tar = "0.4.39"
+bytes = "1.1.0"
+cbindgen = "0.24.3"
+cfg-if = "1.0.0"
+chrono = { version = "0.4.26", default-features = false }
+clap = "4.0.10"
+color-eyre = "0.6.2"
+colorchoice = "1.0.0"
+cstr = "0.2.11"
+derive-getters = "0.2.0"
+derive-new = "0.5.9"
 derive_more = "0.99.17"
+duct = "0.13.6"
+duplicate = "1.0.0"
 easy-ext = "1.0.1"
-fs-err = { version = "2.9.0", features = ["tokio"] }
+educe = "0.4.23"
+enum-map = "3.0.0-beta.1"
+eyre = "0.6.8"
+flate2 = "1.0.25"
+fs-err = "2.9.0"
 futures = "0.3.26"
-indexmap = { version = "2.0.0", features = ["serde"] }
+futures-core = "0.3.25"
+futures-util = "0.3.25"
+heck = "0.4.0"
+humansize = "2.1.2"
+indexmap = "2.0.0"
+indicatif = "0.17.3"
+inventory = "0.3.4"
 itertools = "0.10.5"
+jni = "0.21.1"
+libc = "0.2.134"
+libloading = "0.7.3"
+libtest-mimic = "0.6.0"
+log = "0.4.17"
+nanoid = "0.4.0"
 ndarray = "0.15.6"
+ndarray-stats = "0.5.1"
+octocrab = { version = "0.19.0", default-features = false }
 once_cell = "1.18.0"
+parse-display = "0.8.2"
+pretty_assertions = "1.3.0"
+proc-macro2 = "1.0.69"
+pyo3 = "0.19.2"
+pyo3-asyncio = "0.19.0"
+pyo3-log = "0.9.0"
+quote = "1.0.33"
+rayon = "1.6.1"
 regex = "1.10.0"
+reqwest = { version = "0.11.13", default-features = false }
 rstest = "0.15.0"
-serde = { version = "1.0.145", features = ["derive"] }
-serde_json = { version = "1.0.85", features = ["preserve_order"] }
-strum = { version = "0.24.1", features = ["derive"] }
+serde = "1.0.145"
+serde_json = "1.0.85"
+serde_with = "3.3.0"
+strum = "0.24.1"
+surf = "2.3.2"
+syn = "2.0.38"
+tar = "0.4.38"
 tempfile = "3.6.0"
 test_util = { path = "crates/test_util" }
 thiserror = "1.0.37"
-tracing = { version = "0.1.37", features = ["log"] }
-tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
-uuid = { version = "1.4.0", features = ["v4", "serde"] }
+tokio = "1.25.0"
+toml = "0.7.2"
+tracing = "0.1.37"
+tracing-subscriber = "0.3.16"
+typetag = "0.2.5"
+url = "2.3.0"
+uuid = "1.4.0"
 voicevox_core = { path = "crates/voicevox_core" }
-tokio = { version = "1.25.0", features = ["rt", "rt-multi-thread", "macros", "sync"] }
-derive-getters = "0.2.0"
+windows = "0.43.0"
+zip = "0.6.3"
+
+[workspace.dependencies.onnxruntime]
+git = "https://github.com/VOICEVOX/onnxruntime-rs.git"
+rev = "ebb9dcb9b26ee681889b52b6db3b4f642b04a250"
+
+[workspace.dependencies.open_jtalk]
+git = "https://github.com/VOICEVOX/open_jtalk-rs.git"
+rev = "a16714ce16dec76fd0e3041a7acfa484921db3b5"
+
+# FIXME: iOS対応のpull request(https://github.com/wesleywiser/process_path/pull/16)がマージされる見込みが無いため
+[workspace.dependencies.process_path]
+git = "https://github.com/VOICEVOX/process_path.git"
+rev = "de226a26e8e18edbdb1d6f986afe37bbbf35fbf4"
 
 [workspace.package]
 version = "0.0.0"

--- a/crates/downloader/Cargo.toml
+++ b/crates/downloader/Cargo.toml
@@ -10,25 +10,25 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow.workspace = true
-binstall-tar = "0.4.39"
-bytes = "1.1.0"
-clap.workspace = true
-flate2 = "1.0.25"
-fs-err.workspace = true
-futures-core = "0.3.25"
-futures-util = "0.3.25"
-indicatif = "0.17.3"
-octocrab = { version = "0.19.0", default-features = false, features = ["rustls-tls", "stream"] }
+binstall-tar.workspace = true
+bytes.workspace = true
+clap = { workspace = true, features = ["derive"] }
+flate2.workspace = true
+fs-err = { workspace = true, features = ["tokio"] }
+futures-core.workspace = true
+futures-util.workspace = true
+indicatif.workspace = true
+octocrab = { workspace = true, default-features = false, features = ["rustls-tls", "stream"] }
 once_cell.workspace = true
-parse-display = "0.8.2"
-rayon = "1.6.1"
-reqwest = { version = "0.11.13", default-features = false, features = ["rustls-tls", "stream"] }
-strum.workspace = true
-tokio.workspace = true
+parse-display.workspace = true
+rayon.workspace = true
+reqwest = { workspace = true, default-features = false, features = ["rustls-tls", "stream"] }
+strum = { workspace = true, features = ["derive"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "sync"] }
 tracing.workspace = true
-tracing-subscriber.workspace = true
-url = "2.3.0"
-zip = "0.6.3"
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+url.workspace = true
+zip.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true

--- a/crates/test_util/Cargo.toml
+++ b/crates/test_util/Cargo.toml
@@ -5,21 +5,21 @@ edition.workspace = true
 publish.workspace = true
 
 [dependencies]
-async_zip.workspace = true
+async_zip = { workspace = true, features = ["full"] }
 once_cell.workspace = true
-serde.workspace = true
+serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["fs", "io-util", "sync"] }
 
 [build-dependencies]
 anyhow.workspace = true
-async-std = { version = "1.12.0", features = ["attributes"] }
+async-std = { workspace = true, features = ["attributes"] }
+flate2.workspace = true
 fs-err.workspace = true
-flate2 = "1.0.24"
-serde.workspace = true
-serde_json.workspace = true
-surf = "2.3.2"
-tar = "0.4.38"
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["preserve_order"] }
+surf.workspace = true
+tar.workspace = true
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/crates/voicevox_core/Cargo.toml
+++ b/crates/voicevox_core/Cargo.toml
@@ -10,49 +10,44 @@ directml = ["onnxruntime/directml"]
 
 [dependencies]
 anyhow.workspace = true
-async_zip.workspace = true
-cfg-if = "1.0.0"
+async_zip = { workspace = true, features = ["full"] }
+cfg-if.workspace = true
 derive-getters.workspace = true
-derive-new = "0.5.9"
+derive-new.workspace = true
 derive_more.workspace = true
-duplicate = "1.0.0"
+duplicate.workspace = true
 easy-ext.workspace = true
-educe = "0.4.23"
-enum-map = "3.0.0-beta.1"
-fs-err.workspace = true
+educe.workspace = true
+enum-map.workspace = true
+fs-err = { workspace = true, features = ["tokio"] }
 futures.workspace = true
-indexmap.workspace = true
+indexmap = { workspace = true, features = ["serde"] }
 itertools.workspace = true
-nanoid = "0.4.0"
+nanoid.workspace = true
 ndarray.workspace = true
 once_cell.workspace = true
+onnxruntime.workspace = true
+open_jtalk.workspace = true
 regex.workspace = true
-serde.workspace = true
-serde_json.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["preserve_order"] }
 tempfile.workspace = true
 thiserror.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt"] }
 tracing.workspace = true
-uuid.workspace = true
+uuid = { workspace = true, features = ["v4", "serde"] }
 voicevox_core_macros = { path = "../voicevox_core_macros" }
 
-[dependencies.onnxruntime]
-git = "https://github.com/VOICEVOX/onnxruntime-rs.git"
-rev = "ebb9dcb9b26ee681889b52b6db3b4f642b04a250"
-
-[dependencies.open_jtalk]
-git = "https://github.com/VOICEVOX/open_jtalk-rs.git"
-rev = "a16714ce16dec76fd0e3041a7acfa484921db3b5"
-
 [dev-dependencies]
-heck = "0.4.0"
-pretty_assertions = "1.3.0"
+heck.workspace = true
+pretty_assertions.workspace = true
 rstest.workspace = true
 test_util.workspace = true
+tokio = { workspace = true, features = ["rt", "macros"] }
 
 [target."cfg(windows)".dependencies]
-humansize = "2.1.2"
-windows = { version = "0.43.0", features = ["Win32_Foundation", "Win32_Graphics_Dxgi"] }
+humansize.workspace = true
+windows = { workspace = true, features = ["Win32_Foundation", "Win32_Graphics_Dxgi"] }
 
 [lints.rust]
 unsafe_code = "deny" # FIXME: あまり意味が無くなっているため潔く`allow`にする。あるいはunsafeを撲滅する

--- a/crates/voicevox_core_c_api/Cargo.toml
+++ b/crates/voicevox_core_c_api/Cargo.toml
@@ -16,52 +16,44 @@ name = "e2e"
 directml = ["voicevox_core/directml"]
 
 [dependencies]
-anstream = { version = "0.5.0", default-features = false, features = ["auto"] }
-anstyle-query = "1.0.0"
-colorchoice = "1.0.0"
-cstr = "0.2.11"
+anstream = { workspace = true, default-features = false, features = ["auto"] }
+anstyle-query.workspace = true
+chrono = { workspace = true, default-features = false, features = ["clock"] }
+colorchoice.workspace = true
+cstr.workspace = true
 derive-getters.workspace = true
 futures.workspace = true
 itertools.workspace = true
-libc = "0.2.134"
+libc.workspace = true
 once_cell.workspace = true
-serde_json.workspace = true
+process_path.workspace = true
+serde_json = { workspace = true, features = ["preserve_order"] }
 thiserror.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
 tracing.workspace = true
-tracing-subscriber.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 uuid.workspace = true
 voicevox_core.workspace = true
 
-[dependencies.chrono]
-version = "0.4.23"
-default-features = false
-features = ["clock"]
-
-# FIXME: iOS対応のpull request(https://github.com/wesleywiser/process_path/pull/16)がマージされる見込みが無いため
-[dependencies.process_path]
-git = "https://github.com/VOICEVOX/process_path.git"
-rev = "de226a26e8e18edbdb1d6f986afe37bbbf35fbf4"
-
 [dev-dependencies]
 anyhow.workspace = true
-assert_cmd = { version = "2.0.8", features = ["color-auto"] }
-clap.workspace = true
-duct = "0.13.6"
+assert_cmd = { workspace = true, features = ["color-auto"] }
+clap = { workspace = true, features = ["derive"] }
+duct.workspace = true
 easy-ext.workspace = true
-inventory = "0.3.4"
-libloading = "0.7.3"
-libtest-mimic = "0.6.0"
+inventory.workspace = true
+libloading.workspace = true
+libtest-mimic.workspace = true
 ndarray.workspace = true
-ndarray-stats = "0.5.1"
+ndarray-stats.workspace = true
 regex.workspace = true
-serde.workspace = true
-serde_with = "3.3.0"
-strum.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_with.workspace = true
+strum = { workspace = true, features = ["derive"] }
 tempfile.workspace = true
 test_util.workspace = true
-toml = "0.7.2"
-typetag = "0.2.5"
+toml.workspace = true
+typetag.workspace = true
 
 [lints.rust]
 unsafe_code = "allow" # C APIのための操作

--- a/crates/voicevox_core_java_api/Cargo.toml
+++ b/crates/voicevox_core_java_api/Cargo.toml
@@ -11,14 +11,15 @@ crate-type = ["cdylib"]
 directml = ["voicevox_core/directml"]
 
 [dependencies]
-android_logger = "0.13.1"
-chrono = "0.4.26"
+android_logger.workspace = true
+chrono = { workspace = true, default-features = false, features = ["clock"] }
 derive_more.workspace = true
-jni = "0.21.1"
+jni.workspace = true
 once_cell.workspace = true
-serde_json.workspace = true
-tokio.workspace = true
-tracing-subscriber.workspace = true
+serde_json = { workspace = true, features = ["preserve_order"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
+tracing = { workspace = true, features = ["log"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 uuid.workspace = true
 voicevox_core.workspace = true
 

--- a/crates/voicevox_core_macros/Cargo.toml
+++ b/crates/voicevox_core_macros/Cargo.toml
@@ -10,9 +10,9 @@ proc-macro = true
 
 [dependencies]
 indexmap.workspace = true
-proc-macro2 = "1.0.69"
-quote = "1.0.33"
-syn = { version = "2.0.38", features = ["extra-traits"] }
+proc-macro2.workspace = true
+quote.workspace = true
+syn = { workspace = true, features = ["extra-traits", "full"] }
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/crates/voicevox_core_python_api/Cargo.toml
+++ b/crates/voicevox_core_python_api/Cargo.toml
@@ -12,12 +12,13 @@ directml = ["voicevox_core/directml"]
 
 [dependencies]
 easy-ext.workspace = true
-log = "0.4.17"
-pyo3 = { version = "0.19.2", features = ["abi3-py38", "extension-module"] }
-pyo3-asyncio = { version = "0.19.0", features = ["tokio-runtime"] }
-pyo3-log = "0.9.0"
-serde.workspace = true
+log.workspace = true
+pyo3 = { workspace = true, features = ["abi3-py38", "extension-module"] }
+pyo3-asyncio = { workspace = true, features = ["tokio-runtime"] }
+pyo3-log.workspace = true
+serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+tracing = { workspace = true, features = ["log"] }
 uuid.workspace = true
 voicevox_core.workspace = true
 

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -5,10 +5,10 @@ edition.workspace = true
 publish.workspace = true
 
 [dependencies]
-cbindgen = "0.24.3"
-clap.workspace = true
-color-eyre = "0.6.2"
-eyre = "0.6.8"
+cbindgen.workspace = true
+clap = { workspace = true, features = ["derive"] }
+color-eyre.workspace = true
+eyre.workspace = true
 fs-err.workspace = true
 
 [lints.rust]


### PR DESCRIPTION
## 内容

Cargo.tomlのdependenciesについて、

1. `version`は`workspace.dependencies`に
2. `features`はpackageの`dependencies`系に

書くようにします。

1.についてはrust-lang/cargo自体がやっています。

2.については、次のコマンドが通るように`features`の補足も行いました。

```console
❯ find ./crates/ -name Cargo.toml -exec cargo clippy --manifest-path {} ';'
❯ find ./crates/ -name Cargo.toml -exec cargo clippy --manifest-path {} --all-targets ';'
```

## 関連 Issue

## その他
