### PR TITLE
Fix Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2952,7 +2952,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2965,7 +2965,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]


### PR DESCRIPTION
## 内容

#742 のマージによりoutdatedになったCargo.lockを修復します。

## 関連 Issue

## その他

こうなる可能性は知っていたので、レビューのときに手元で確認しとかないとなと思いつつ忘れてしまいました。

仕組みとして防止するにはmerge queueとかを使うとか?
