### PR TITLE
fix: `voicevox_user_dict_add_word`がスタックを破壊するのを修正

### DIFF
--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -1161,7 +1161,7 @@ pub unsafe extern "C" fn voicevox_user_dict_add_word(
     into_result_code_with_error((|| {
         let word = word.read_unaligned().try_into_word()?;
         let uuid = user_dict.dict.add_word(word)?;
-        output_word_uuid.as_ptr().copy_from(uuid.as_bytes(), 16);
+        output_word_uuid.as_ptr().write_unaligned(uuid.into_bytes());
 
         Ok(())
     })())


### PR DESCRIPTION
## 内容

Rust 1.79に上げるとC APIのテストがSEGV(多分)することがわかりました。
<https://github.com/VOICEVOX/voicevox_core/actions/runs/9505427859?pr=799>

原因は`voicevox_user_dict_add_word`の実装です。起こっていることはおそらくこんな感じです。
<https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=3d7d63d7dd6216fbb5172391013be984>

`voicevox_user_dict_add_word`は現在`output_word`に書き込む方法を誤っており、16バイトではなく16×16=256バイトを`memmove`してスタックを破壊しています。書き込む方法を正しくすることで修正を行います。

## 関連 Issue

## その他
