### PR TITLE
change: VVMにUUIDを割り振り、それを`VoiceModelId`とする

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1823,15 +1823,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nanoid"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
-dependencies = [
- "rand",
-]
-
-[[package]]
 name = "ndarray"
 version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3587,7 +3578,6 @@ dependencies = [
  "indexmap 2.0.0",
  "itertools 0.10.5",
  "jlabel",
- "nanoid",
  "ndarray",
  "once_cell",
  "open_jtalk",
@@ -3662,6 +3652,7 @@ dependencies = [
  "android_logger",
  "chrono",
  "derive_more",
+ "easy-ext",
  "jni",
  "once_cell",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ libc = "0.2.134"
 libloading = "0.7.3"
 libtest-mimic = "0.6.0"
 log = "0.4.17"
-nanoid = "0.4.0"
 ndarray = "0.15.6"
 ndarray-stats = "0.5.1"
 octocrab = { version = "0.19.0", default-features = false }

--- a/crates/voicevox_core/Cargo.toml
+++ b/crates/voicevox_core/Cargo.toml
@@ -25,7 +25,6 @@ futures.workspace = true
 indexmap = { workspace = true, features = ["serde"] }
 itertools.workspace = true
 jlabel.workspace = true
-nanoid.workspace = true
 ndarray.workspace = true
 once_cell.workspace = true
 open_jtalk.workspace = true

--- a/crates/voicevox_core/src/__internal/interop.rs
+++ b/crates/voicevox_core/src/__internal/interop.rs
@@ -1,1 +1,4 @@
-pub use crate::{metas::merge as merge_metas, synthesizer::blocking::PerformInference};
+pub use crate::{
+    metas::merge as merge_metas, synthesizer::blocking::PerformInference,
+    voice_model::blocking::IdRef,
+};

--- a/crates/voicevox_core/src/manifest.rs
+++ b/crates/voicevox_core/src/manifest.rs
@@ -6,7 +6,7 @@ use derive_new::new;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 
-use crate::StyleId;
+use crate::{StyleId, VoiceModelId};
 
 pub type RawManifestVersion = String;
 #[derive(Deserialize, Clone, Debug, PartialEq, new)]
@@ -38,10 +38,9 @@ impl Display for ModelInnerId {
 
 #[derive(Deserialize, Getters, Clone)]
 pub struct Manifest {
-    // FIXME: UUIDにする
-    // https://github.com/VOICEVOX/voicevox_core/issues/581
     #[allow(dead_code)]
     manifest_version: ManifestVersion,
+    pub(crate) id: VoiceModelId,
     metas_filename: String,
     #[serde(flatten)]
     domains: ManifestDomains,

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -207,12 +207,12 @@ pub(crate) mod blocking {
         }
 
         /// 音声モデルの読み込みを解除する。
-        pub fn unload_voice_model(&self, voice_model_id: &VoiceModelId) -> Result<()> {
+        pub fn unload_voice_model(&self, voice_model_id: VoiceModelId) -> Result<()> {
             self.status.unload_model(voice_model_id)
         }
 
         /// 指定したIDの音声モデルが読み込まれているか判定する。
-        pub fn is_loaded_voice_model(&self, voice_model_id: &VoiceModelId) -> bool {
+        pub fn is_loaded_voice_model(&self, voice_model_id: VoiceModelId) -> bool {
             self.status.is_loaded_model(voice_model_id)
         }
 
@@ -841,7 +841,7 @@ pub(crate) mod blocking {
             let PredictDurationOutput {
                 phoneme_length: output,
             } = self.status.run_session(
-                &model_id,
+                model_id,
                 PredictDurationInput {
                     phoneme_list: ndarray::arr1(phoneme_vector),
                     speaker_id: ndarray::arr1(&[model_inner_id.raw_id().into()]),
@@ -874,7 +874,7 @@ pub(crate) mod blocking {
             let (model_id, model_inner_id) = self.status.ids_for::<TalkDomain>(style_id)?;
 
             let PredictIntonationOutput { f0_list: output } = self.status.run_session(
-                &model_id,
+                model_id,
                 PredictIntonationInput {
                     length: ndarray::arr0(length as i64),
                     vowel_phoneme_list: ndarray::arr1(vowel_phoneme_vector),
@@ -917,7 +917,7 @@ pub(crate) mod blocking {
             );
 
             let DecodeOutput { wave: output } = self.status.run_session(
-                &model_id,
+                model_id,
                 DecodeInput {
                     f0: ndarray::arr1(&f0_with_padding)
                         .into_shape([length_with_padding, 1])
@@ -1150,11 +1150,11 @@ pub(crate) mod tokio {
             self.0.status.insert_model(model.header(), model_bytes)
         }
 
-        pub fn unload_voice_model(&self, voice_model_id: &VoiceModelId) -> Result<()> {
+        pub fn unload_voice_model(&self, voice_model_id: VoiceModelId) -> Result<()> {
             self.0.unload_voice_model(voice_model_id)
         }
 
-        pub fn is_loaded_voice_model(&self, voice_model_id: &VoiceModelId) -> bool {
+        pub fn is_loaded_voice_model(&self, voice_model_id: VoiceModelId) -> bool {
             self.0.is_loaded_voice_model(voice_model_id)
         }
 

--- a/crates/voicevox_core/src/voice_model.rs
+++ b/crates/voicevox_core/src/voice_model.rs
@@ -4,11 +4,13 @@
 
 use anyhow::anyhow;
 use derive_getters::Getters;
+use derive_more::From;
 use derive_new::new;
 use easy_ext::ext;
 use enum_map::EnumMap;
 use itertools::Itertools as _;
 use serde::Deserialize;
+use uuid::Uuid;
 
 use crate::{
     error::{LoadModelError, LoadModelErrorKind, LoadModelResult},
@@ -24,7 +26,7 @@ use std::path::{Path, PathBuf};
 /// [`VoiceModelId`]の実体。
 ///
 /// [`VoiceModelId`]: VoiceModelId
-pub type RawVoiceModelId = String;
+pub type RawVoiceModelId = Uuid;
 
 pub(crate) type ModelBytesWithInnerIdsByDomain =
     (Option<(StyleIdToModelInnerId, EnumMap<TalkOperation, Vec<u8>>)>,);
@@ -34,6 +36,7 @@ pub(crate) type ModelBytesWithInnerIdsByDomain =
     PartialEq,
     Eq,
     Clone,
+    Copy,
     Ord,
     Hash,
     PartialOrd,
@@ -42,7 +45,9 @@ pub(crate) type ModelBytesWithInnerIdsByDomain =
     Getters,
     derive_more::Display,
     Debug,
+    From,
 )]
+#[serde(transparent)]
 pub struct VoiceModelId {
     raw_voice_model_id: RawVoiceModelId,
 }
@@ -53,9 +58,7 @@ pub struct VoiceModelId {
 /// モデルの`[u8]`と分けて`Status`に渡す。
 #[derive(Clone)]
 pub(crate) struct VoiceModelHeader {
-    /// ID。
-    pub(crate) id: VoiceModelId,
-    manifest: Manifest,
+    pub(crate) manifest: Manifest,
     /// メタ情報。
     ///
     /// `manifest`が対応していない`StyleType`のスタイルは含まれるべきではない。
@@ -64,12 +67,7 @@ pub(crate) struct VoiceModelHeader {
 }
 
 impl VoiceModelHeader {
-    fn new(
-        id: VoiceModelId,
-        manifest: Manifest,
-        metas: &[u8],
-        path: &Path,
-    ) -> LoadModelResult<Self> {
+    fn new(manifest: Manifest, metas: &[u8], path: &Path) -> LoadModelResult<Self> {
         let metas =
             serde_json::from_slice::<VoiceModelMeta>(metas).map_err(|source| LoadModelError {
                 path: path.to_owned(),
@@ -94,7 +92,6 @@ impl VoiceModelHeader {
             })?;
 
         Ok(Self {
-            id,
             manifest,
             metas,
             path: path.to_owned(),
@@ -151,8 +148,8 @@ pub(crate) mod blocking {
         path::Path,
     };
 
+    use easy_ext::ext;
     use enum_map::EnumMap;
-    use nanoid::nanoid;
     use ouroboros::self_referencing;
     use rayon::iter::{IntoParallelIterator as _, ParallelIterator as _};
     use serde::de::DeserializeOwned;
@@ -220,14 +217,13 @@ pub(crate) mod blocking {
             let reader = BlockingVvmEntryReader::open(path)?;
             let manifest = reader.read_vvm_json::<Manifest>("manifest.json")?;
             let metas = &reader.read_vvm_entry(manifest.metas_filename())?;
-            let id = VoiceModelId::new(nanoid!());
-            let header = VoiceModelHeader::new(id, manifest, metas, path)?;
+            let header = VoiceModelHeader::new(manifest, metas, path)?;
             Ok(Self { header })
         }
 
         /// ID。
-        pub fn id(&self) -> &VoiceModelId {
-            &self.header.id
+        pub fn id(&self) -> VoiceModelId {
+            self.header.manifest.id
         }
 
         /// メタ情報。
@@ -289,6 +285,13 @@ pub(crate) mod blocking {
             })
         }
     }
+
+    #[ext(IdRef)]
+    pub impl VoiceModel {
+        fn id_ref(&self) -> &VoiceModelId {
+            &self.header.manifest.id
+        }
+    }
 }
 
 pub(crate) mod tokio {
@@ -297,7 +300,6 @@ pub(crate) mod tokio {
     use derive_new::new;
     use enum_map::EnumMap;
     use futures::future::{join3, OptionFuture};
-    use nanoid::nanoid;
     use serde::de::DeserializeOwned;
 
     use crate::{
@@ -360,14 +362,13 @@ pub(crate) mod tokio {
             let reader = AsyncVvmEntryReader::open(path.as_ref()).await?;
             let manifest = reader.read_vvm_json::<Manifest>("manifest.json").await?;
             let metas = &reader.read_vvm_entry(manifest.metas_filename()).await?;
-            let id = VoiceModelId::new(nanoid!());
-            let header = VoiceModelHeader::new(id, manifest, metas, path.as_ref())?;
+            let header = VoiceModelHeader::new(manifest, metas, path.as_ref())?;
             Ok(Self { header })
         }
 
         /// ID。
-        pub fn id(&self) -> &VoiceModelId {
-            &self.header.id
+        pub fn id(&self) -> VoiceModelId {
+            self.header.manifest.id
         }
 
         /// メタ情報。

--- a/crates/voicevox_core_c_api/Cargo.toml
+++ b/crates/voicevox_core_c_api/Cargo.toml
@@ -24,6 +24,7 @@ chrono = { workspace = true, default-features = false, features = ["clock"] }
 colorchoice.workspace = true
 cstr.workspace = true
 derive-getters.workspace = true
+easy-ext.workspace = true
 futures.workspace = true
 itertools.workspace = true
 libc.workspace = true

--- a/crates/voicevox_core_c_api/include/voicevox_core.h
+++ b/crates/voicevox_core_c_api/include/voicevox_core.h
@@ -277,7 +277,7 @@ typedef struct VoicevoxInitializeOptions {
 /**
  * 音声モデルID。
  */
-typedef const char *VoicevoxVoiceModelId;
+typedef const uint8_t (*VoicevoxVoiceModelId)[16];
 
 /**
  * スタイルID。
@@ -554,7 +554,7 @@ VoicevoxResultCode voicevox_synthesizer_load_voice_model(const struct VoicevoxSy
  *
  * \safety{
  * - `synthesizer`は ::voicevox_synthesizer_new で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
- * - `model_id`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
+ * - `model_id`は<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * }
  */
 #ifdef _WIN32
@@ -589,7 +589,7 @@ bool voicevox_synthesizer_is_gpu_mode(const struct VoicevoxSynthesizer *synthesi
  *
  * \safety{
  * - `synthesizer`は ::voicevox_synthesizer_new で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
- * - `model_id`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
+ * - `model_id`は<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * }
  */
 #ifdef _WIN32

--- a/crates/voicevox_core_c_api/src/c_impls.rs
+++ b/crates/voicevox_core_c_api/src/c_impls.rs
@@ -5,6 +5,9 @@ use voicevox_core::{InitializeOptions, Result, VoiceModelId};
 
 use crate::{helpers::CApiResult, OpenJtalkRc, VoicevoxSynthesizer, VoicevoxVoiceModel};
 
+// FIXME: 中身(Rust API)を直接操作するかラッパーメソッド越しにするのかが混在していて、一貫性を
+// 欠いている
+
 impl OpenJtalkRc {
     pub(crate) fn new(open_jtalk_dic_dir: impl AsRef<Utf8Path>) -> Result<Self> {
         Ok(Self {
@@ -28,7 +31,7 @@ impl VoicevoxSynthesizer {
         Ok(())
     }
 
-    pub(crate) fn unload_voice_model(&self, model_id: &VoiceModelId) -> Result<()> {
+    pub(crate) fn unload_voice_model(&self, model_id: VoiceModelId) -> Result<()> {
         self.synthesizer.unload_voice_model(model_id)?;
         Ok(())
     }
@@ -42,8 +45,7 @@ impl VoicevoxSynthesizer {
 impl VoicevoxVoiceModel {
     pub(crate) fn from_path(path: impl AsRef<Path>) -> Result<Self> {
         let model = voicevox_core::blocking::VoiceModel::from_path(path)?;
-        let id = CString::new(model.id().raw_voice_model_id().as_str()).unwrap();
         let metas = CString::new(serde_json::to_string(model.metas()).unwrap()).unwrap();
-        Ok(Self { model, id, metas })
+        Ok(Self { model, metas })
     }
 }

--- a/crates/voicevox_core_c_api/src/compatible_engine.rs
+++ b/crates/voicevox_core_c_api/src/compatible_engine.rs
@@ -37,10 +37,7 @@ struct VoiceModelSet {
 
 static VOICE_MODEL_SET: Lazy<VoiceModelSet> = Lazy::new(|| {
     let all_vvms = get_all_models();
-    let model_map: BTreeMap<_, _> = all_vvms
-        .iter()
-        .map(|vvm| (vvm.id().clone(), vvm.clone()))
-        .collect();
+    let model_map: BTreeMap<_, _> = all_vvms.iter().map(|vvm| (vvm.id(), vvm.clone())).collect();
     let metas = voicevox_core::__internal::interop::merge_metas(
         all_vvms.iter().flat_map(|vvm| vvm.metas()),
     );
@@ -48,7 +45,7 @@ static VOICE_MODEL_SET: Lazy<VoiceModelSet> = Lazy::new(|| {
     for vvm in all_vvms.iter() {
         for meta in vvm.metas().iter() {
             for style in meta.styles().iter() {
-                style_model_map.insert(*style.id(), vvm.id().clone());
+                style_model_map.insert(*style.id(), vvm.id());
             }
         }
     }

--- a/crates/voicevox_core_c_api/src/helpers.rs
+++ b/crates/voicevox_core_c_api/src/helpers.rs
@@ -1,5 +1,7 @@
+use easy_ext::ext;
 use std::{error::Error as _, ffi::CStr, fmt::Debug, iter};
-use voicevox_core::{AudioQueryModel, UserDictWord};
+use uuid::Uuid;
+use voicevox_core::{AudioQueryModel, UserDictWord, VoiceModelId};
 
 use thiserror::Error;
 use tracing::error;
@@ -160,6 +162,13 @@ impl Default for VoicevoxSynthesisOptions {
         Self {
             enable_interrogative_upspeak: options.enable_interrogative_upspeak,
         }
+    }
+}
+
+#[ext(UuidBytesExt)]
+pub(crate) impl uuid::Bytes {
+    fn to_model_id(self) -> VoiceModelId {
+        Uuid::from_bytes(self).into()
     }
 }
 

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -12,7 +12,7 @@ mod slice_owner;
 use self::drop_check::C_STRING_DROP_CHECKER;
 use self::helpers::{
     accent_phrases_to_json, audio_query_model_to_json, ensure_utf8, into_result_code_with_error,
-    CApiError,
+    CApiError, UuidBytesExt as _,
 };
 use self::result_code::VoicevoxResultCode;
 use self::slice_owner::U8_SLICE_OWNER;
@@ -30,7 +30,8 @@ use std::sync::{Arc, Once};
 use tracing_subscriber::fmt::format::Writer;
 use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
-use voicevox_core::{AccentPhraseModel, AudioQueryModel, TtsOptions, UserDictWord, VoiceModelId};
+use voicevox_core::__internal::interop::IdRef as _;
+use voicevox_core::{AccentPhraseModel, AudioQueryModel, TtsOptions, UserDictWord};
 use voicevox_core::{StyleId, SupportedDevices, SynthesisOptions};
 
 fn init_logger_once() {
@@ -238,12 +239,11 @@ pub extern "C" fn voicevox_get_version() -> *const c_char {
 #[derive(Getters)]
 pub struct VoicevoxVoiceModel {
     model: voicevox_core::blocking::VoiceModel,
-    id: CString,
     metas: CString,
 }
 
 /// 音声モデルID。
-pub type VoicevoxVoiceModelId = *const c_char;
+pub type VoicevoxVoiceModelId<'a> = &'a [u8; 16];
 
 /// スタイルID。
 ///
@@ -285,9 +285,9 @@ pub unsafe extern "C" fn voicevox_voice_model_new_from_path(
 /// - `model`は ::voicevox_voice_model_new_from_path で得たものでなければならず、また ::voicevox_voice_model_delete で解放されていてはいけない。
 /// }
 #[no_mangle]
-pub extern "C" fn voicevox_voice_model_id(model: &VoicevoxVoiceModel) -> VoicevoxVoiceModelId {
+pub extern "C" fn voicevox_voice_model_id(model: &VoicevoxVoiceModel) -> VoicevoxVoiceModelId<'_> {
     init_logger_once();
-    model.id().as_ptr()
+    model.model.id_ref().raw_voice_model_id().as_bytes()
 }
 
 /// ::VoicevoxVoiceModel からメタ情報を取得する。
@@ -399,20 +399,16 @@ pub extern "C" fn voicevox_synthesizer_load_voice_model(
 ///
 /// \safety{
 /// - `synthesizer`は ::voicevox_synthesizer_new で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
-/// - `model_id`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
+/// - `model_id`は<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
 /// }
 #[no_mangle]
-pub unsafe extern "C" fn voicevox_synthesizer_unload_voice_model(
+pub extern "C" fn voicevox_synthesizer_unload_voice_model(
     synthesizer: &VoicevoxSynthesizer,
-    model_id: VoicevoxVoiceModelId,
+    model_id: VoicevoxVoiceModelId<'_>,
 ) -> VoicevoxResultCode {
     init_logger_once();
-    into_result_code_with_error((|| {
-        let raw_model_id = ensure_utf8(unsafe { CStr::from_ptr(model_id) })?;
-        synthesizer
-            .unload_voice_model(&VoiceModelId::new(raw_model_id.to_string()))
-            .map_err(Into::into)
-    })())
+    let model_id = model_id.to_model_id();
+    into_result_code_with_error(synthesizer.unload_voice_model(model_id).map_err(Into::into))
 }
 
 /// ハードウェアアクセラレーションがGPUモードか判定する。
@@ -439,21 +435,16 @@ pub extern "C" fn voicevox_synthesizer_is_gpu_mode(synthesizer: &VoicevoxSynthes
 ///
 /// \safety{
 /// - `synthesizer`は ::voicevox_synthesizer_new で得たものでなければならず、また ::voicevox_synthesizer_delete で解放されていてはいけない。
-/// - `model_id`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
+/// - `model_id`は<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
 /// }
 #[no_mangle]
-pub unsafe extern "C" fn voicevox_synthesizer_is_loaded_voice_model(
+pub extern "C" fn voicevox_synthesizer_is_loaded_voice_model(
     synthesizer: &VoicevoxSynthesizer,
-    model_id: VoicevoxVoiceModelId,
+    model_id: VoicevoxVoiceModelId<'_>,
 ) -> bool {
     init_logger_once();
-    let Ok(raw_model_id) = ensure_utf8(unsafe { CStr::from_ptr(model_id) }) else {
-        // 与えられたIDがUTF-8ではない場合、それに対応する`VoicdModel`は確実に存在しない
-        return false;
-    };
-    synthesizer
-        .synthesizer()
-        .is_loaded_voice_model(&VoiceModelId::new(raw_model_id.into()))
+    let model_id = model_id.to_model_id();
+    synthesizer.synthesizer().is_loaded_voice_model(model_id)
 }
 
 /// 今読み込んでいる音声モデルのメタ情報を、JSONで取得する。

--- a/crates/voicevox_core_java_api/Cargo.toml
+++ b/crates/voicevox_core_java_api/Cargo.toml
@@ -15,6 +15,7 @@ directml = ["voicevox_core/directml"]
 android_logger.workspace = true
 chrono = { workspace = true, default-features = false, features = ["clock"] }
 derive_more.workspace = true
+easy-ext.workspace = true
 jni.workspace = true
 once_cell.workspace = true
 serde_json = { workspace = true, features = ["preserve_order"] }

--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/Synthesizer.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/Synthesizer.java
@@ -5,6 +5,7 @@ import jakarta.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 import jp.hiroshiba.voicevoxcore.exceptions.InferenceFailedException;
 import jp.hiroshiba.voicevoxcore.exceptions.InvalidModelDataException;
 
@@ -65,7 +66,7 @@ public class Synthesizer extends Dll {
    *
    * @param voiceModelId 読み込みを解除する音声モデルのID。
    */
-  public void unloadVoiceModel(String voiceModelId) {
+  public void unloadVoiceModel(UUID voiceModelId) {
     rsUnloadVoiceModel(voiceModelId);
   }
 
@@ -75,7 +76,7 @@ public class Synthesizer extends Dll {
    * @param voiceModelId 音声モデルのID。
    * @return 指定した音声モデルのIDが読み込まれているかどうか。
    */
-  public boolean isLoadedVoiceModel(String voiceModelId) {
+  public boolean isLoadedVoiceModel(UUID voiceModelId) {
     return rsIsLoadedVoiceModel(voiceModelId);
   }
 
@@ -274,9 +275,9 @@ public class Synthesizer extends Dll {
 
   private native void rsLoadVoiceModel(VoiceModel voiceModel) throws InvalidModelDataException;
 
-  private native void rsUnloadVoiceModel(String voiceModelId);
+  private native void rsUnloadVoiceModel(UUID voiceModelId);
 
-  private native boolean rsIsLoadedVoiceModel(String voiceModelId);
+  private native boolean rsIsLoadedVoiceModel(UUID voiceModelId);
 
   @Nonnull
   private native String rsAudioQueryFromKana(String kana, int styleId)

--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/VoiceModel.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/VoiceModel.java
@@ -5,13 +5,14 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import java.util.UUID;
 
 /** 音声モデル。 */
 public class VoiceModel extends Dll {
   private long handle;
 
   /** ID。 */
-  @Nonnull public final String id;
+  @Nonnull public final UUID id;
 
   /** メタ情報。 */
   @Nonnull public final SpeakerMeta[] metas;
@@ -36,7 +37,7 @@ public class VoiceModel extends Dll {
   private native void rsFromPath(String modelPath);
 
   @Nonnull
-  private native String rsGetId();
+  private native UUID rsGetId();
 
   @Nonnull
   private native String rsGetMetasJson();

--- a/crates/voicevox_core_java_api/src/synthesizer.rs
+++ b/crates/voicevox_core_java_api/src/synthesizer.rs
@@ -1,5 +1,5 @@
 use crate::{
-    common::{throw_if_err, JavaApiError},
+    common::{throw_if_err, JNIEnvExt as _, JavaApiError},
     enum_object, object, object_type,
 };
 
@@ -115,10 +115,10 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsLoadVoice
 unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsUnloadVoiceModel<'local>(
     env: JNIEnv<'local>,
     this: JObject<'local>,
-    model_id: JString<'local>,
+    model_id: JObject<'local>,
 ) {
     throw_if_err(env, (), |env| {
-        let model_id: String = env.get_string(&model_id)?.into();
+        let model_id = env.get_uuid(&model_id)?.into();
 
         let internal = env
             .get_rust_field::<_, _, Arc<voicevox_core::blocking::Synthesizer<voicevox_core::blocking::OpenJtalk>>>(
@@ -126,7 +126,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsUnloadVoi
             )?
             .clone();
 
-        internal.unload_voice_model(&voicevox_core::VoiceModelId::new(model_id))?;
+        internal.unload_voice_model(model_id)?;
 
         Ok(())
     })
@@ -138,10 +138,10 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsIsLoadedV
 >(
     env: JNIEnv<'local>,
     this: JObject<'local>,
-    model_id: JString<'local>,
+    model_id: JObject<'local>,
 ) -> jboolean {
     throw_if_err(env, false, |env| {
-        let model_id: String = env.get_string(&model_id)?.into();
+        let model_id = env.get_uuid(&model_id)?.into();
 
         let internal = env
             .get_rust_field::<_, _, Arc<voicevox_core::blocking::Synthesizer<voicevox_core::blocking::OpenJtalk>>>(
@@ -149,7 +149,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsIsLoadedV
             )?
             .clone();
 
-        let is_loaded = internal.is_loaded_voice_model(&voicevox_core::VoiceModelId::new(model_id));
+        let is_loaded = internal.is_loaded_voice_model(model_id);
 
         Ok(is_loaded)
     })

--- a/crates/voicevox_core_java_api/src/voice_model.rs
+++ b/crates/voicevox_core_java_api/src/voice_model.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, sync::Arc};
 
-use crate::common::throw_if_err;
+use crate::common::{throw_if_err, JNIEnvExt as _};
 use jni::{
     objects::{JObject, JString},
     sys::jobject,
@@ -35,9 +35,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_VoiceModel_rsGetId<'loc
             .get_rust_field::<_, _, Arc<voicevox_core::blocking::VoiceModel>>(&this, "handle")?
             .clone();
 
-        let id = internal.id().raw_voice_model_id();
-
-        let id = env.new_string(id)?;
+        let id = env.new_uuid(*internal.id().raw_voice_model_id())?;
 
         Ok(id.into_raw())
     })

--- a/crates/voicevox_core_python_api/python/voicevox_core/_models.py
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_models.py
@@ -1,6 +1,7 @@
 import dataclasses
 from enum import Enum
 from typing import List, NewType, Optional
+from uuid import UUID
 
 import pydantic
 
@@ -24,13 +25,13 @@ Parameters
 x : str
 """
 
-VoiceModelId = NewType("VoiceModelId", str)
+VoiceModelId = NewType("VoiceModelId", UUID)
 """
 音声モデルID。
 
 Parameters
 ----------
-x : str
+x : UUID
 """
 
 

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/asyncio.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/asyncio.pyi
@@ -109,7 +109,7 @@ class Synthesizer:
             読み込むモデルのスタイルID。
         """
         ...
-    def unload_voice_model(self, voice_model_id: Union[VoiceModelId, str]) -> None:
+    def unload_voice_model(self, voice_model_id: Union[VoiceModelId, UUID]) -> None:
         """
         音声モデルの読み込みを解除する。
 
@@ -119,7 +119,7 @@ class Synthesizer:
             音声モデルID。
         """
         ...
-    def is_loaded_voice_model(self, voice_model_id: Union[VoiceModelId, str]) -> bool:
+    def is_loaded_voice_model(self, voice_model_id: Union[VoiceModelId, UUID]) -> bool:
         """
         指定したvoice_model_idのモデルが読み込まれているか判定する。
 

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
@@ -104,7 +104,7 @@ class Synthesizer:
             読み込むモデルのスタイルID。
         """
         ...
-    def unload_voice_model(self, voice_model_id: Union[VoiceModelId, str]) -> None:
+    def unload_voice_model(self, voice_model_id: Union[VoiceModelId, UUID]) -> None:
         """
         音声モデルの読み込みを解除する。
 
@@ -114,7 +114,7 @@ class Synthesizer:
             音声モデルID。
         """
         ...
-    def is_loaded_voice_model(self, voice_model_id: Union[VoiceModelId, str]) -> bool:
+    def is_loaded_voice_model(self, voice_model_id: Union[VoiceModelId, UUID]) -> bool:
         """
         指定したvoice_model_idのモデルが読み込まれているか判定する。
 

--- a/crates/voicevox_core_python_api/src/convert.rs
+++ b/crates/voicevox_core_python_api/src/convert.rs
@@ -149,6 +149,7 @@ pub(crate) fn to_rust_uuid(ob: &PyAny) -> PyResult<Uuid> {
     let uuid = ob.getattr("hex")?.extract::<String>()?;
     uuid.parse::<Uuid>().into_py_value_result()
 }
+// FIXME: `to_object`は必要無いのでは?
 pub(crate) fn to_py_uuid(py: Python<'_>, uuid: Uuid) -> PyResult<PyObject> {
     let uuid = uuid.hyphenated().to_string();
     let uuid = py.import("uuid")?.call_method1("UUID", (uuid,))?;

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -154,13 +154,13 @@ mod blocking {
     use camino::Utf8PathBuf;
     use pyo3::{
         pyclass, pymethods,
-        types::{IntoPyDict as _, PyBytes, PyDict, PyList, PyString},
+        types::{IntoPyDict as _, PyBytes, PyDict, PyList},
         PyAny, PyObject, PyRef, PyResult, Python,
     };
     use uuid::Uuid;
     use voicevox_core::{
         AccelerationMode, AudioQueryModel, InitializeOptions, StyleId, SynthesisOptions,
-        TtsOptions, UserDictWord, VoiceModelId,
+        TtsOptions, UserDictWord,
     };
 
     use crate::{convert::VoicevoxCoreResultExt as _, Closable};
@@ -180,8 +180,9 @@ mod blocking {
         }
 
         #[getter]
-        fn id(&self) -> &str {
-            self.model.id().raw_voice_model_id()
+        fn id(&self, py: Python<'_>) -> PyResult<PyObject> {
+            let id = *self.model.id().raw_voice_model_id();
+            crate::convert::to_py_uuid(py, id)
         }
 
         #[getter]
@@ -289,23 +290,26 @@ mod blocking {
                 .into_py_result(py)
         }
 
-        fn unload_voice_model(&mut self, voice_model_id: &str, py: Python<'_>) -> PyResult<()> {
+        fn unload_voice_model(
+            &mut self,
+            #[pyo3(from_py_with = "crate::convert::to_rust_uuid")] voice_model_id: Uuid,
+            py: Python<'_>,
+        ) -> PyResult<()> {
             self.synthesizer
                 .get()?
-                .unload_voice_model(&VoiceModelId::new(voice_model_id.to_string()))
+                .unload_voice_model(voice_model_id.into())
                 .into_py_result(py)
         }
 
         // C APIの挙動と一貫性を持たせる。
-        fn is_loaded_voice_model(&self, voice_model_id: &PyString) -> PyResult<bool> {
-            let Ok(voice_model_id) = voice_model_id.to_str() else {
-                // 与えられたIDがUTF-8ではない場合、それに対応する`VoicdModel`は確実に存在しない
-                return Ok(false);
-            };
+        fn is_loaded_voice_model(
+            &self,
+            #[pyo3(from_py_with = "crate::convert::to_rust_uuid")] voice_model_id: Uuid,
+        ) -> PyResult<bool> {
             Ok(self
                 .synthesizer
                 .get()?
-                .is_loaded_voice_model(&VoiceModelId::new(voice_model_id.to_string())))
+                .is_loaded_voice_model(voice_model_id.into()))
         }
 
         fn audio_query_from_kana<'py>(
@@ -579,13 +583,13 @@ mod asyncio {
     use camino::Utf8PathBuf;
     use pyo3::{
         pyclass, pymethods,
-        types::{IntoPyDict as _, PyBytes, PyDict, PyList, PyString},
+        types::{IntoPyDict as _, PyBytes, PyDict, PyList},
         PyAny, PyObject, PyRef, PyResult, Python, ToPyObject as _,
     };
     use uuid::Uuid;
     use voicevox_core::{
         AccelerationMode, AudioQueryModel, InitializeOptions, StyleId, SynthesisOptions,
-        TtsOptions, UserDictWord, VoiceModelId,
+        TtsOptions, UserDictWord,
     };
 
     use crate::{convert::VoicevoxCoreResultExt as _, Closable};
@@ -608,8 +612,9 @@ mod asyncio {
         }
 
         #[getter]
-        fn id(&self) -> &str {
-            self.model.id().raw_voice_model_id()
+        fn id(&self, py: Python<'_>) -> PyResult<PyObject> {
+            let id = *self.model.id().raw_voice_model_id();
+            crate::convert::to_py_uuid(py, id)
         }
 
         #[getter]
@@ -725,23 +730,26 @@ mod asyncio {
             })
         }
 
-        fn unload_voice_model(&mut self, voice_model_id: &str, py: Python<'_>) -> PyResult<()> {
+        fn unload_voice_model(
+            &mut self,
+            #[pyo3(from_py_with = "crate::convert::to_rust_uuid")] voice_model_id: Uuid,
+            py: Python<'_>,
+        ) -> PyResult<()> {
             self.synthesizer
                 .get()?
-                .unload_voice_model(&VoiceModelId::new(voice_model_id.to_string()))
+                .unload_voice_model(voice_model_id.into())
                 .into_py_result(py)
         }
 
         // C APIの挙動と一貫性を持たせる。
-        fn is_loaded_voice_model(&self, voice_model_id: &PyString) -> PyResult<bool> {
-            let Ok(voice_model_id) = voice_model_id.to_str() else {
-                // 与えられたIDがUTF-8ではない場合、それに対応する`VoicdModel`は確実に存在しない
-                return Ok(false);
-            };
+        fn is_loaded_voice_model(
+            &self,
+            #[pyo3(from_py_with = "crate::convert::to_rust_uuid")] voice_model_id: Uuid,
+        ) -> PyResult<bool> {
             Ok(self
                 .synthesizer
                 .get()?
-                .is_loaded_voice_model(&VoiceModelId::new(voice_model_id.to_string())))
+                .is_loaded_voice_model(voice_model_id.into()))
         }
 
         fn audio_query_from_kana<'py>(

--- a/model/sample.vvm/manifest.json
+++ b/model/sample.vvm/manifest.json
@@ -1,5 +1,6 @@
 {
   "manifest_version": "0.0.0",
+  "id": "018fa5b1-146c-71e9-b523-6f6dabcf05fe",
   "metas_filename": "metas.json",
   "talk": {
     "predict_duration_filename": "predict_duration.onnx",


### PR DESCRIPTION
## 内容

<https://github.com/VOICEVOX/voicevox_core/issues/581#issuecomment-1837168657>の3.です。manifest.jsonにUUIDとして`id`を持たせ、それを`VoiceModelId`として扱います。

パブリックAPIにおける"model\_id"のような名前は全部"model\_uuid"に置き換えるべきかもしれませんが、`id`のままでも不自然ではないということもあって迷ったのでやらないでおきました。

## 関連 Issue

ref #581

## その他

sample.vvmの`id`は、RFC 9562を記念して(?)[UUID V7](https://www.rfc-editor.org/rfc/rfc9562.html#name-uuid-version-7)を使ってみました。
