### PR TITLE
Fix: 空の辞書でクラッシュするバグを修正

### DIFF
--- a/crates/voicevox_core/src/user_dict/dict.rs
+++ b/crates/voicevox_core/src/user_dict/dict.rs
@@ -99,6 +99,11 @@ pub(crate) mod blocking {
                 "\n",
             )
         }
+
+        /// ユーザー辞書が空かどうかを返す。
+        pub(crate) fn is_empty(&self) -> bool {
+            self.words.lock().unwrap().is_empty()
+        }
     }
 }
 
@@ -173,6 +178,11 @@ pub(crate) mod tokio {
         /// MeCabで使用する形式に変換する。
         pub(crate) fn to_mecab_format(&self) -> String {
             self.0.to_mecab_format()
+        }
+
+        /// ユーザー辞書が空かどうかを返す。
+        pub(crate) fn is_empty(&self) -> bool {
+            self.0.is_empty()
         }
     }
 }


### PR DESCRIPTION
## 内容

タイトル通り。

## 関連 Issue

（なし）

## その他

Rustのユーザー辞書テスト、どこに書けば良いんだろうか...
open_jtalk.rs？