### PR TITLE
chore: renovate.jsonの"packagePatterns"を"depPatterns"に

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,12 +8,12 @@
     {
       "groupSlug": "rust",
       "groupName": "Rust",
-      "matchPackagePatterns": "^Rust$"
+      "matchDepPatterns": "^Rust$"
     },
     {
       "groupSlug": "others",
       "groupName": "Others",
-      "excludePackagePatterns": "^Rust$",
+      "excludeDepPatterns": "^Rust$",
       "dependencyDashboardApproval": true
     }
   ],


### PR DESCRIPTION
## 内容

[Renovateのページ](https://developer.mend.io/github/VOICEVOX/voicevox_core)を開いたらこんな表示があったので対応します。ちなみにこのメッセージは、このリポジトリのissueにあるdashboardでも見れます。

![image](https://github.com/VOICEVOX/voicevox_core/assets/14125495/6560f4c7-d082-4670-98e4-3f74edf81b12)

"packagePatterns"と"depPatterns"の違いは以下のような感じらしいです。`^Rust$`は実際"packageName"ではなく"depName"を指していますし、上記のメッセージがその"warning"っぽい(ログを見ても同内容のwarningがある)ので、指示に従って置き換えるのが正解だと思います。

> `matchPackagePatterns` will try matching `packageName` first and then fall back to matching `depName`. If the fallback is used, Renovate will log a warning, because the fallback will be removed in a future release. Use `matchDepPatterns` instead.

[`matchPackagePatterns` - Configuration Options - Renovate Docs](https://docs.renovatebot.com/configuration-options/#matchpackagepatterns)

## 関連 Issue

## その他
