### PR TITLE
C APIとPython APIの不必要なUTF-8の要求を外す

### DIFF
--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -441,8 +441,10 @@ pub unsafe extern "C" fn voicevox_synthesizer_is_loaded_voice_model(
     model_id: VoicevoxVoiceModelId,
 ) -> bool {
     init_logger_once();
-    // FIXME: 不正なUTF-8文字列に対し、正式なエラーとするか黙って`false`を返す
-    let raw_model_id = ensure_utf8(unsafe { CStr::from_ptr(model_id) }).unwrap();
+    let Ok(raw_model_id) = ensure_utf8(unsafe { CStr::from_ptr(model_id) }) else {
+        // 与えられたIDがUTF-8ではない場合、それに対応する`VoicdModel`は確実に存在しない
+        return false;
+    };
     synthesizer
         .synthesizer()
         .is_loaded_voice_model(&VoiceModelId::new(raw_model_id.into()))

--- a/crates/voicevox_core_python_api/src/convert.rs
+++ b/crates/voicevox_core_python_api/src/convert.rs
@@ -39,7 +39,7 @@ pub fn from_acceleration_mode(ob: &PyAny) -> PyResult<AccelerationMode> {
     }
 }
 
-// FIXME: `VoiceModel`や`UserDict`についてはこれではなく、`PathBuf::extract`を直接使うようにする
+// FIXME: `UserDict`についてはこれではなく、`PathBuf::extract`を直接使うようにする
 pub fn from_utf8_path(ob: &PyAny) -> PyResult<Utf8PathBuf> {
     PathBuf::extract(ob)?
         .into_os_string()


### PR DESCRIPTION
## 内容

次の変更を加えます。

- C API
    - `voicevox_synthesizer_is_loaded_voice_model`: 引数`model_id`がUTF-8ではない場合、パニックする代わりに黙って`false`を返す。
- Python API
    - `VoiceModel::is_loaded_voice_model`: 引数にRustの`str`ではなくPythonの`str`を要求し、UTF-8ではない場合黙って`False`を返す(C APIと一貫性を持たせる)。
    - `VoiceModel::from_path`: 引数がUTF-8であることを要求しない。

Java APIについては、MUTF-8 → UTF-8の変換が多分必ず成功するので、`isLoadedVoiceModel`も含めそのままです。

あとユーザー辞書については、別PRにしようと思います。

## 関連 Issue

## その他
