### PR TITLE
`macos-latest` = `macos-14`に適応する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -277,13 +277,6 @@ jobs:
           pip install --upgrade poetry
           poetry install --with dev --with test
       - run: cargo build -p test_util -vv # build scriptにより/crates/test_util/data/の生成
-      # `macos-latest`(=`macos-12`)で次の問題が発生するため、それに対するワークアラウンド
-      # https://github.com/VOICEVOX/voicevox_core/issues/653#issuecomment-1782108410
-      - if: startsWith(matrix.os, 'mac')
-        name: Build open_jtalk-sys
-        run: |
-          poetry run -- cargo build -p voicevox_core_python_api -vv || true
-          [ -n "$(find ../../target/debug/deps -name 'libopen_jtalk_sys-*.rlib')" ]
       - run: poetry run maturin build --locked
       - run: poetry run maturin develop --locked
       - name: 必要なDLLをコピーしてpytestを実行
@@ -312,7 +305,7 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/rust-toolchain-from-file
       - name: Set up Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: "11"
           distribution: "adopt"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -305,7 +305,7 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/rust-toolchain-from-file
       - name: Set up Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: "11"
           distribution: "adopt"


### PR DESCRIPTION
## 内容

`macos-latest`が`macos-14` (AArch64)になったためそれに対応します。

<https://github.com/qryxip/voicevox_core/actions/runs/8869988493/job/24351267440>

## 関連 Issue

## その他
