### PR TITLE
change: `style_id_to_model_inner_id` → `style_id_to_inner_voice_id`

### DIFF
--- a/crates/voicevox_core/src/manifest.rs
+++ b/crates/voicevox_core/src/manifest.rs
@@ -19,18 +19,18 @@ impl Display for ManifestVersion {
 }
 
 /// モデル内IDの実体
-pub type RawModelInnerId = u32;
+pub type RawInnerVoiceId = u32;
 /// モデル内ID
 #[derive(PartialEq, Eq, Clone, Copy, Ord, PartialOrd, Deserialize, Serialize, new, Debug)]
-pub struct ModelInnerId(RawModelInnerId);
+pub struct InnerVoiceId(RawInnerVoiceId);
 
-impl ModelInnerId {
-    pub fn raw_id(self) -> RawModelInnerId {
+impl InnerVoiceId {
+    pub fn raw_id(self) -> RawInnerVoiceId {
         self.0
     }
 }
 
-impl Display for ModelInnerId {
+impl Display for InnerVoiceId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.raw_id())
     }
@@ -58,12 +58,12 @@ pub(crate) struct TalkManifest {
     pub(crate) predict_intonation_filename: String,
     pub(crate) decode_filename: String,
     #[serde(default)]
-    pub(crate) style_id_to_model_inner_id: StyleIdToModelInnerId,
+    pub(crate) style_id_to_inner_voice_id: StyleIdToInnerVoiceId,
 }
 
 #[serde_as]
 #[derive(Default, Clone, Deref, Deserialize)]
 #[deref(forward)]
-pub(crate) struct StyleIdToModelInnerId(
-    #[serde_as(as = "Arc<BTreeMap<DisplayFromStr, _>>")] Arc<BTreeMap<StyleId, ModelInnerId>>,
+pub(crate) struct StyleIdToInnerVoiceId(
+    #[serde_as(as = "Arc<BTreeMap<DisplayFromStr, _>>")] Arc<BTreeMap<StyleId, InnerVoiceId>>,
 );

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -836,7 +836,7 @@ pub(crate) mod blocking {
 
     impl<O> PerformInference for self::Synthesizer<O> {
         fn predict_duration(&self, phoneme_vector: &[i64], style_id: StyleId) -> Result<Vec<f32>> {
-            let (model_id, model_inner_id) = self.status.ids_for::<TalkDomain>(style_id)?;
+            let (model_id, inner_voice_id) = self.status.ids_for::<TalkDomain>(style_id)?;
 
             let PredictDurationOutput {
                 phoneme_length: output,
@@ -844,7 +844,7 @@ pub(crate) mod blocking {
                 &model_id,
                 PredictDurationInput {
                     phoneme_list: ndarray::arr1(phoneme_vector),
-                    speaker_id: ndarray::arr1(&[model_inner_id.raw_id().into()]),
+                    speaker_id: ndarray::arr1(&[inner_voice_id.raw_id().into()]),
                 },
             )?;
             let mut output = output.into_raw_vec();
@@ -871,7 +871,7 @@ pub(crate) mod blocking {
             end_accent_phrase_vector: &[i64],
             style_id: StyleId,
         ) -> Result<Vec<f32>> {
-            let (model_id, model_inner_id) = self.status.ids_for::<TalkDomain>(style_id)?;
+            let (model_id, inner_voice_id) = self.status.ids_for::<TalkDomain>(style_id)?;
 
             let PredictIntonationOutput { f0_list: output } = self.status.run_session(
                 &model_id,
@@ -883,7 +883,7 @@ pub(crate) mod blocking {
                     end_accent_list: ndarray::arr1(end_accent_vector),
                     start_accent_phrase_list: ndarray::arr1(start_accent_phrase_vector),
                     end_accent_phrase_list: ndarray::arr1(end_accent_phrase_vector),
-                    speaker_id: ndarray::arr1(&[model_inner_id.raw_id().into()]),
+                    speaker_id: ndarray::arr1(&[inner_voice_id.raw_id().into()]),
                 },
             )?;
 
@@ -898,7 +898,7 @@ pub(crate) mod blocking {
             phoneme_vector: &[f32],
             style_id: StyleId,
         ) -> Result<Vec<f32>> {
-            let (model_id, model_inner_id) = self.status.ids_for::<TalkDomain>(style_id)?;
+            let (model_id, inner_voice_id) = self.status.ids_for::<TalkDomain>(style_id)?;
 
             // 音が途切れてしまうのを避けるworkaround処理が入っている
             // TODO: 改善したらここのpadding処理を取り除く
@@ -925,7 +925,7 @@ pub(crate) mod blocking {
                     phoneme: ndarray::arr1(&phoneme_with_padding)
                         .into_shape([length_with_padding, phoneme_size])
                         .unwrap(),
-                    speaker_id: ndarray::arr1(&[model_inner_id.raw_id().into()]),
+                    speaker_id: ndarray::arr1(&[inner_voice_id.raw_id().into()]),
                 },
             )?;
 

--- a/model/sample.vvm/manifest.json
+++ b/model/sample.vvm/manifest.json
@@ -5,7 +5,7 @@
     "predict_duration_filename": "predict_duration.onnx",
     "predict_intonation_filename": "predict_intonation.onnx",
     "decode_filename": "decode.onnx",
-    "style_id_to_model_inner_id": {
+    "style_id_to_inner_voice_id": {
       "302": 2,
       "303": 3
     }


### PR DESCRIPTION
## 内容

<https://github.com/VOICEVOX/voicevox_core/issues/581#issuecomment-1837168657>の2.です。`style_id_to_model_inner_id`を`style_id_to_inner_voice_id`にします。

## 関連 Issue

ref #581

## その他
