### PR TITLE
TextAnalyzer traitにstring->AccentPhraseModel[]を移動

### DIFF
--- a/crates/voicevox_core/src/lib.rs
+++ b/crates/voicevox_core/src/lib.rs
@@ -12,13 +12,13 @@ mod numerics;
 mod result;
 mod synthesizer;
 mod task;
-mod text_analyzer;
 mod user_dict;
 mod version;
 mod voice_model;
 
 pub mod __internal;
 pub mod blocking;
+pub mod text_analyzer;
 pub mod tokio;
 
 #[cfg(test)]

--- a/crates/voicevox_core/src/lib.rs
+++ b/crates/voicevox_core/src/lib.rs
@@ -12,6 +12,7 @@ mod numerics;
 mod result;
 mod synthesizer;
 mod task;
+mod text_analyzer;
 mod user_dict;
 mod version;
 mod voice_model;

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -179,7 +179,7 @@ pub(crate) mod blocking {
             return Ok(Self {
                 status,
                 open_jtalk_analyzer: OpenJTalkAnalyzer::new(open_jtalk),
-                kana_analyzer: KanaAnalyzer::new(),
+                kana_analyzer: KanaAnalyzer {},
                 use_gpu,
             });
 

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -92,7 +92,7 @@ pub(crate) mod blocking {
             InferenceSessionOptions,
         },
         numerics::F32Ext as _,
-        text_analyzer::{KanaParser, OpenJtalk, TextAnalyzer},
+        text_analyzer::{KanaAnalyzer, OpenJTalkAnalyzer, TextAnalyzer},
         AccentPhraseModel, AudioQueryModel, FullcontextExtractor, Result, StyleId,
         SupportedDevices, SynthesisOptions, VoiceModelId, VoiceModelMeta,
     };
@@ -104,8 +104,8 @@ pub(crate) mod blocking {
     /// 音声シンセサイザ。
     pub struct Synthesizer<O> {
         pub(super) status: Status<InferenceRuntimeImpl, InferenceDomainImpl>,
-        open_jtalk: OpenJtalk<O>,
-        kana_parser: KanaParser,
+        open_jtalk_analyzer: OpenJTalkAnalyzer<O>,
+        kana_analyzer: KanaAnalyzer,
         use_gpu: bool,
     }
 
@@ -178,8 +178,8 @@ pub(crate) mod blocking {
 
             return Ok(Self {
                 status,
-                open_jtalk: OpenJtalk::new(open_jtalk),
-                kana_parser: KanaParser::new(),
+                open_jtalk_analyzer: OpenJTalkAnalyzer::new(open_jtalk),
+                kana_analyzer: KanaAnalyzer::new(),
                 use_gpu,
             });
 
@@ -460,7 +460,7 @@ pub(crate) mod blocking {
             kana: &str,
             style_id: StyleId,
         ) -> Result<Vec<AccentPhraseModel>> {
-            let accent_phrases = self.kana_parser.analyze(kana)?;
+            let accent_phrases = self.kana_analyzer.analyze(kana)?;
             self.replace_mora_data(&accent_phrases, style_id)
         }
 
@@ -747,7 +747,7 @@ pub(crate) mod blocking {
             text: &str,
             style_id: StyleId,
         ) -> Result<Vec<AccentPhraseModel>> {
-            let accent_phrases = self.open_jtalk.analyze(text)?;
+            let accent_phrases = self.open_jtalk_analyzer.analyze(text)?;
             self.replace_mora_data(&accent_phrases, style_id)
         }
 

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -80,7 +80,7 @@ pub(crate) mod blocking {
     use enum_map::enum_map;
 
     use crate::{
-        engine::{self, create_kana, MoraModel, OjtPhoneme},
+        engine::{create_kana, MoraModel, OjtPhoneme},
         error::ErrorRepr,
         infer::{
             domain::{
@@ -92,7 +92,7 @@ pub(crate) mod blocking {
             InferenceSessionOptions,
         },
         numerics::F32Ext as _,
-        text_analyzer::{KanaAnalyzer, OpenJTalkAnalyzer, TextAnalyzer},
+        text_analyzer::{mora_to_text, KanaAnalyzer, OpenJTalkAnalyzer, TextAnalyzer},
         AccentPhraseModel, AudioQueryModel, FullcontextExtractor, Result, StyleId,
         SupportedDevices, SynthesisOptions, VoiceModelId, VoiceModelMeta,
     };
@@ -179,7 +179,7 @@ pub(crate) mod blocking {
             return Ok(Self {
                 status,
                 open_jtalk_analyzer: OpenJTalkAnalyzer::new(open_jtalk),
-                kana_analyzer: KanaAnalyzer {},
+                kana_analyzer: KanaAnalyzer,
                 use_gpu,
             });
 
@@ -1109,21 +1109,6 @@ pub(crate) mod blocking {
         }
 
         (consonant_phoneme_list, vowel_phoneme_list, vowel_indexes)
-    }
-
-    fn mora_to_text(mora: impl AsRef<str>) -> String {
-        let last_char = mora.as_ref().chars().last().unwrap();
-        let mora = if ['A', 'I', 'U', 'E', 'O'].contains(&last_char) {
-            format!(
-                "{}{}",
-                &mora.as_ref()[0..mora.as_ref().len() - 1],
-                last_char.to_lowercase()
-            )
-        } else {
-            mora.as_ref().to_string()
-        };
-        // もしカタカナに変換できなければ、引数で与えた文字列がそのまま返ってくる
-        engine::mora2text(&mora).to_string()
     }
 
     impl AudioQueryModel {

--- a/crates/voicevox_core/src/text_analyzer.rs
+++ b/crates/voicevox_core/src/text_analyzer.rs
@@ -106,7 +106,7 @@ fn utterance_to_accent_phrases(utterance: Utterance) -> Vec<AccentPhraseModel> {
     accent_phrases
 }
 
-fn mora_to_text(mora: impl AsRef<str>) -> String {
+pub fn mora_to_text(mora: impl AsRef<str>) -> String {
     let last_char = mora.as_ref().chars().last().unwrap();
     let mora = if ['A', 'I', 'U', 'E', 'O'].contains(&last_char) {
         format!(

--- a/crates/voicevox_core/src/text_analyzer.rs
+++ b/crates/voicevox_core/src/text_analyzer.rs
@@ -1,0 +1,124 @@
+use crate::{
+    engine::{self, parse_kana, MoraModel, Utterance},
+    AccentPhraseModel, FullcontextExtractor, Result,
+};
+
+pub trait TextAnalyzer {
+    fn analyze(&self, text: &str) -> Result<Vec<AccentPhraseModel>>;
+}
+
+/// AquesTalk風記法からAccentPhraseの配列を生成するTextAnalyzer
+pub struct KanaParser {}
+
+impl KanaParser {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl TextAnalyzer for KanaParser {
+    fn analyze(&self, text: &str) -> Result<Vec<AccentPhraseModel>> {
+        Ok(parse_kana(text)?)
+    }
+}
+
+/// OpenJtalkからAccentPhraseの配列を生成するTextAnalyzer
+pub struct OpenJtalk<O> {
+    open_jtalk: O,
+}
+
+impl<O> OpenJtalk<O> {
+    pub fn new(open_jtalk: O) -> Self {
+        Self { open_jtalk }
+    }
+}
+
+impl<O: FullcontextExtractor> TextAnalyzer for OpenJtalk<O> {
+    fn analyze(&self, text: &str) -> Result<Vec<AccentPhraseModel>> {
+        if text.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let utterance = Utterance::extract_full_context_label(&self.open_jtalk, text)?;
+
+        let accent_phrases: Vec<AccentPhraseModel> = utterance
+            .breath_groups()
+            .iter()
+            .enumerate()
+            .fold(Vec::new(), |mut accum_vec, (i, breath_group)| {
+                accum_vec.extend(breath_group.accent_phrases().iter().enumerate().map(
+                    |(j, accent_phrase)| {
+                        let moras = accent_phrase
+                            .moras()
+                            .iter()
+                            .map(|mora| {
+                                let mora_text = mora
+                                    .phonemes()
+                                    .iter()
+                                    .map(|phoneme| phoneme.phoneme().to_string())
+                                    .collect::<Vec<_>>()
+                                    .join("");
+
+                                let (consonant, consonant_length) =
+                                    if let Some(consonant) = mora.consonant() {
+                                        (Some(consonant.phoneme().to_string()), Some(0.))
+                                    } else {
+                                        (None, None)
+                                    };
+
+                                MoraModel::new(
+                                    mora_to_text(mora_text),
+                                    consonant,
+                                    consonant_length,
+                                    mora.vowel().phoneme().into(),
+                                    0.,
+                                    0.,
+                                )
+                            })
+                            .collect();
+
+                        let pause_mora = if i != utterance.breath_groups().len() - 1
+                            && j == breath_group.accent_phrases().len() - 1
+                        {
+                            Some(MoraModel::new(
+                                "、".into(),
+                                None,
+                                None,
+                                "pau".into(),
+                                0.,
+                                0.,
+                            ))
+                        } else {
+                            None
+                        };
+
+                        AccentPhraseModel::new(
+                            moras,
+                            *accent_phrase.accent(),
+                            pause_mora,
+                            *accent_phrase.is_interrogative(),
+                        )
+                    },
+                ));
+
+                accum_vec
+            });
+
+        Ok(accent_phrases)
+    }
+}
+
+fn mora_to_text(mora: impl AsRef<str>) -> String {
+    let last_char = mora.as_ref().chars().last().unwrap();
+    let mora = if ['A', 'I', 'U', 'E', 'O'].contains(&last_char) {
+        format!(
+            "{}{}",
+            &mora.as_ref()[0..mora.as_ref().len() - 1],
+            last_char.to_lowercase()
+        )
+    } else {
+        mora.as_ref().to_string()
+    };
+    // もしカタカナに変換できなければ、引数で与えた文字列がそのまま返ってくる
+    engine::mora2text(&mora).to_string()
+}

--- a/crates/voicevox_core/src/text_analyzer.rs
+++ b/crates/voicevox_core/src/text_analyzer.rs
@@ -8,38 +8,36 @@ pub trait TextAnalyzer {
 }
 
 /// AquesTalk風記法からAccentPhraseの配列を生成するTextAnalyzer
-pub struct KanaParser {}
+pub struct KanaAnalyzer;
 
-impl KanaParser {
+impl KanaAnalyzer {
     pub fn new() -> Self {
         Self {}
     }
 }
 
-impl TextAnalyzer for KanaParser {
+impl TextAnalyzer for KanaAnalyzer {
     fn analyze(&self, text: &str) -> Result<Vec<AccentPhraseModel>> {
         Ok(parse_kana(text)?)
     }
 }
 
 /// OpenJtalkからAccentPhraseの配列を生成するTextAnalyzer
-pub struct OpenJtalk<O> {
-    open_jtalk: O,
-}
+pub struct OpenJTalkAnalyzer<O>(O);
 
-impl<O> OpenJtalk<O> {
+impl<O> OpenJTalkAnalyzer<O> {
     pub fn new(open_jtalk: O) -> Self {
-        Self { open_jtalk }
+        Self(open_jtalk)
     }
 }
 
-impl<O: FullcontextExtractor> TextAnalyzer for OpenJtalk<O> {
+impl<O: FullcontextExtractor> TextAnalyzer for OpenJTalkAnalyzer<O> {
     fn analyze(&self, text: &str) -> Result<Vec<AccentPhraseModel>> {
         if text.is_empty() {
             return Ok(Vec::new());
         }
 
-        let utterance = Utterance::extract_full_context_label(&self.open_jtalk, text)?;
+        let utterance = Utterance::extract_full_context_label(&self.0, text)?;
 
         let accent_phrases: Vec<AccentPhraseModel> = utterance
             .breath_groups()

--- a/crates/voicevox_core/src/text_analyzer.rs
+++ b/crates/voicevox_core/src/text_analyzer.rs
@@ -8,6 +8,7 @@ pub trait TextAnalyzer {
 }
 
 /// AquesTalk風記法からAccentPhraseの配列を生成するTextAnalyzer
+#[derive(Clone)]
 pub struct KanaAnalyzer;
 
 impl KanaAnalyzer {
@@ -26,6 +27,7 @@ impl TextAnalyzer for KanaAnalyzer {
 }
 
 /// OpenJtalkからAccentPhraseの配列を生成するTextAnalyzer
+#[derive(Clone)]
 pub struct OpenJTalkAnalyzer<O>(O);
 
 impl<O> OpenJTalkAnalyzer<O> {

--- a/crates/voicevox_core/src/text_analyzer.rs
+++ b/crates/voicevox_core/src/text_analyzer.rs
@@ -11,12 +11,6 @@ pub trait TextAnalyzer {
 #[derive(Clone)]
 pub struct KanaAnalyzer;
 
-impl KanaAnalyzer {
-    pub fn new() -> Self {
-        Self {}
-    }
-}
-
 impl TextAnalyzer for KanaAnalyzer {
     fn analyze(&self, text: &str) -> Result<Vec<AccentPhraseModel>> {
         if text.is_empty() {


### PR DESCRIPTION
## 内容

#730 で話されている，`TextAnalyzer` interfaceを実装するための準備として，Rust側に`TextAnalyzer` traitを生やしました．

また，

- AquesTalk風記法からAccentPhraseの配列を生成するTextAnalyzer
- OpenJtalkからAccentPhraseの配列を生成するTextAnalyzer

を実装するためにSynthesizerからコードを移動し，これら2つのTextAnalyzerをSynthesizerに持たせました．

Issue全体の実装をする(_kana系APIとOpenJTalkの統合)を行うと，Synthesizerを触る部分全体にAPI変更が波及してしまうため，外から見たAPIの変更は現時点では全く行っていません．

## 関連 Issue

#730

## その他
