### PR TITLE
change: macOS 11のサポートを切る

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -123,7 +123,7 @@ jobs:
               "can_skip_in_simple_test": true
             },
             {
-              "os": "macos-11",
+              "os": "macos-12",
               "features": "",
               "target": "aarch64-apple-darwin",
               "artifact_name": "osx-arm64-cpu",
@@ -131,7 +131,7 @@ jobs:
               "can_skip_in_simple_test": false
             },
             {
-              "os": "macos-11",
+              "os": "macos-12",
               "features": "",
               "target": "x86_64-apple-darwin",
               "artifact_name": "osx-x64-cpu",

--- a/.github/workflows/build_and_deploy_downloader.yml
+++ b/.github/workflows/build_and_deploy_downloader.yml
@@ -60,11 +60,11 @@ jobs:
 
           - name: download-osx-x64
             target: x86_64-apple-darwin
-            os: macos-11
+            os: macos-12
 
           - name: download-osx-arm64
             target: aarch64-apple-darwin
-            os: macos-11
+            os: macos-12
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,8 +103,8 @@ jobs:
             { "os": "windows-2022", "features": "", "can_skip_in_simple_test": true },
             { "os": "windows-2019", "features": "directml", "can_skip_in_simple_test": false },
             { "os": "windows-2022", "features": "directml", "can_skip_in_simple_test": true },
-            { "os": "macos-11", "features": "", "can_skip_in_simple_test": false },
-            { "os": "macos-12", "features": "", "can_skip_in_simple_test": true },
+            { "os": "macos-12", "features": "", "can_skip_in_simple_test": false },
+            { "os": "macos-13", "features": "", "can_skip_in_simple_test": true },
             { "os": "ubuntu-20.04", "features": "", "can_skip_in_simple_test": false },
             { "os": "ubuntu-22.04", "features": "", "can_skip_in_simple_test": true }
           ]'


### PR DESCRIPTION
## 内容

`macos-11`がついに動かなくなったのでmacOS 11のサポートを切ります。

![image](https://github.com/VOICEVOX/voicevox_core/assets/14125495/c4a0de17-9a8b-483a-a6a8-a47ab20fdbbf)

また、`macos-11`と`macos-12`でテストを回していたところはそれぞれ`12`と`13`にします。

## 関連 Issue

VOICEVOX/voicevox_engine#1205

## その他
