### PR TITLE
`OpenJtalk`を`Synthesizer<OpenJtalk> | Synthesizer<()>`として持つ

### DIFF
--- a/crates/voicevox_core/src/__internal/doctest_fixtures.rs
+++ b/crates/voicevox_core/src/__internal/doctest_fixtures.rs
@@ -1,12 +1,12 @@
-use std::{path::Path, sync::Arc};
+use std::path::Path;
 
 use crate::{AccelerationMode, InitializeOptions, OpenJtalk, Synthesizer, VoiceModel};
 
 pub async fn synthesizer_with_sample_voice_model(
     open_jtalk_dic_dir: impl AsRef<Path>,
-) -> anyhow::Result<Synthesizer> {
+) -> anyhow::Result<Synthesizer<OpenJtalk>> {
     let syntesizer = Synthesizer::new(
-        Arc::new(OpenJtalk::new(open_jtalk_dic_dir).await.unwrap()),
+        OpenJtalk::new(open_jtalk_dic_dir).await?,
         &InitializeOptions {
             acceleration_mode: AccelerationMode::Cpu,
             ..Default::default()

--- a/crates/voicevox_core/src/engine/open_jtalk.rs
+++ b/crates/voicevox_core/src/engine/open_jtalk.rs
@@ -1,9 +1,6 @@
 use std::io::Write;
 use std::sync::Arc;
-use std::{
-    path::{Path, PathBuf},
-    sync::Mutex,
-};
+use std::{path::Path, sync::Mutex};
 
 use anyhow::anyhow;
 use tempfile::NamedTempFile;
@@ -21,9 +18,10 @@ pub(crate) struct OpenjtalkFunctionError {
 }
 
 /// テキスト解析器としてのOpen JTalk。
+#[derive(Clone)]
 pub struct OpenJtalk {
     resources: Arc<Mutex<Resources>>,
-    dict_dir: Option<PathBuf>,
+    dict_dir: Arc<String>, // FIXME: `camino::Utf8PathBuf`にする
 }
 
 struct Resources {
@@ -36,46 +34,41 @@ struct Resources {
 unsafe impl Send for Resources {}
 
 impl OpenJtalk {
-    // FIXME: この関数は廃止し、`Synthesizer`は`Option<OpenJtalk>`という形でこの構造体を持つ
-    pub fn new_without_dic() -> Self {
-        Self {
-            resources: Mutex::new(Resources {
+    pub async fn new(open_jtalk_dict_dir: impl AsRef<Path>) -> crate::result::Result<Self> {
+        let dict_dir = open_jtalk_dict_dir
+            .as_ref()
+            .to_str()
+            .unwrap_or_else(|| todo!()) // FIXME: `camino::Utf8Path`を要求するようにする
+            .to_owned();
+        let dict_dir = Arc::new(dict_dir);
+
+        crate::task::asyncify(move || {
+            let mut resources = Resources {
                 mecab: ManagedResource::initialize(),
                 njd: ManagedResource::initialize(),
                 jpcommon: ManagedResource::initialize(),
-            })
-            .into(),
-            dict_dir: None,
-        }
-    }
+            };
 
-    pub async fn new(open_jtalk_dict_dir: impl AsRef<Path>) -> crate::result::Result<Self> {
-        let open_jtalk_dict_dir = open_jtalk_dict_dir.as_ref().to_owned();
-
-        crate::task::asyncify(move || {
-            let mut s = Self::new_without_dic();
-            s.load(open_jtalk_dict_dir).map_err(|()| {
+            let result = resources.mecab.load(&*dict_dir);
+            if !result {
                 // FIXME: 「システム辞書を読もうとしたけど読めなかった」というエラーをちゃんと用意する
-                ErrorRepr::NotLoadedOpenjtalkDict
-            })?;
-            Ok(s)
+                return Err(ErrorRepr::NotLoadedOpenjtalkDict.into());
+            }
+
+            Ok(Self {
+                resources: Mutex::new(resources).into(),
+                dict_dir,
+            })
         })
         .await
     }
 
-    // 先に`load`を呼ぶ必要がある。
     /// ユーザー辞書を設定する。
     ///
     /// この関数を呼び出した後にユーザー辞書を変更した場合は、再度この関数を呼ぶ必要がある。
     pub async fn use_user_dict(&self, user_dict: &UserDict) -> crate::result::Result<()> {
-        let dict_dir = self
-            .dict_dir
-            .as_ref()
-            .and_then(|dict_dir| dict_dir.to_str())
-            .ok_or(ErrorRepr::NotLoadedOpenjtalkDict)?
-            .to_owned();
-
         let resources = self.resources.clone();
+        let dict_dir = self.dict_dir.clone();
 
         let words = user_dict.to_mecab_format();
 
@@ -108,7 +101,7 @@ impl OpenJtalk {
 
             let Resources { mecab, .. } = &mut *resources.lock().unwrap();
 
-            Ok(mecab.load_with_userdic(dict_dir.as_ref(), Some(Path::new(&temp_dict_path))))
+            Ok(mecab.load_with_userdic((*dict_dir).as_ref(), Some(Path::new(&temp_dict_path))))
         })
         .await?;
 
@@ -166,26 +159,6 @@ impl OpenJtalk {
                 source: None,
             })
         }
-    }
-
-    fn load(&mut self, open_jtalk_dict_dir: impl AsRef<Path>) -> std::result::Result<(), ()> {
-        let result = self
-            .resources
-            .lock()
-            .unwrap()
-            .mecab
-            .load(open_jtalk_dict_dir.as_ref());
-        if result {
-            self.dict_dir = Some(open_jtalk_dict_dir.as_ref().into());
-            Ok(())
-        } else {
-            self.dict_dir = None;
-            Err(())
-        }
-    }
-
-    pub fn dict_loaded(&self) -> bool {
-        self.dict_dir.is_some()
     }
 }
 

--- a/crates/voicevox_core_c_api/src/c_impls.rs
+++ b/crates/voicevox_core_c_api/src/c_impls.rs
@@ -1,4 +1,4 @@
-use std::{ffi::CString, path::Path, sync::Arc};
+use std::{ffi::CString, path::Path};
 
 use voicevox_core::{InitializeOptions, OpenJtalk, Result, Synthesizer, VoiceModel, VoiceModelId};
 
@@ -7,7 +7,7 @@ use crate::{CApiResult, OpenJtalkRc, VoicevoxSynthesizer, VoicevoxVoiceModel};
 impl OpenJtalkRc {
     pub(crate) async fn new(open_jtalk_dic_dir: impl AsRef<Path>) -> Result<Self> {
         Ok(Self {
-            open_jtalk: Arc::new(OpenJtalk::new(open_jtalk_dic_dir).await?),
+            open_jtalk: OpenJtalk::new(open_jtalk_dic_dir).await?,
         })
     }
 }

--- a/crates/voicevox_core_c_api/src/compatible_engine.rs
+++ b/crates/voicevox_core_c_api/src/compatible_engine.rs
@@ -1,9 +1,9 @@
-use std::{collections::BTreeMap, sync::Arc};
+use std::collections::BTreeMap;
 
 use super::*;
 use libc::c_int;
 
-use voicevox_core::{OpenJtalk, StyleId, VoiceModel, __internal::interop::PerformInference as _};
+use voicevox_core::{StyleId, VoiceModel, __internal::interop::PerformInference as _};
 
 macro_rules! ensure_initialized {
     ($synthesizer:expr $(,)?) => {
@@ -88,10 +88,10 @@ fn voice_model_set() -> &'static VoiceModelSet {
     &VOICE_MODEL_SET
 }
 
-static SYNTHESIZER: Lazy<Mutex<Option<voicevox_core::Synthesizer>>> =
+static SYNTHESIZER: Lazy<Mutex<Option<voicevox_core::Synthesizer<()>>>> =
     Lazy::new(|| Mutex::new(None));
 
-fn lock_synthesizer() -> MutexGuard<'static, Option<voicevox_core::Synthesizer>> {
+fn lock_synthesizer() -> MutexGuard<'static, Option<voicevox_core::Synthesizer<()>>> {
     SYNTHESIZER.lock().unwrap()
 }
 
@@ -108,7 +108,7 @@ pub extern "C" fn initialize(use_gpu: bool, cpu_num_threads: c_int, load_all_mod
     // で行っているという構造になってしまっているので、外すとロガーの初期化が遅れてしまでう
     let result = RUNTIME.block_on(async {
         let synthesizer = voicevox_core::Synthesizer::new(
-            Arc::new(OpenJtalk::new_without_dic()),
+            (),
             &voicevox_core::InitializeOptions {
                 acceleration_mode: if use_gpu {
                     voicevox_core::AccelerationMode::Gpu

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -104,7 +104,7 @@ static RUNTIME: Lazy<Runtime> = Lazy::new(|| {
 /// ```
 /// }
 pub struct OpenJtalkRc {
-    open_jtalk: Arc<OpenJtalk>,
+    open_jtalk: OpenJtalk,
 }
 
 /// ::OpenJtalkRc を<b>構築</b>(_construct_)する。
@@ -317,7 +317,7 @@ pub extern "C" fn voicevox_voice_model_delete(model: Box<VoicevoxVoiceModel>) {
 /// <b>構築</b>(_construction_)は ::voicevox_synthesizer_new で行い、<b>破棄</b>(_destruction_)は ::voicevox_synthesizer_delete で行う。
 #[derive(Getters)]
 pub struct VoicevoxSynthesizer {
-    synthesizer: Synthesizer,
+    synthesizer: Synthesizer<OpenJtalk>,
 }
 
 /// ::VoicevoxSynthesizer を<b>構築</b>(_construct_)する。

--- a/crates/voicevox_core_java_api/src/open_jtalk.rs
+++ b/crates/voicevox_core_java_api/src/open_jtalk.rs
@@ -17,7 +17,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_OpenJtalk_rsNew<'local>
         let open_jtalk_dict_dir = &*Cow::from(&open_jtalk_dict_dir);
 
         let internal = RUNTIME.block_on(voicevox_core::OpenJtalk::new(open_jtalk_dict_dir))?;
-        env.set_rust_field(&this, "handle", Arc::new(internal))?;
+        env.set_rust_field(&this, "handle", internal)?;
 
         Ok(())
     })
@@ -31,7 +31,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_OpenJtalk_rsUseUserDict
 ) {
     throw_if_err(env, (), |env| {
         let internal = env
-            .get_rust_field::<_, _, Arc<voicevox_core::OpenJtalk>>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::OpenJtalk>(&this, "handle")?
             .clone();
 
         let user_dict = env

--- a/crates/voicevox_core_java_api/src/synthesizer.rs
+++ b/crates/voicevox_core_java_api/src/synthesizer.rs
@@ -50,7 +50,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsNew<'loca
         options.cpu_num_threads = cpu_num_threads.i().expect("cpuNumThreads is not integer") as u16;
 
         let open_jtalk = env
-            .get_rust_field::<_, _, Arc<voicevox_core::OpenJtalk>>(&open_jtalk, "handle")?
+            .get_rust_field::<_, _, voicevox_core::OpenJtalk>(&open_jtalk, "handle")?
             .clone();
         let internal = voicevox_core::Synthesizer::new(open_jtalk, Box::leak(Box::new(options)))?;
         env.set_rust_field(&this, "handle", internal)?;
@@ -64,7 +64,9 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsIsGpuMode
 ) -> jboolean {
     throw_if_err(env, false, |env| {
         let internal = env
-            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer<voicevox_core::OpenJtalk>>(
+                &this, "handle",
+            )?
             .clone();
 
         Ok(internal.is_gpu_mode())
@@ -78,7 +80,9 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsGetMetasJ
 ) -> jobject {
     throw_if_err(env, std::ptr::null_mut(), |env| {
         let internal = env
-            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer<voicevox_core::OpenJtalk>>(
+                &this, "handle",
+            )?
             .clone();
 
         let metas_json = serde_json::to_string(&internal.metas()).expect("should not fail");
@@ -100,7 +104,9 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsLoadVoice
             .get_rust_field::<_, _, Arc<voicevox_core::VoiceModel>>(&model, "handle")?
             .clone();
         let internal = env
-            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer<voicevox_core::OpenJtalk>>(
+                &this, "handle",
+            )?
             .clone();
         RUNTIME.block_on(internal.load_voice_model(&model))?;
         Ok(())
@@ -117,7 +123,9 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsUnloadVoi
         let model_id: String = env.get_string(&model_id)?.into();
 
         let internal = env
-            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer<voicevox_core::OpenJtalk>>(
+                &this, "handle",
+            )?
             .clone();
 
         internal.unload_voice_model(&voicevox_core::VoiceModelId::new(model_id))?;
@@ -138,7 +146,9 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsIsLoadedV
         let model_id: String = env.get_string(&model_id)?.into();
 
         let internal = env
-            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer<voicevox_core::OpenJtalk>>(
+                &this, "handle",
+            )?
             .clone();
 
         let is_loaded = internal.is_loaded_voice_model(&voicevox_core::VoiceModelId::new(model_id));
@@ -162,7 +172,9 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsAudioQuer
         let style_id = style_id as u32;
 
         let internal = env
-            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer<voicevox_core::OpenJtalk>>(
+                &this, "handle",
+            )?
             .clone();
 
         let audio_query = RUNTIME.block_on(
@@ -189,7 +201,9 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsAudioQuer
         let style_id = style_id as u32;
 
         let internal = env
-            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer<voicevox_core::OpenJtalk>>(
+                &this, "handle",
+            )?
             .clone();
 
         let audio_query =
@@ -217,7 +231,9 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsAccentPhr
         let style_id = style_id as u32;
 
         let internal = env
-            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer<voicevox_core::OpenJtalk>>(
+                &this, "handle",
+            )?
             .clone();
 
         let accent_phrases = RUNTIME.block_on(
@@ -244,7 +260,9 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsAccentPhr
         let style_id = style_id as u32;
 
         let internal = env
-            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer<voicevox_core::OpenJtalk>>(
+                &this, "handle",
+            )?
             .clone();
 
         let accent_phrases = RUNTIME.block_on(
@@ -273,7 +291,9 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsReplaceMo
         let style_id = style_id as u32;
 
         let internal = env
-            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer<voicevox_core::OpenJtalk>>(
+                &this, "handle",
+            )?
             .clone();
 
         let replaced_accent_phrases = RUNTIME.block_on(
@@ -303,7 +323,9 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsReplacePh
         let style_id = style_id as u32;
 
         let internal = env
-            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer<voicevox_core::OpenJtalk>>(
+                &this, "handle",
+            )?
             .clone();
 
         let replaced_accent_phrases = {
@@ -334,7 +356,9 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsReplaceMo
         let style_id = style_id as u32;
 
         let internal = env
-            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer<voicevox_core::OpenJtalk>>(
+                &this, "handle",
+            )?
             .clone();
 
         let replaced_accent_phrases = RUNTIME.block_on(
@@ -363,7 +387,9 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsSynthesis
         let style_id = style_id as u32;
 
         let internal = env
-            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer<voicevox_core::OpenJtalk>>(
+                &this, "handle",
+            )?
             .clone();
 
         let wave = {
@@ -397,7 +423,9 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsTtsFromKa
         let style_id = style_id as u32;
 
         let internal = env
-            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer<voicevox_core::OpenJtalk>>(
+                &this, "handle",
+            )?
             .clone();
 
         let wave = {
@@ -431,7 +459,9 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsTts<'loca
         let style_id = style_id as u32;
 
         let internal = env
-            .get_rust_field::<_, _, voicevox_core::Synthesizer>(&this, "handle")?
+            .get_rust_field::<_, _, voicevox_core::Synthesizer<voicevox_core::OpenJtalk>>(
+                &this, "handle",
+            )?
             .clone();
 
         let wave = {

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -114,7 +114,7 @@ impl VoiceModel {
 #[pyclass]
 #[derive(Clone)]
 struct OpenJtalk {
-    open_jtalk: Arc<voicevox_core::OpenJtalk>,
+    open_jtalk: voicevox_core::OpenJtalk,
 }
 
 #[pymethods]
@@ -127,7 +127,7 @@ impl OpenJtalk {
     ) -> PyResult<&PyAny> {
         pyo3_asyncio::tokio::future_into_py(py, async move {
             let open_jtalk = voicevox_core::OpenJtalk::new(open_jtalk_dict_dir).await;
-            let open_jtalk = Python::with_gil(|py| open_jtalk.into_py_result(py))?.into();
+            let open_jtalk = Python::with_gil(|py| open_jtalk.into_py_result(py))?;
             Ok(Self { open_jtalk })
         })
     }
@@ -144,7 +144,7 @@ impl OpenJtalk {
 
 #[pyclass]
 struct Synthesizer {
-    synthesizer: Closable<voicevox_core::Synthesizer, Self>,
+    synthesizer: Closable<voicevox_core::Synthesizer<voicevox_core::OpenJtalk>, Self>,
 }
 
 #[pymethods]


### PR DESCRIPTION
## 内容

`struct OpenJtalk`を`Synthesizer<OpenJtalk> | Synthesizer<()>`として持つようにします。
（Rust APIはパブリックではないので暫定）

これにより、`OpenJtalk`は必ずシステム辞書を読み込んでいる状態になります。

変更しているpublic APIはRust APIのみです。C（`compatible_engine`を除く）もPythonもJavaも現状Open JTalkが必須となっているのですが、もし必須ではなくするとしたら、設計については議論の余地があると思っています。

考慮すべきはこんな感じだと思っていて、

- アドホック多相（`Synthesizer<()>`からはメソッドが生えなくて、`Synthesizer<OpenJtalk>`からは生えてくる）があると仮定しない
    - Rust APIはまた組み直す
- classの継承があると仮定しない（Rust以外にもGoとかがある）
- ~~関数の引数や戻り値に動的ディスパッチされるinterfaceが使えると仮定しない~~
- interfaceとかabstract classに該当するものは、現代的な言語には流石にあるはず
    - classの継承があるなら、親側をabstractということにすればいけるはず。例えばOCamlやSML#でも[多相バリアント](https://ocaml.jp/refman/ch04s02.html)で部分型付けが表現できるのでどうにかなるはず（[参考](https://zenn.dev/akabe/articles/phantom-types-subtyping-introduction)）
- 言語間で**多少**形が違うくらいは許容してもよいはず。例えばCは、`void*`で扱って実行時チェックとするしかないはず

これをもとにしても、私が今思い付くだけでこれくらいの選択肢はあると思います。

```
class Synthesizer （OpenJtalkはオプショナルなオブジェクトとして持ち、null（相当）であるときにメソッドを呼ぶと実行時エラー）
```

```
class SynthesizerWithoutOpenjtalk （互いに親子関係には無い）
class Synthesizer                 （〃）
```

```
class Synthesizer
└── class SynthesisEngine （`Synthesizer::engine`として所有）
```

```
interface SynthesisEngine （存在型か、動的ディスパッチでコンストラクトする）
└── class Synthesizer
```

```
interface SynthesisEngine            （引数のみに登場し、返り値としては登場しない）
├── class SynthesizerWithoutOpenjtalk
└── class Synthesizer
```

## 関連 Issue

#545

## その他
