### PR TITLE
アイテムの可視性を必要最低限にする

### DIFF
--- a/crates/test_util/src/lib.rs
+++ b/crates/test_util/src/lib.rs
@@ -22,7 +22,7 @@ pub const OPEN_JTALK_DIC_DIR: &str = concat!(
     "/data/open_jtalk_dic_utf_8-1.11"
 );
 
-pub const EXAMPLE_DATA_JSON: &str = include_str!(concat!(
+const EXAMPLE_DATA_JSON: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/data/example_data.json"
 ));

--- a/crates/voicevox_core/src/engine/acoustic_feature_extractor.rs
+++ b/crates/voicevox_core/src/engine/acoustic_feature_extractor.rs
@@ -61,7 +61,7 @@ static PHONEME_MAP: Lazy<HashMap<&str, i64>> = Lazy::new(|| {
 });
 
 #[derive(Debug, Clone, PartialEq, new, Default, Getters)]
-pub struct OjtPhoneme {
+pub(crate) struct OjtPhoneme {
     phoneme: String,
     #[allow(dead_code)]
     start: f32,
@@ -70,15 +70,15 @@ pub struct OjtPhoneme {
 }
 
 impl OjtPhoneme {
-    pub fn num_phoneme() -> usize {
+    pub(crate) fn num_phoneme() -> usize {
         PHONEME_MAP.len()
     }
 
-    pub fn space_phoneme() -> String {
+    fn space_phoneme() -> String {
         "pau".into()
     }
 
-    pub fn phoneme_id(&self) -> i64 {
+    pub(crate) fn phoneme_id(&self) -> i64 {
         if self.phoneme.is_empty() {
             -1
         } else {
@@ -86,7 +86,7 @@ impl OjtPhoneme {
         }
     }
 
-    pub fn convert(phonemes: &[OjtPhoneme]) -> Vec<OjtPhoneme> {
+    pub(crate) fn convert(phonemes: &[OjtPhoneme]) -> Vec<OjtPhoneme> {
         let mut phonemes = phonemes.to_owned();
         if let Some(first_phoneme) = phonemes.first_mut() {
             if first_phoneme.phoneme.contains("sil") {

--- a/crates/voicevox_core/src/engine/kana_parser.rs
+++ b/crates/voicevox_core/src/engine/kana_parser.rs
@@ -163,7 +163,7 @@ pub(crate) fn parse_kana(text: &str) -> KanaParseResult<Vec<AccentPhraseModel>> 
     Ok(parsed_result)
 }
 
-pub fn create_kana(accent_phrases: &[AccentPhraseModel]) -> String {
+pub(crate) fn create_kana(accent_phrases: &[AccentPhraseModel]) -> String {
     let mut text = String::new();
     for phrase in accent_phrases {
         let moras = phrase.moras();

--- a/crates/voicevox_core/src/engine/mora_list.rs
+++ b/crates/voicevox_core/src/engine/mora_list.rs
@@ -186,7 +186,7 @@ pub(super) const MORA_LIST_MINIMUM: &[[&str; 3]] = &[
     ["ア", "", "a"],
 ];
 
-pub fn mora2text(mora: &str) -> &str {
+pub(crate) fn mora2text(mora: &str) -> &str {
     for &[text, consonant, vowel] in MORA_LIST_MINIMUM {
         if mora.len() >= consonant.len()
             && &mora[..consonant.len()] == consonant

--- a/crates/voicevox_core/src/infer/status.rs
+++ b/crates/voicevox_core/src/infer/status.rs
@@ -31,14 +31,14 @@ pub(crate) struct Status<R: InferenceRuntime, D: InferenceDomain> {
 }
 
 impl<R: InferenceRuntime, D: InferenceDomain> Status<R, D> {
-    pub fn new(session_options: EnumMap<D::Operation, InferenceSessionOptions>) -> Self {
+    pub(crate) fn new(session_options: EnumMap<D::Operation, InferenceSessionOptions>) -> Self {
         Self {
             loaded_models: Default::default(),
             session_options,
         }
     }
 
-    pub fn insert_model(
+    pub(crate) fn insert_model(
         &self,
         model_header: &VoiceModelHeader,
         model_bytes: &EnumMap<D::Operation, Vec<u8>>,
@@ -64,11 +64,11 @@ impl<R: InferenceRuntime, D: InferenceDomain> Status<R, D> {
         Ok(())
     }
 
-    pub fn unload_model(&self, voice_model_id: &VoiceModelId) -> Result<()> {
+    pub(crate) fn unload_model(&self, voice_model_id: &VoiceModelId) -> Result<()> {
         self.loaded_models.lock().unwrap().remove(voice_model_id)
     }
 
-    pub fn metas(&self) -> VoiceModelMeta {
+    pub(crate) fn metas(&self) -> VoiceModelMeta {
         self.loaded_models.lock().unwrap().metas()
     }
 
@@ -76,18 +76,18 @@ impl<R: InferenceRuntime, D: InferenceDomain> Status<R, D> {
         self.loaded_models.lock().unwrap().ids_for(style_id)
     }
 
-    pub fn is_loaded_model(&self, voice_model_id: &VoiceModelId) -> bool {
+    pub(crate) fn is_loaded_model(&self, voice_model_id: &VoiceModelId) -> bool {
         self.loaded_models
             .lock()
             .unwrap()
             .contains_voice_model(voice_model_id)
     }
 
-    pub fn is_loaded_model_by_style_id(&self, style_id: StyleId) -> bool {
+    pub(crate) fn is_loaded_model_by_style_id(&self, style_id: StyleId) -> bool {
         self.loaded_models.lock().unwrap().contains_style(style_id)
     }
 
-    pub fn validate_speaker_id(&self, style_id: StyleId) -> bool {
+    pub(crate) fn validate_speaker_id(&self, style_id: StyleId) -> bool {
         self.is_loaded_model_by_style_id(style_id)
     }
 

--- a/crates/voicevox_core/src/lib.rs
+++ b/crates/voicevox_core/src/lib.rs
@@ -12,13 +12,13 @@ mod numerics;
 mod result;
 mod synthesizer;
 mod task;
+mod text_analyzer;
 mod user_dict;
 mod version;
 mod voice_model;
 
 pub mod __internal;
 pub mod blocking;
-pub mod text_analyzer;
 pub mod tokio;
 
 #[cfg(test)]

--- a/crates/voicevox_core/src/test_util.rs
+++ b/crates/voicevox_core/src/test_util.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use crate::Result;
 
-pub async fn open_default_vvm_file() -> crate::tokio::VoiceModel {
+pub(crate) async fn open_default_vvm_file() -> crate::tokio::VoiceModel {
     crate::tokio::VoiceModel::from_path(
         ::test_util::convert_zip_vvm(
             PathBuf::from(env!("CARGO_WORKSPACE_DIR"))

--- a/crates/voicevox_core/src/text_analyzer.rs
+++ b/crates/voicevox_core/src/text_analyzer.rs
@@ -3,13 +3,13 @@ use crate::{
     AccentPhraseModel, FullcontextExtractor, Result,
 };
 
-pub trait TextAnalyzer {
+pub(crate) trait TextAnalyzer {
     fn analyze(&self, text: &str) -> Result<Vec<AccentPhraseModel>>;
 }
 
 /// AquesTalk風記法からAccentPhraseの配列を生成するTextAnalyzer
 #[derive(Clone)]
-pub struct KanaAnalyzer;
+pub(crate) struct KanaAnalyzer;
 
 impl TextAnalyzer for KanaAnalyzer {
     fn analyze(&self, text: &str) -> Result<Vec<AccentPhraseModel>> {
@@ -22,10 +22,10 @@ impl TextAnalyzer for KanaAnalyzer {
 
 /// OpenJtalkからAccentPhraseの配列を生成するTextAnalyzer
 #[derive(Clone)]
-pub struct OpenJTalkAnalyzer<O>(O);
+pub(crate) struct OpenJTalkAnalyzer<O>(O);
 
 impl<O> OpenJTalkAnalyzer<O> {
-    pub fn new(open_jtalk: O) -> Self {
+    pub(crate) fn new(open_jtalk: O) -> Self {
         Self(open_jtalk)
     }
 }

--- a/crates/voicevox_core/src/user_dict/part_of_speech_data.rs
+++ b/crates/voicevox_core/src/user_dict/part_of_speech_data.rs
@@ -1,37 +1,36 @@
-use derive_getters::Getters;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
 
 use crate::UserDictWordType;
 
 /// 最小の優先度。
-pub static MIN_PRIORITY: u32 = 0;
+pub(super) static MIN_PRIORITY: u32 = 0;
 /// 最大の優先度。
-pub static MAX_PRIORITY: u32 = 10;
+pub(super) static MAX_PRIORITY: u32 = 10;
 
 /// 品詞ごとの情報。
-#[derive(Debug, Getters)]
-pub struct PartOfSpeechDetail {
+#[derive(Debug)]
+pub(super) struct PartOfSpeechDetail {
     /// 品詞。
-    pub part_of_speech: &'static str,
+    pub(super) part_of_speech: &'static str,
     /// 品詞細分類1。
-    pub part_of_speech_detail_1: &'static str,
+    pub(super) part_of_speech_detail_1: &'static str,
     /// 品詞細分類2。
-    pub part_of_speech_detail_2: &'static str,
+    pub(super) part_of_speech_detail_2: &'static str,
     /// 品詞細分類3。
-    pub part_of_speech_detail_3: &'static str,
+    pub(super) part_of_speech_detail_3: &'static str,
     /// 文脈IDは辞書の左・右文脈IDのこと。
     ///
     /// 参考: <https://github.com/VOICEVOX/open_jtalk/blob/427cfd761b78efb6094bea3c5bb8c968f0d711ab/src/mecab-naist-jdic/_left-id.def>
-    pub context_id: i32,
+    pub(super) context_id: i32,
     /// コストのパーセンタイル。
-    pub cost_candidates: Vec<i32>,
+    cost_candidates: Vec<i32>,
     /// アクセント結合規則の一覧。
-    pub accent_associative_rules: Vec<&'static str>,
+    _accent_associative_rules: Vec<&'static str>, // unused for now
 }
 
 // 元データ： https://github.com/VOICEVOX/voicevox_engine/blob/master/voicevox_engine/part_of_speech_data.py
-pub static PART_OF_SPEECH_DETAIL: Lazy<HashMap<UserDictWordType, PartOfSpeechDetail>> =
+pub(super) static PART_OF_SPEECH_DETAIL: Lazy<HashMap<UserDictWordType, PartOfSpeechDetail>> =
     Lazy::new(|| {
         HashMap::from_iter([
             (
@@ -45,7 +44,7 @@ pub static PART_OF_SPEECH_DETAIL: Lazy<HashMap<UserDictWordType, PartOfSpeechDet
                     cost_candidates: vec![
                         -988, 3488, 4768, 6048, 7328, 8609, 8734, 8859, 8984, 9110, 14176,
                     ],
-                    accent_associative_rules: vec!["*", "C1", "C2", "C3", "C4", "C5"],
+                    _accent_associative_rules: vec!["*", "C1", "C2", "C3", "C4", "C5"],
                 },
             ),
             (
@@ -59,7 +58,7 @@ pub static PART_OF_SPEECH_DETAIL: Lazy<HashMap<UserDictWordType, PartOfSpeechDet
                     cost_candidates: vec![
                         -4445, 49, 1473, 2897, 4321, 5746, 6554, 7362, 8170, 8979, 15001,
                     ],
-                    accent_associative_rules: vec!["*", "C1", "C2", "C3", "C4", "C5"],
+                    _accent_associative_rules: vec!["*", "C1", "C2", "C3", "C4", "C5"],
                 },
             ),
             (
@@ -73,7 +72,7 @@ pub static PART_OF_SPEECH_DETAIL: Lazy<HashMap<UserDictWordType, PartOfSpeechDet
                     cost_candidates: vec![
                         3100, 6160, 6360, 6561, 6761, 6962, 7414, 7866, 8318, 8771, 13433,
                     ],
-                    accent_associative_rules: vec!["*"],
+                    _accent_associative_rules: vec!["*"],
                 },
             ),
             (
@@ -87,7 +86,7 @@ pub static PART_OF_SPEECH_DETAIL: Lazy<HashMap<UserDictWordType, PartOfSpeechDet
                     cost_candidates: vec![
                         1527, 3266, 3561, 3857, 4153, 4449, 5149, 5849, 6549, 7250, 10001,
                     ],
-                    accent_associative_rules: vec!["*"],
+                    _accent_associative_rules: vec!["*"],
                 },
             ),
             (
@@ -101,7 +100,7 @@ pub static PART_OF_SPEECH_DETAIL: Lazy<HashMap<UserDictWordType, PartOfSpeechDet
                     cost_candidates: vec![
                         4399, 5373, 6041, 6710, 7378, 8047, 9440, 10834, 12228, 13622, 15847,
                     ],
-                    accent_associative_rules: vec!["*", "C1", "C2", "C3", "C4", "C5"],
+                    _accent_associative_rules: vec!["*", "C1", "C2", "C3", "C4", "C5"],
                 },
             ),
         ])
@@ -115,7 +114,7 @@ fn search_cost_candidates(context_id: i32) -> &'static [i32] {
         .cost_candidates
 }
 
-pub fn priority2cost(context_id: i32, priority: u32) -> i32 {
+pub(super) fn priority2cost(context_id: i32, priority: u32) -> i32 {
     let cost_candidates = search_cost_candidates(context_id);
     cost_candidates[(MAX_PRIORITY - priority) as usize]
 }

--- a/crates/voicevox_core/src/user_dict/word.rs
+++ b/crates/voicevox_core/src/user_dict/word.rs
@@ -219,7 +219,7 @@ pub enum UserDictWordType {
 }
 
 impl UserDictWord {
-    pub fn to_mecab_format(&self) -> String {
+    pub(super) fn to_mecab_format(&self) -> String {
         let pos = PART_OF_SPEECH_DETAIL.get(&self.word_type).unwrap();
         format!(
             "{},{},{},{},{},{},{},{},{},{},{},{},{},{}/{},{}",

--- a/crates/voicevox_core_c_api/src/helpers.rs
+++ b/crates/voicevox_core_c_api/src/helpers.rs
@@ -63,7 +63,7 @@ pub(crate) fn into_result_code_with_error(result: CApiResult<()>) -> VoicevoxRes
 pub(crate) type CApiResult<T> = std::result::Result<T, CApiError>;
 
 #[derive(Error, Debug)]
-pub enum CApiError {
+pub(crate) enum CApiError {
     #[error("{0}")]
     RustApi(#[from] voicevox_core::Error),
     #[error("UTF-8として不正な入力です")]

--- a/crates/voicevox_core_java_api/src/common.rs
+++ b/crates/voicevox_core_java_api/src/common.rs
@@ -29,7 +29,7 @@ macro_rules! enum_object {
     };
 }
 
-pub fn throw_if_err<T, F>(mut env: JNIEnv<'_>, fallback: T, inner: F) -> T
+pub(crate) fn throw_if_err<T, F>(mut env: JNIEnv<'_>, fallback: T, inner: F) -> T
 where
     F: FnOnce(&mut JNIEnv<'_>) -> Result<T, JavaApiError>,
 {
@@ -155,7 +155,7 @@ where
 }
 
 #[derive(From, Debug)]
-pub enum JavaApiError {
+pub(crate) enum JavaApiError {
     #[from]
     RustApi(voicevox_core::Error),
 

--- a/crates/voicevox_core_python_api/src/convert.rs
+++ b/crates/voicevox_core_python_api/src/convert.rs
@@ -22,7 +22,7 @@ use crate::{
     UseUserDictError, WordNotFoundError,
 };
 
-pub fn from_acceleration_mode(ob: &PyAny) -> PyResult<AccelerationMode> {
+pub(crate) fn from_acceleration_mode(ob: &PyAny) -> PyResult<AccelerationMode> {
     let py = ob.py();
 
     let class = py.import("voicevox_core")?.getattr("AccelerationMode")?;
@@ -40,7 +40,7 @@ pub fn from_acceleration_mode(ob: &PyAny) -> PyResult<AccelerationMode> {
 }
 
 // FIXME: `UserDict`についてはこれではなく、`PathBuf::extract`を直接使うようにする
-pub fn from_utf8_path(ob: &PyAny) -> PyResult<Utf8PathBuf> {
+pub(crate) fn from_utf8_path(ob: &PyAny) -> PyResult<Utf8PathBuf> {
     PathBuf::extract(ob)?
         .into_os_string()
         .into_string()
@@ -48,7 +48,7 @@ pub fn from_utf8_path(ob: &PyAny) -> PyResult<Utf8PathBuf> {
         .map_err(|s| PyValueError::new_err(format!("{s:?} cannot be encoded to UTF-8")))
 }
 
-pub fn from_dataclass<T: DeserializeOwned>(ob: &PyAny) -> PyResult<T> {
+pub(crate) fn from_dataclass<T: DeserializeOwned>(ob: &PyAny) -> PyResult<T> {
     let py = ob.py();
 
     let ob = py.import("dataclasses")?.call_method1("asdict", (ob,))?;
@@ -59,7 +59,7 @@ pub fn from_dataclass<T: DeserializeOwned>(ob: &PyAny) -> PyResult<T> {
     serde_json::from_str(json).into_py_value_result()
 }
 
-pub fn to_pydantic_voice_model_meta<'py>(
+pub(crate) fn to_pydantic_voice_model_meta<'py>(
     metas: &VoiceModelMeta,
     py: Python<'py>,
 ) -> PyResult<Vec<&'py PyAny>> {
@@ -74,7 +74,7 @@ pub fn to_pydantic_voice_model_meta<'py>(
         .collect::<PyResult<Vec<_>>>()
 }
 
-pub fn to_pydantic_dataclass(x: impl Serialize, class: &PyAny) -> PyResult<&PyAny> {
+pub(crate) fn to_pydantic_dataclass(x: impl Serialize, class: &PyAny) -> PyResult<&PyAny> {
     let py = class.py();
 
     let x = serde_json::to_string(&x).into_py_value_result()?;
@@ -108,7 +108,7 @@ pub(crate) fn blocking_modify_accent_phrases<'py>(
         .collect()
 }
 
-pub fn async_modify_accent_phrases<'py, Fun, Fut>(
+pub(crate) fn async_modify_accent_phrases<'py, Fun, Fut>(
     accent_phrases: &'py PyList,
     speaker_id: StyleId,
     py: Python<'py>,
@@ -145,16 +145,16 @@ where
     )
 }
 
-pub fn to_rust_uuid(ob: &PyAny) -> PyResult<Uuid> {
+pub(crate) fn to_rust_uuid(ob: &PyAny) -> PyResult<Uuid> {
     let uuid = ob.getattr("hex")?.extract::<String>()?;
     uuid.parse::<Uuid>().into_py_value_result()
 }
-pub fn to_py_uuid(py: Python<'_>, uuid: Uuid) -> PyResult<PyObject> {
+pub(crate) fn to_py_uuid(py: Python<'_>, uuid: Uuid) -> PyResult<PyObject> {
     let uuid = uuid.hyphenated().to_string();
     let uuid = py.import("uuid")?.call_method1("UUID", (uuid,))?;
     Ok(uuid.to_object(py))
 }
-pub fn to_rust_user_dict_word(ob: &PyAny) -> PyResult<voicevox_core::UserDictWord> {
+pub(crate) fn to_rust_user_dict_word(ob: &PyAny) -> PyResult<voicevox_core::UserDictWord> {
     voicevox_core::UserDictWord::new(
         ob.getattr("surface")?.extract()?,
         ob.getattr("pronunciation")?.extract()?,
@@ -164,7 +164,7 @@ pub fn to_rust_user_dict_word(ob: &PyAny) -> PyResult<voicevox_core::UserDictWor
     )
     .into_py_result(ob.py())
 }
-pub fn to_py_user_dict_word<'py>(
+pub(crate) fn to_py_user_dict_word<'py>(
     py: Python<'py>,
     word: &voicevox_core::UserDictWord,
 ) -> PyResult<&'py PyAny> {
@@ -174,14 +174,14 @@ pub fn to_py_user_dict_word<'py>(
         .downcast()?;
     to_pydantic_dataclass(word, class)
 }
-pub fn to_rust_word_type(word_type: &PyAny) -> PyResult<UserDictWordType> {
+pub(crate) fn to_rust_word_type(word_type: &PyAny) -> PyResult<UserDictWordType> {
     let name = word_type.getattr("name")?.extract::<String>()?;
 
     serde_json::from_value::<UserDictWordType>(json!(name)).into_py_value_result()
 }
 
 #[ext(VoicevoxCoreResultExt)]
-pub impl<T> voicevox_core::Result<T> {
+pub(crate) impl<T> voicevox_core::Result<T> {
     fn into_py_result(self, py: Python<'_>) -> PyResult<T> {
         use voicevox_core::ErrorKind;
 


### PR DESCRIPTION
## 内容

Rustコードの全アイテムの可視性(_visibility_)を、可能な限り狭めます。
(いくつか見落としがあるかもしれません)

## 関連 Issue

Resolves #594.

## その他
