### PR TITLE
change: `manifest_version`を`vvm_format_version`に

### DIFF
--- a/crates/voicevox_core/src/manifest.rs
+++ b/crates/voicevox_core/src/manifest.rs
@@ -1,20 +1,46 @@
-use std::{collections::BTreeMap, fmt::Display, sync::Arc};
+use std::{
+    collections::BTreeMap,
+    fmt::{self, Display},
+    sync::Arc,
+};
 
 use derive_getters::Getters;
 use derive_more::Deref;
 use derive_new::new;
-use serde::{Deserialize, Serialize};
+use serde::{de, Deserialize, Deserializer, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 
 use crate::StyleId;
 
-pub type RawManifestVersion = String;
-#[derive(Deserialize, Clone, Debug, PartialEq, new)]
-pub struct ManifestVersion(RawManifestVersion);
+#[derive(Clone)]
+struct FormatVersionV1;
 
-impl Display for ManifestVersion {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+impl<'de> Deserialize<'de> for FormatVersionV1 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        return deserializer.deserialize_str(Visitor);
+
+        struct Visitor;
+
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = FormatVersionV1;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a string")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                match v {
+                    "1" => Ok(FormatVersionV1),
+                    v => Err(E::custom(format!("未知の`vvm_format_version`です: `{v}`"))),
+                }
+            }
+        }
     }
 }
 
@@ -41,7 +67,7 @@ pub struct Manifest {
     // FIXME: UUIDにする
     // https://github.com/VOICEVOX/voicevox_core/issues/581
     #[allow(dead_code)]
-    manifest_version: ManifestVersion,
+    vvm_format_version: FormatVersionV1,
     metas_filename: String,
     #[serde(flatten)]
     domains: ManifestDomains,
@@ -67,3 +93,35 @@ pub(crate) struct TalkManifest {
 pub(crate) struct StyleIdToModelInnerId(
     #[serde_as(as = "Arc<BTreeMap<DisplayFromStr, _>>")] Arc<BTreeMap<StyleId, ModelInnerId>>,
 );
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Deref;
+
+    use rstest::rstest;
+    use serde::Deserialize;
+
+    use super::FormatVersionV1;
+
+    #[rstest]
+    #[case("{\"vvm_format_version\":\"1\"}", Ok(()))]
+    #[case(
+        "{\"vvm_format_version\":\"2\"}",
+        Err("未知の`vvm_format_version`です: `2` at line 1 column 25")
+    )]
+    fn vvm_format_version_works(
+        #[case] input: &str,
+        #[case] expected: Result<(), &str>,
+    ) -> anyhow::Result<()> {
+        let actual = serde_json::from_str::<ManifestPart>(input).map_err(|e| e.to_string());
+        let actual = actual.as_ref().map(|_| ()).map_err(Deref::deref);
+        assert_eq!(expected, actual);
+        return Ok(());
+
+        #[derive(Deserialize)]
+        struct ManifestPart {
+            #[allow(dead_code)]
+            vvm_format_version: FormatVersionV1,
+        }
+    }
+}

--- a/model/sample.vvm/manifest.json
+++ b/model/sample.vvm/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": "0.0.0",
+  "vvm_format_version": "1",
   "metas_filename": "metas.json",
   "talk": {
     "predict_duration_filename": "predict_duration.onnx",


### PR DESCRIPTION
## 内容

<https://github.com/VOICEVOX/voicevox_core/issues/581#issuecomment-1837168657>の1.です。`manifest_version` (SemVer)を`vvm_format_version` (整数値を文字列化したもの)にします。

実装は<https://github.com/VOICEVOX/voicevox_core/issues/581#issuecomment-1837447739>で書いたやつの冗長な方を持って来ました。
(エラーメッセージにこだわらないのなら`enum`のやつでもいいかもしれません)

## 関連 Issue

ref #581

## その他
