### PR TITLE
音声合成の処理を丸ごとスレッド分離して実行する

### DIFF
--- a/crates/voicevox_core/src/__internal.rs
+++ b/crates/voicevox_core/src/__internal.rs
@@ -1,4 +1,5 @@
 pub mod doctest_fixtures;
+pub mod interop;
 
 // VOICEVOX CORE内のラッパー向けの実装
 // FIXME: 要議論: https://github.com/VOICEVOX/voicevox_core/issues/595

--- a/crates/voicevox_core/src/__internal/interop.rs
+++ b/crates/voicevox_core/src/__internal/interop.rs
@@ -1,0 +1,1 @@
+pub use crate::synthesizer::PerformInference;

--- a/crates/voicevox_core/src/infer/status.rs
+++ b/crates/voicevox_core/src/infer/status.rs
@@ -90,10 +90,16 @@ impl<R: InferenceRuntime, D: InferenceDomain> Status<R, D> {
         self.is_loaded_model_by_style_id(style_id)
     }
 
+    /// 推論を実行する。
+    ///
+    /// # Performance
+    ///
+    /// CPU/GPU-boundな操作であるため、非同期ランタイム上では直接実行されるべきではない。
+    ///
     /// # Panics
     ///
     /// `self`が`model_id`を含んでいないとき、パニックする。
-    pub(crate) async fn run_session<I>(
+    pub(crate) fn run_session<I>(
         &self,
         model_id: &VoiceModelId,
         input: I,
@@ -103,10 +109,7 @@ impl<R: InferenceRuntime, D: InferenceDomain> Status<R, D> {
         I::Signature: InferenceSignature<Domain = D>,
     {
         let sess = self.loaded_models.lock().unwrap().get(model_id);
-
-        tokio::task::spawn_blocking(move || sess.run(input))
-            .await
-            .unwrap()
+        sess.run(input)
     }
 }
 

--- a/crates/voicevox_core/src/lib.rs
+++ b/crates/voicevox_core/src/lib.rs
@@ -11,11 +11,11 @@ mod metas;
 mod numerics;
 mod result;
 mod synthesizer;
+mod task;
 mod user_dict;
 mod version;
 mod voice_model;
 
-#[doc(hidden)]
 pub mod __internal;
 
 #[cfg(test)]
@@ -31,7 +31,9 @@ pub use self::result::*;
 pub use self::voice_model::*;
 pub use devices::*;
 pub use manifest::*;
-pub use synthesizer::*;
+pub use synthesizer::{
+    AccelerationMode, InitializeOptions, SynthesisOptions, Synthesizer, TtsOptions,
+};
 pub use user_dict::*;
 pub use version::*;
 

--- a/crates/voicevox_core/src/task.rs
+++ b/crates/voicevox_core/src/task.rs
@@ -1,0 +1,16 @@
+use std::panic;
+
+/// ブロッキング操作を非同期化する。
+///
+/// # Panics
+///
+/// - `f`がパニックした場合、パニックがそのままunwindされる。
+/// - tokioのランタイムの都合で`f`の実行が"cancel"された場合パニックする。
+pub(crate) async fn asyncify<F: FnOnce() -> R + Send + 'static, R: Send + 'static>(f: F) -> R {
+    tokio::task::spawn_blocking(f)
+        .await
+        .unwrap_or_else(|err| match err.try_into_panic() {
+            Ok(panic) => panic::resume_unwind(panic),
+            Err(err) => panic!("{err}"), // FIXME: エラーとして回収する
+        })
+}

--- a/crates/voicevox_core_java_api/src/synthesizer.rs
+++ b/crates/voicevox_core_java_api/src/synthesizer.rs
@@ -53,7 +53,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsNew<'loca
             .get_rust_field::<_, _, Arc<voicevox_core::OpenJtalk>>(&open_jtalk, "handle")?
             .clone();
         let internal = voicevox_core::Synthesizer::new(open_jtalk, Box::leak(Box::new(options)))?;
-        env.set_rust_field(&this, "handle", Arc::new(internal))?;
+        env.set_rust_field(&this, "handle", internal)?;
         Ok(())
     })
 }
@@ -64,7 +64,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsIsGpuMode
 ) -> jboolean {
     throw_if_err(env, false, |env| {
         let internal = env
-            .get_rust_field::<_, _, Arc<voicevox_core::Synthesizer>>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
             .clone();
 
         Ok(internal.is_gpu_mode())
@@ -78,7 +78,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsGetMetasJ
 ) -> jobject {
     throw_if_err(env, std::ptr::null_mut(), |env| {
         let internal = env
-            .get_rust_field::<_, _, Arc<voicevox_core::Synthesizer>>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
             .clone();
 
         let metas_json = serde_json::to_string(&internal.metas()).expect("should not fail");
@@ -100,7 +100,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsLoadVoice
             .get_rust_field::<_, _, Arc<voicevox_core::VoiceModel>>(&model, "handle")?
             .clone();
         let internal = env
-            .get_rust_field::<_, _, Arc<voicevox_core::Synthesizer>>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
             .clone();
         RUNTIME.block_on(internal.load_voice_model(&model))?;
         Ok(())
@@ -117,7 +117,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsUnloadVoi
         let model_id: String = env.get_string(&model_id)?.into();
 
         let internal = env
-            .get_rust_field::<_, _, Arc<voicevox_core::Synthesizer>>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
             .clone();
 
         internal.unload_voice_model(&voicevox_core::VoiceModelId::new(model_id))?;
@@ -138,7 +138,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsIsLoadedV
         let model_id: String = env.get_string(&model_id)?.into();
 
         let internal = env
-            .get_rust_field::<_, _, Arc<voicevox_core::Synthesizer>>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
             .clone();
 
         let is_loaded = internal.is_loaded_voice_model(&voicevox_core::VoiceModelId::new(model_id));
@@ -162,7 +162,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsAudioQuer
         let style_id = style_id as u32;
 
         let internal = env
-            .get_rust_field::<_, _, Arc<voicevox_core::Synthesizer>>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
             .clone();
 
         let audio_query = RUNTIME.block_on(
@@ -189,7 +189,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsAudioQuer
         let style_id = style_id as u32;
 
         let internal = env
-            .get_rust_field::<_, _, Arc<voicevox_core::Synthesizer>>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
             .clone();
 
         let audio_query =
@@ -217,7 +217,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsAccentPhr
         let style_id = style_id as u32;
 
         let internal = env
-            .get_rust_field::<_, _, Arc<voicevox_core::Synthesizer>>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
             .clone();
 
         let accent_phrases = RUNTIME.block_on(
@@ -244,7 +244,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsAccentPhr
         let style_id = style_id as u32;
 
         let internal = env
-            .get_rust_field::<_, _, Arc<voicevox_core::Synthesizer>>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
             .clone();
 
         let accent_phrases = RUNTIME.block_on(
@@ -273,7 +273,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsReplaceMo
         let style_id = style_id as u32;
 
         let internal = env
-            .get_rust_field::<_, _, Arc<voicevox_core::Synthesizer>>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
             .clone();
 
         let replaced_accent_phrases = RUNTIME.block_on(
@@ -303,7 +303,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsReplacePh
         let style_id = style_id as u32;
 
         let internal = env
-            .get_rust_field::<_, _, Arc<voicevox_core::Synthesizer>>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
             .clone();
 
         let replaced_accent_phrases = {
@@ -334,7 +334,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsReplaceMo
         let style_id = style_id as u32;
 
         let internal = env
-            .get_rust_field::<_, _, Arc<voicevox_core::Synthesizer>>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
             .clone();
 
         let replaced_accent_phrases = RUNTIME.block_on(
@@ -363,7 +363,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsSynthesis
         let style_id = style_id as u32;
 
         let internal = env
-            .get_rust_field::<_, _, Arc<voicevox_core::Synthesizer>>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
             .clone();
 
         let wave = {
@@ -397,7 +397,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsTtsFromKa
         let style_id = style_id as u32;
 
         let internal = env
-            .get_rust_field::<_, _, Arc<voicevox_core::Synthesizer>>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
             .clone();
 
         let wave = {
@@ -431,7 +431,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsTts<'loca
         let style_id = style_id as u32;
 
         let internal = env
-            .get_rust_field::<_, _, Arc<voicevox_core::Synthesizer>>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
             .clone();
 
         let wave = {

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -144,7 +144,7 @@ impl OpenJtalk {
 
 #[pyclass]
 struct Synthesizer {
-    synthesizer: Closable<Arc<voicevox_core::Synthesizer>, Self>,
+    synthesizer: Closable<voicevox_core::Synthesizer, Self>,
 }
 
 #[pymethods]
@@ -167,7 +167,7 @@ impl Synthesizer {
                 cpu_num_threads,
             },
         );
-        let synthesizer = Python::with_gil(|py| synthesizer.into_py_result(py))?.into();
+        let synthesizer = Python::with_gil(|py| synthesizer.into_py_result(py))?;
         let synthesizer = Closable::new(synthesizer);
         Ok(Self { synthesizer })
     }


### PR DESCRIPTION
## 内容

`Synthesizer`の音声合成系のメソッドを、すべて丸ごとスレッド分離して実行するようにし、asyncのランタイムを阻害しないようにします。

#545 の以下のタスクを完全に解決します。

>     - [ ] モデルを実行するところとかは`tokio::task::spawn_blocking`で囲ったりするべきでは?

## 関連 Issue

#545

## その他
