### PR TITLE
downloader, test_util, xtaskの`package.version`を省略する

### DIFF
--- a/crates/downloader/Cargo.toml
+++ b/crates/downloader/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
 name = "downloader"
-version = "0.0.0"
 edition.workspace = true
-publish.workspace = true
 
 [[bin]]
 name = "download"

--- a/crates/test_util/Cargo.toml
+++ b/crates/test_util/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
 name = "test_util"
-version = "0.0.0"
 edition.workspace = true
-publish.workspace = true
 
 [dependencies]
 async_zip = { workspace = true, features = ["full"] }

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
 name = "xtask"
-version = "0.0.0"
 edition.workspace = true
-publish.workspace = true
 
 [dependencies]
 cbindgen.workspace = true


### PR DESCRIPTION
## 内容

Rust 1.75より、Cargo.tomlの`package.version`は省略可能になります。デフォルト値は`0.0.0`になります。また`package.version`を省略した場合、`package.publish = false`と同じ効果が発生します。

このPRは、ライブラリ/バイナリとしてリリースすることが無いであろう3つのクレートの`package.version`を省略します。`cargo set-version`は`package.version`が無くても普通に新規で挿入してくれるみたいなので全クレートでもよさそうですが、いったん様子見で。

## 関連 Issue

## その他
