### PR TITLE
Pyright/Pylanceに対応する

### DIFF
--- a/crates/voicevox_core_python_api/pyproject.toml
+++ b/crates/voicevox_core_python_api/pyproject.toml
@@ -22,6 +22,9 @@ build-backend = "maturin"
 [tool.isort]
 profile = "black"
 
+[tool.pyright]
+executionEnvironments = [{ root = "python/test" }, { root = "python" }]
+
 [tool.maturin]
 module-name = "voicevox_core._rust"
 bindings = "pyo3"

--- a/crates/voicevox_core_python_api/python/voicevox_core/asyncio.py
+++ b/crates/voicevox_core_python_api/python/voicevox_core/asyncio.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingModuleSource=false
 from ._rust.asyncio import OpenJtalk, Synthesizer, UserDict, VoiceModel
 
 __all__ = ["OpenJtalk", "Synthesizer", "UserDict", "VoiceModel"]

--- a/crates/voicevox_core_python_api/python/voicevox_core/blocking.py
+++ b/crates/voicevox_core_python_api/python/voicevox_core/blocking.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingModuleSource=false
 from ._rust.blocking import OpenJtalk, Synthesizer, UserDict, VoiceModel
 
 __all__ = ["OpenJtalk", "Synthesizer", "UserDict", "VoiceModel"]


### PR DESCRIPTION
## 内容

Pyright/Pylanceに対応し、エラー/警告なく動くようにします。

```console
❯ (cd ./crates/voicevox_core_python_api && pyright) && (cd ./example/python && pyright)
0 errors, 0 warnings, 0 informations
0 errors, 0 warnings, 0 informations
```

## 関連 Issue

## その他

CIでPyrightを動かすというのも考えたのですが、このPRではやっていません。mypyを入れるか次第ですね。両方サポートでもいい気はしますが。
(ちなみに私はNeovimでPythonを書いていますが、mypyではなくpyrightを使っています。LSPとしてフォーマッタが起動できないとかを除けば快適です)