### PR TITLE
[project-s] モデルへの入力の形・データを修正

### DIFF
--- a/crates/voicevox_core/src/publish.rs
+++ b/crates/voicevox_core/src/publish.rs
@@ -759,7 +759,7 @@ impl InferenceCore {
         &mut self,
         phoneme: &[i64],
         note: &[i64],
-        _f0: &[f32],
+        f0: &[f32],
         speaker_id: u32,
     ) -> Result<Vec<f32>> {
         if !self.initialized {
@@ -787,13 +787,13 @@ impl InferenceCore {
             return Err(Error::InvalidModelIndex { model_index });
         }
 
-        // TODO: f0を使う
         let mut phoneme_array = NdArray::new(ndarray::arr1(phoneme).into_shape([1, phoneme.len()]).unwrap());
         let mut note_array = NdArray::new(ndarray::arr1(note).into_shape([1, note.len()]).unwrap());
+        let mut f0_array = NdArray::new(ndarray::arr1(f0).into_shape([1, f0.len()]).unwrap());
         let mut speaker_id_array = NdArray::new(ndarray::arr1(&[speaker_id as i64]));
 
         let input_tensors: Vec<&mut dyn AnyArray> =
-            vec![&mut phoneme_array, &mut note_array, &mut speaker_id_array];
+            vec![&mut phoneme_array, &mut note_array, &mut f0_array, &mut speaker_id_array];
 
         status.predict_sing_volume_session_run(model_index, input_tensors)
     }

--- a/crates/voicevox_core/src/publish.rs
+++ b/crates/voicevox_core/src/publish.rs
@@ -699,9 +699,9 @@ impl InferenceCore {
             return Err(Error::InvalidModelIndex { model_index });
         }
 
-        let mut consonant_array = NdArray::new(ndarray::arr1(consonant));
-        let mut vowel_array = NdArray::new(ndarray::arr1(vowel));
-        let mut note_duration_array = NdArray::new(ndarray::arr1(note_duration));
+        let mut consonant_array = NdArray::new(ndarray::arr1(consonant).into_shape([1, consonant.len()]).unwrap());
+        let mut vowel_array = NdArray::new(ndarray::arr1(vowel).into_shape([1, vowel.len()]).unwrap());
+        let mut note_duration_array = NdArray::new(ndarray::arr1(note_duration).into_shape([1, note_duration.len()]).unwrap());
         let mut speaker_id_array = NdArray::new(ndarray::arr1(&[speaker_id as i64]));
 
         let input_tensors: Vec<&mut dyn AnyArray> = vec![
@@ -745,8 +745,8 @@ impl InferenceCore {
             return Err(Error::InvalidModelIndex { model_index });
         }
 
-        let mut phoneme_array = NdArray::new(ndarray::arr1(phoneme));
-        let mut note_array = NdArray::new(ndarray::arr1(note));
+        let mut phoneme_array = NdArray::new(ndarray::arr1(phoneme).into_shape([1, phoneme.len()]).unwrap());
+        let mut note_array = NdArray::new(ndarray::arr1(note).into_shape([1, note.len()]).unwrap());
         let mut speaker_id_array = NdArray::new(ndarray::arr1(&[speaker_id as i64]));
 
         let input_tensors: Vec<&mut dyn AnyArray> =
@@ -788,8 +788,8 @@ impl InferenceCore {
         }
 
         // TODO: f0を使う
-        let mut phoneme_array = NdArray::new(ndarray::arr1(phoneme));
-        let mut note_array = NdArray::new(ndarray::arr1(note));
+        let mut phoneme_array = NdArray::new(ndarray::arr1(phoneme).into_shape([1, phoneme.len()]).unwrap());
+        let mut note_array = NdArray::new(ndarray::arr1(note).into_shape([1, note.len()]).unwrap());
         let mut speaker_id_array = NdArray::new(ndarray::arr1(&[speaker_id as i64]));
 
         let input_tensors: Vec<&mut dyn AnyArray> =
@@ -830,9 +830,9 @@ impl InferenceCore {
             return Err(Error::InvalidModelIndex { model_index });
         }
 
-        let mut phoneme_array = NdArray::new(ndarray::arr1(phoneme));
-        let mut f0_array = NdArray::new(ndarray::arr1(f0));
-        let mut volume_array = NdArray::new(ndarray::arr1(volume));
+        let mut phoneme_array = NdArray::new(ndarray::arr1(phoneme).into_shape([1, phoneme.len()]).unwrap());
+        let mut f0_array = NdArray::new(ndarray::arr1(f0).into_shape([1, f0.len()]).unwrap());
+        let mut volume_array = NdArray::new(ndarray::arr1(volume).into_shape([1, volume.len()]).unwrap());
         let mut speaker_id_array = NdArray::new(ndarray::arr1(&[speaker_id as i64]));
 
         let input_tensors: Vec<&mut dyn AnyArray> = vec![

--- a/crates/voicevox_core/src/publish.rs
+++ b/crates/voicevox_core/src/publish.rs
@@ -699,9 +699,18 @@ impl InferenceCore {
             return Err(Error::InvalidModelIndex { model_index });
         }
 
-        let mut consonant_array = NdArray::new(ndarray::arr1(consonant).into_shape([1, consonant.len()]).unwrap());
-        let mut vowel_array = NdArray::new(ndarray::arr1(vowel).into_shape([1, vowel.len()]).unwrap());
-        let mut note_duration_array = NdArray::new(ndarray::arr1(note_duration).into_shape([1, note_duration.len()]).unwrap());
+        let mut consonant_array = NdArray::new(
+            ndarray::arr1(consonant)
+                .into_shape([1, consonant.len()])
+                .unwrap(),
+        );
+        let mut vowel_array =
+            NdArray::new(ndarray::arr1(vowel).into_shape([1, vowel.len()]).unwrap());
+        let mut note_duration_array = NdArray::new(
+            ndarray::arr1(note_duration)
+                .into_shape([1, note_duration.len()])
+                .unwrap(),
+        );
         let mut speaker_id_array = NdArray::new(ndarray::arr1(&[speaker_id as i64]));
 
         let input_tensors: Vec<&mut dyn AnyArray> = vec![
@@ -745,7 +754,11 @@ impl InferenceCore {
             return Err(Error::InvalidModelIndex { model_index });
         }
 
-        let mut phoneme_array = NdArray::new(ndarray::arr1(phoneme).into_shape([1, phoneme.len()]).unwrap());
+        let mut phoneme_array = NdArray::new(
+            ndarray::arr1(phoneme)
+                .into_shape([1, phoneme.len()])
+                .unwrap(),
+        );
         let mut note_array = NdArray::new(ndarray::arr1(note).into_shape([1, note.len()]).unwrap());
         let mut speaker_id_array = NdArray::new(ndarray::arr1(&[speaker_id as i64]));
 
@@ -787,13 +800,21 @@ impl InferenceCore {
             return Err(Error::InvalidModelIndex { model_index });
         }
 
-        let mut phoneme_array = NdArray::new(ndarray::arr1(phoneme).into_shape([1, phoneme.len()]).unwrap());
+        let mut phoneme_array = NdArray::new(
+            ndarray::arr1(phoneme)
+                .into_shape([1, phoneme.len()])
+                .unwrap(),
+        );
         let mut note_array = NdArray::new(ndarray::arr1(note).into_shape([1, note.len()]).unwrap());
         let mut f0_array = NdArray::new(ndarray::arr1(f0).into_shape([1, f0.len()]).unwrap());
         let mut speaker_id_array = NdArray::new(ndarray::arr1(&[speaker_id as i64]));
 
-        let input_tensors: Vec<&mut dyn AnyArray> =
-            vec![&mut phoneme_array, &mut note_array, &mut f0_array, &mut speaker_id_array];
+        let input_tensors: Vec<&mut dyn AnyArray> = vec![
+            &mut phoneme_array,
+            &mut note_array,
+            &mut f0_array,
+            &mut speaker_id_array,
+        ];
 
         status.predict_sing_volume_session_run(model_index, input_tensors)
     }
@@ -830,9 +851,14 @@ impl InferenceCore {
             return Err(Error::InvalidModelIndex { model_index });
         }
 
-        let mut phoneme_array = NdArray::new(ndarray::arr1(phoneme).into_shape([1, phoneme.len()]).unwrap());
+        let mut phoneme_array = NdArray::new(
+            ndarray::arr1(phoneme)
+                .into_shape([1, phoneme.len()])
+                .unwrap(),
+        );
         let mut f0_array = NdArray::new(ndarray::arr1(f0).into_shape([1, f0.len()]).unwrap());
-        let mut volume_array = NdArray::new(ndarray::arr1(volume).into_shape([1, volume.len()]).unwrap());
+        let mut volume_array =
+            NdArray::new(ndarray::arr1(volume).into_shape([1, volume.len()]).unwrap());
         let mut speaker_id_array = NdArray::new(ndarray::arr1(&[speaker_id as i64]));
 
         let input_tensors: Vec<&mut dyn AnyArray> = vec![


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
project-sモデルへ入力する値をすべて`(1, data length)`のような形にreshapeしました。
また、`predict_sing_volume`のTODOを解決し、f0を入力するようにしました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
ref #712 
