### PR TITLE
dataclassでオプショナルになっているべきフィールドをオプショナルにする

### DIFF
--- a/crates/voicevox_core/src/engine/model.rs
+++ b/crates/voicevox_core/src/engine/model.rs
@@ -87,6 +87,7 @@ mod tests {
     use super::*;
     use crate::*;
     use pretty_assertions::assert_eq;
+    use serde_json::json;
 
     #[rstest]
     fn check_audio_query_model_json_field_snake_case() {
@@ -114,5 +115,33 @@ mod tests {
             }
             _ => {}
         }
+    }
+
+    #[rstest]
+    fn it_accepts_json_without_optional_fields() -> anyhow::Result<()> {
+        serde_json::from_value::<AudioQueryModel>(json!({
+            "accent_phrases": [
+                {
+                    "moras": [
+                        {
+                            "text": "ア",
+                            "vowel": "a",
+                            "vowel_length": 0.0,
+                            "pitch": 0.0
+                        }
+                    ],
+                    "accent": 1
+                }
+            ],
+            "speed_scale": 1.0,
+            "pitch_scale": 0.0,
+            "intonation_scale": 1.0,
+            "volume_scale": 1.0,
+            "pre_phoneme_length": 0.1,
+            "post_phoneme_length": 0.1,
+            "output_sampling_rate": 24000,
+            "output_stereo": false
+        }))?;
+        Ok(())
     }
 }

--- a/crates/voicevox_core_python_api/python/test/test_audio_query.py
+++ b/crates/voicevox_core_python_api/python/test/test_audio_query.py
@@ -1,0 +1,38 @@
+import json
+import textwrap
+
+from voicevox_core import AudioQuery
+
+
+def test_accept_json_without_optional_fields() -> None:
+    AudioQuery(
+        **json.loads(
+            textwrap.dedent(
+                """\
+                {
+                  "accent_phrases": [
+                    {
+                      "moras": [
+                        {
+                          "text": "ア",
+                          "vowel": "a",
+                          "vowel_length": 0.0,
+                          "pitch": 0.0
+                        }
+                      ],
+                      "accent": 1
+                    }
+                  ],
+                  "speed_scale": 1.0,
+                  "pitch_scale": 0.0,
+                  "intonation_scale": 1.0,
+                  "volume_scale": 1.0,
+                  "pre_phoneme_length": 0.1,
+                  "post_phoneme_length": 0.1,
+                  "output_sampling_rate": 24000,
+                  "output_stereo": false
+                }
+                """,
+            )
+        )
+    )

--- a/crates/voicevox_core_python_api/python/voicevox_core/_models.py
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_models.py
@@ -119,12 +119,6 @@ class Mora:
     text: str
     """文字。"""
 
-    consonant: Optional[str]
-    """子音の音素。"""
-
-    consonant_length: Optional[float]
-    """子音の音長。"""
-
     vowel: str
     """母音の音素。"""
 
@@ -133,6 +127,12 @@ class Mora:
 
     pitch: float
     """音高。"""
+
+    consonant: Optional[str] = None
+    """子音の音素。"""
+
+    consonant_length: Optional[float] = None
+    """子音の音長。"""
 
 
 @pydantic.dataclasses.dataclass
@@ -145,10 +145,10 @@ class AccentPhrase:
     accent: int
     """アクセント箇所。"""
 
-    pause_mora: Optional[Mora]
+    pause_mora: Optional[Mora] = None
     """後ろに無音を付けるかどうか。"""
 
-    is_interrogative: bool
+    is_interrogative: bool = False
     """疑問系かどうか。"""
 
 
@@ -183,7 +183,7 @@ class AudioQuery:
     output_stereo: bool
     """音声データをステレオ出力するか否か。"""
 
-    kana: Optional[str]  # FIXME: requiredになっている（他の`Optional`も同様）
+    kana: Optional[str] = None
     """
     [読み取り専用] AquesTalk風記法。
 


### PR DESCRIPTION
## 内容

Python APIにおける以下のdataclassのフィールドを、Rust APIとENGINEに合わせてオプショナルにします。

- `Mora.consonant: Optional[str]`
- `Mora.consonant_length: Optional[str]`
- `AccentPhrase.pause_mora: Optional[Mora]`
- `AccentPhrase.is_interrogative: bool`
- `AudioQuery.kana: Optional[str]`

0.14からユーザーに提供している部分への修正となります。

## 関連 Issue

<https://github.com/VOICEVOX/voicevox_core/pull/695#discussion_r1405403733>

## その他

Java APIについてですが、GSONはそもそも`"null"`とか`"{}"`みたいなものも受理するようです。
