### PR TITLE
refactor: Rust APIのAudioQuery系の型名から接尾辞"Model"を削除

### DIFF
--- a/crates/voicevox_core/src/engine/mod.rs
+++ b/crates/voicevox_core/src/engine/mod.rs
@@ -10,6 +10,6 @@ pub(crate) use self::full_context_label::{
     extract_full_context_label, mora_to_text, FullContextLabelError,
 };
 pub(crate) use self::kana_parser::{create_kana, parse_kana, KanaParseError};
-pub use self::model::{AccentPhraseModel, AudioQueryModel, MoraModel};
+pub use self::model::{AccentPhrase, AudioQuery, Mora};
 pub(crate) use self::mora_list::mora2text;
 pub use self::open_jtalk::FullcontextExtractor;

--- a/crates/voicevox_core/src/engine/model.rs
+++ b/crates/voicevox_core/src/engine/model.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 /// モーラ（子音＋母音）ごとの情報。
 #[derive(Clone, Debug, new, Getters, Deserialize, Serialize, PartialEq)]
-pub struct MoraModel {
+pub struct Mora {
     /// 文字。
     text: String,
     /// 子音の音素。
@@ -23,20 +23,20 @@ pub struct MoraModel {
 
 /// AccentPhrase (アクセント句ごとの情報)。
 #[derive(Clone, Debug, new, Getters, Deserialize, Serialize, PartialEq)]
-pub struct AccentPhraseModel {
+pub struct AccentPhrase {
     /// モーラの配列。
-    moras: Vec<MoraModel>,
+    moras: Vec<Mora>,
     /// アクセント箇所。
     accent: usize,
     /// 後ろに無音を付けるかどうか。
-    pause_mora: Option<MoraModel>,
+    pause_mora: Option<Mora>,
     /// 疑問系かどうか。
     #[serde(default)]
     is_interrogative: bool,
 }
 
-impl AccentPhraseModel {
-    pub(super) fn set_pause_mora(&mut self, pause_mora: Option<MoraModel>) {
+impl AccentPhrase {
+    pub(super) fn set_pause_mora(&mut self, pause_mora: Option<Mora>) {
         self.pause_mora = pause_mora;
     }
 
@@ -48,9 +48,9 @@ impl AccentPhraseModel {
 /// AudioQuery (音声合成用のクエリ)。
 #[allow(clippy::too_many_arguments)]
 #[derive(Clone, new, Getters, Deserialize, Serialize)]
-pub struct AudioQueryModel {
+pub struct AudioQuery {
     /// アクセント句の配列。
-    accent_phrases: Vec<AccentPhraseModel>,
+    accent_phrases: Vec<AccentPhrase>,
     /// 全体の話速。
     speed_scale: f32,
     /// 全体の音高。
@@ -76,7 +76,7 @@ pub struct AudioQueryModel {
     kana: Option<String>,
 }
 
-impl AudioQueryModel {
+impl AudioQuery {
     pub(crate) fn with_kana(self, kana: Option<String>) -> Self {
         Self { kana, ..self }
     }
@@ -88,12 +88,12 @@ mod tests {
     use rstest::rstest;
     use serde_json::json;
 
-    use super::AudioQueryModel;
+    use super::AudioQuery;
 
     #[rstest]
     fn check_audio_query_model_json_field_snake_case() {
         let audio_query_model =
-            AudioQueryModel::new(vec![], 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0, false, None);
+            AudioQuery::new(vec![], 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0, false, None);
         let val = serde_json::to_value(audio_query_model).unwrap();
         check_json_field_snake_case(&val);
     }
@@ -120,7 +120,7 @@ mod tests {
 
     #[rstest]
     fn it_accepts_json_without_optional_fields() -> anyhow::Result<()> {
-        serde_json::from_value::<AudioQueryModel>(json!({
+        serde_json::from_value::<AudioQuery>(json!({
             "accent_phrases": [
                 {
                     "moras": [

--- a/crates/voicevox_core/src/lib.rs
+++ b/crates/voicevox_core/src/lib.rs
@@ -93,7 +93,7 @@ use rstest_reuse;
 
 pub use self::{
     devices::SupportedDevices,
-    engine::{AccentPhraseModel, AudioQueryModel, FullcontextExtractor},
+    engine::{AccentPhrase, AudioQuery, FullcontextExtractor, Mora},
     error::{Error, ErrorKind},
     metas::{
         RawStyleId, RawStyleVersion, SpeakerMeta, StyleId, StyleMeta, StyleType, StyleVersion,

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -76,7 +76,7 @@ pub(crate) mod blocking {
     use enum_map::enum_map;
 
     use crate::{
-        engine::{create_kana, mora_to_text, MoraModel, OjtPhoneme},
+        engine::{create_kana, mora_to_text, Mora, OjtPhoneme},
         error::ErrorRepr,
         infer::{
             domains::{
@@ -88,8 +88,8 @@ pub(crate) mod blocking {
         },
         status::Status,
         text_analyzer::{KanaAnalyzer, OpenJTalkAnalyzer, TextAnalyzer},
-        AccentPhraseModel, AudioQueryModel, FullcontextExtractor, Result, StyleId,
-        SynthesisOptions, VoiceModelId, VoiceModelMeta,
+        AccentPhrase, AudioQuery, FullcontextExtractor, Result, StyleId, SynthesisOptions,
+        VoiceModelId, VoiceModelMeta,
     };
 
     use super::{AccelerationMode, InitializeOptions, TtsOptions};
@@ -243,7 +243,7 @@ pub(crate) mod blocking {
         /// AudioQueryから音声合成を行う。
         pub fn synthesis(
             &self,
-            audio_query: &AudioQueryModel,
+            audio_query: &AudioQuery,
             style_id: StyleId,
             options: &SynthesisOptions,
         ) -> Result<Vec<u8>> {
@@ -352,12 +352,12 @@ pub(crate) mod blocking {
             return Ok(to_wav(wave, audio_query));
 
             fn adjust_interrogative_accent_phrases(
-                accent_phrases: &[AccentPhraseModel],
-            ) -> Vec<AccentPhraseModel> {
+                accent_phrases: &[AccentPhrase],
+            ) -> Vec<AccentPhrase> {
                 accent_phrases
                     .iter()
                     .map(|accent_phrase| {
-                        AccentPhraseModel::new(
+                        AccentPhrase::new(
                             adjust_interrogative_moras(accent_phrase),
                             *accent_phrase.accent(),
                             accent_phrase.pause_mora().clone(),
@@ -367,13 +367,13 @@ pub(crate) mod blocking {
                     .collect()
             }
 
-            fn adjust_interrogative_moras(accent_phrase: &AccentPhraseModel) -> Vec<MoraModel> {
+            fn adjust_interrogative_moras(accent_phrase: &AccentPhrase) -> Vec<Mora> {
                 let moras = accent_phrase.moras();
                 if *accent_phrase.is_interrogative() && !moras.is_empty() {
                     let last_mora = moras.last().unwrap();
                     let last_mora_pitch = *last_mora.pitch();
                     if last_mora_pitch != 0.0 {
-                        let mut new_moras: Vec<MoraModel> = Vec::with_capacity(moras.len() + 1);
+                        let mut new_moras: Vec<Mora> = Vec::with_capacity(moras.len() + 1);
                         new_moras.extend_from_slice(moras.as_slice());
                         let interrogative_mora = make_interrogative_mora(last_mora);
                         new_moras.push(interrogative_mora);
@@ -383,14 +383,14 @@ pub(crate) mod blocking {
                 moras.clone()
             }
 
-            fn make_interrogative_mora(last_mora: &MoraModel) -> MoraModel {
+            fn make_interrogative_mora(last_mora: &Mora) -> Mora {
                 const FIX_VOWEL_LENGTH: f32 = 0.15;
                 const ADJUST_PITCH: f32 = 0.3;
                 const MAX_PITCH: f32 = 6.5;
 
                 let pitch = (*last_mora.pitch() + ADJUST_PITCH).min(MAX_PITCH);
 
-                MoraModel::new(
+                Mora::new(
                     mora_to_text(None, last_mora.vowel()),
                     None,
                     None,
@@ -400,7 +400,7 @@ pub(crate) mod blocking {
                 )
             }
 
-            fn to_wav(wave: &[f32], audio_query: &AudioQueryModel) -> Vec<u8> {
+            fn to_wav(wave: &[f32], audio_query: &AudioQuery) -> Vec<u8> {
                 let volume_scale = *audio_query.volume_scale();
                 let output_stereo = *audio_query.output_stereo();
                 let output_sampling_rate = *audio_query.output_sampling_rate();
@@ -475,7 +475,7 @@ pub(crate) mod blocking {
             &self,
             kana: &str,
             style_id: StyleId,
-        ) -> Result<Vec<AccentPhraseModel>> {
+        ) -> Result<Vec<AccentPhrase>> {
             let accent_phrases = self.kana_analyzer.analyze(kana)?;
             self.replace_mora_data(&accent_phrases, style_id)
         }
@@ -483,9 +483,9 @@ pub(crate) mod blocking {
         /// AccentPhraseの配列の音高・音素長を、特定の声で生成しなおす。
         pub fn replace_mora_data(
             &self,
-            accent_phrases: &[AccentPhraseModel],
+            accent_phrases: &[AccentPhrase],
             style_id: StyleId,
-        ) -> Result<Vec<AccentPhraseModel>> {
+        ) -> Result<Vec<AccentPhrase>> {
             let accent_phrases = self.replace_phoneme_length(accent_phrases, style_id)?;
             self.replace_mora_pitch(&accent_phrases, style_id)
         }
@@ -493,9 +493,9 @@ pub(crate) mod blocking {
         /// AccentPhraseの配列の音素長を、特定の声で生成しなおす。
         pub fn replace_phoneme_length(
             &self,
-            accent_phrases: &[AccentPhraseModel],
+            accent_phrases: &[AccentPhrase],
             style_id: StyleId,
-        ) -> Result<Vec<AccentPhraseModel>> {
+        ) -> Result<Vec<AccentPhrase>> {
             let (_, phoneme_data_list) = initial_process(accent_phrases);
 
             let (_, _, vowel_indexes_data) = split_mora(&phoneme_data_list);
@@ -510,12 +510,12 @@ pub(crate) mod blocking {
             let new_accent_phrases = accent_phrases
                 .iter()
                 .map(|accent_phrase| {
-                    AccentPhraseModel::new(
+                    AccentPhrase::new(
                         accent_phrase
                             .moras()
                             .iter()
                             .map(|mora| {
-                                let new_mora = MoraModel::new(
+                                let new_mora = Mora::new(
                                     mora.text().clone(),
                                     mora.consonant().clone(),
                                     mora.consonant().as_ref().map(|_| {
@@ -531,7 +531,7 @@ pub(crate) mod blocking {
                             .collect(),
                         *accent_phrase.accent(),
                         accent_phrase.pause_mora().as_ref().map(|pause_mora| {
-                            let new_pause_mora = MoraModel::new(
+                            let new_pause_mora = Mora::new(
                                 pause_mora.text().clone(),
                                 pause_mora.consonant().clone(),
                                 *pause_mora.consonant_length(),
@@ -553,9 +553,9 @@ pub(crate) mod blocking {
         /// AccentPhraseの配列の音高を、特定の声で生成しなおす。
         pub fn replace_mora_pitch(
             &self,
-            accent_phrases: &[AccentPhraseModel],
+            accent_phrases: &[AccentPhrase],
             style_id: StyleId,
-        ) -> Result<Vec<AccentPhraseModel>> {
+        ) -> Result<Vec<AccentPhrase>> {
             let (_, phoneme_data_list) = initial_process(accent_phrases);
 
             let mut base_start_accent_list = vec![0];
@@ -626,12 +626,12 @@ pub(crate) mod blocking {
             let new_accent_phrases = accent_phrases
                 .iter()
                 .map(|accent_phrase| {
-                    AccentPhraseModel::new(
+                    AccentPhrase::new(
                         accent_phrase
                             .moras()
                             .iter()
                             .map(|mora| {
-                                let new_mora = MoraModel::new(
+                                let new_mora = Mora::new(
                                     mora.text().clone(),
                                     mora.consonant().clone(),
                                     *mora.consonant_length(),
@@ -645,7 +645,7 @@ pub(crate) mod blocking {
                             .collect(),
                         *accent_phrase.accent(),
                         accent_phrase.pause_mora().as_ref().map(|pause_mora| {
-                            let new_pause_mora = MoraModel::new(
+                            let new_pause_mora = Mora::new(
                                 pause_mora.text().clone(),
                                 pause_mora.consonant().clone(),
                                 *pause_mora.consonant_length(),
@@ -665,7 +665,7 @@ pub(crate) mod blocking {
 
             fn create_one_accent_list(
                 accent_list: &mut Vec<i64>,
-                accent_phrase: &AccentPhraseModel,
+                accent_phrase: &AccentPhrase,
                 point: i32,
             ) {
                 let mut one_accent_list: Vec<i64> = Vec::new();
@@ -713,14 +713,9 @@ pub(crate) mod blocking {
         /// ```
         ///
         /// [AudioQuery]: crate::AudioQueryModel
-        pub fn audio_query_from_kana(
-            &self,
-            kana: &str,
-            style_id: StyleId,
-        ) -> Result<AudioQueryModel> {
+        pub fn audio_query_from_kana(&self, kana: &str, style_id: StyleId) -> Result<AudioQuery> {
             let accent_phrases = self.create_accent_phrases_from_kana(kana, style_id)?;
-            Ok(AudioQueryModel::from_accent_phrases(accent_phrases)
-                .with_kana(Some(kana.to_owned())))
+            Ok(AudioQuery::from_accent_phrases(accent_phrases).with_kana(Some(kana.to_owned())))
         }
 
         /// AquesTalk風記法から音声合成を行う。
@@ -764,7 +759,7 @@ pub(crate) mod blocking {
             &self,
             text: &str,
             style_id: StyleId,
-        ) -> Result<Vec<AccentPhraseModel>> {
+        ) -> Result<Vec<AccentPhrase>> {
             let accent_phrases = self.open_jtalk_analyzer.analyze(text)?;
             self.replace_mora_data(&accent_phrases, style_id)
         }
@@ -795,9 +790,9 @@ pub(crate) mod blocking {
         /// ```
         ///
         /// [AudioQuery]: crate::AudioQueryModel
-        pub fn audio_query(&self, text: &str, style_id: StyleId) -> Result<AudioQueryModel> {
+        pub fn audio_query(&self, text: &str, style_id: StyleId) -> Result<AudioQuery> {
             let accent_phrases = self.create_accent_phrases(text, style_id)?;
-            Ok(AudioQueryModel::from_accent_phrases(accent_phrases))
+            Ok(AudioQuery::from_accent_phrases(accent_phrases))
         }
 
         /// 日本語のテキストから音声合成を行う。
@@ -1036,7 +1031,7 @@ pub(crate) mod blocking {
         }
     }
 
-    fn initial_process(accent_phrases: &[AccentPhraseModel]) -> (Vec<MoraModel>, Vec<OjtPhoneme>) {
+    fn initial_process(accent_phrases: &[AccentPhrase]) -> (Vec<Mora>, Vec<OjtPhoneme>) {
         let flatten_moras = to_flatten_moras(accent_phrases);
 
         let mut phoneme_strings = vec!["pau".to_string()];
@@ -1052,7 +1047,7 @@ pub(crate) mod blocking {
 
         return (flatten_moras, phoneme_data_list);
 
-        fn to_flatten_moras(accent_phrases: &[AccentPhraseModel]) -> Vec<MoraModel> {
+        fn to_flatten_moras(accent_phrases: &[AccentPhrase]) -> Vec<Mora> {
             let mut flatten_moras = Vec::new();
 
             for accent_phrase in accent_phrases {
@@ -1114,8 +1109,8 @@ pub(crate) mod blocking {
         (consonant_phoneme_list, vowel_phoneme_list, vowel_indexes)
     }
 
-    impl AudioQueryModel {
-        fn from_accent_phrases(accent_phrases: Vec<AccentPhraseModel>) -> Self {
+    impl AudioQuery {
+        fn from_accent_phrases(accent_phrases: Vec<AccentPhrase>) -> Self {
             let kana = create_kana(&accent_phrases);
             Self::new(
                 accent_phrases,
@@ -1137,8 +1132,8 @@ pub(crate) mod tokio {
     use std::sync::Arc;
 
     use crate::{
-        AccentPhraseModel, AudioQueryModel, FullcontextExtractor, Result, StyleId,
-        SynthesisOptions, VoiceModelId, VoiceModelMeta,
+        AccentPhrase, AudioQuery, FullcontextExtractor, Result, StyleId, SynthesisOptions,
+        VoiceModelId, VoiceModelMeta,
     };
 
     use super::{InitializeOptions, TtsOptions};
@@ -1191,7 +1186,7 @@ pub(crate) mod tokio {
 
         pub async fn synthesis(
             &self,
-            audio_query: &AudioQueryModel,
+            audio_query: &AudioQuery,
             style_id: StyleId,
             options: &SynthesisOptions,
         ) -> Result<Vec<u8>> {
@@ -1207,7 +1202,7 @@ pub(crate) mod tokio {
             &self,
             kana: &str,
             style_id: StyleId,
-        ) -> Result<Vec<AccentPhraseModel>> {
+        ) -> Result<Vec<AccentPhrase>> {
             let blocking = self.0.clone();
             let kana = kana.to_owned();
 
@@ -1217,9 +1212,9 @@ pub(crate) mod tokio {
 
         pub async fn replace_mora_data(
             &self,
-            accent_phrases: &[AccentPhraseModel],
+            accent_phrases: &[AccentPhrase],
             style_id: StyleId,
-        ) -> Result<Vec<AccentPhraseModel>> {
+        ) -> Result<Vec<AccentPhrase>> {
             let blocking = self.0.clone();
             let accent_phrases = accent_phrases.to_owned();
 
@@ -1229,9 +1224,9 @@ pub(crate) mod tokio {
 
         pub async fn replace_phoneme_length(
             &self,
-            accent_phrases: &[AccentPhraseModel],
+            accent_phrases: &[AccentPhrase],
             style_id: StyleId,
-        ) -> Result<Vec<AccentPhraseModel>> {
+        ) -> Result<Vec<AccentPhrase>> {
             let blocking = self.0.clone();
             let accent_phrases = accent_phrases.to_owned();
 
@@ -1243,9 +1238,9 @@ pub(crate) mod tokio {
 
         pub async fn replace_mora_pitch(
             &self,
-            accent_phrases: &[AccentPhraseModel],
+            accent_phrases: &[AccentPhrase],
             style_id: StyleId,
-        ) -> Result<Vec<AccentPhraseModel>> {
+        ) -> Result<Vec<AccentPhrase>> {
             let blocking = self.0.clone();
             let accent_phrases = accent_phrases.to_owned();
 
@@ -1257,7 +1252,7 @@ pub(crate) mod tokio {
             &self,
             kana: &str,
             style_id: StyleId,
-        ) -> Result<AudioQueryModel> {
+        ) -> Result<AudioQuery> {
             let blocking = self.0.clone();
             let kana = kana.to_owned();
 
@@ -1283,14 +1278,14 @@ pub(crate) mod tokio {
             &self,
             text: &str,
             style_id: StyleId,
-        ) -> Result<Vec<AccentPhraseModel>> {
+        ) -> Result<Vec<AccentPhrase>> {
             let blocking = self.0.clone();
             let text = text.to_owned();
 
             crate::task::asyncify(move || blocking.create_accent_phrases(&text, style_id)).await
         }
 
-        pub async fn audio_query(&self, text: &str, style_id: StyleId) -> Result<AudioQueryModel> {
+        pub async fn audio_query(&self, text: &str, style_id: StyleId) -> Result<AudioQuery> {
             let blocking = self.0.clone();
             let text = text.to_owned();
 
@@ -1316,9 +1311,7 @@ pub(crate) mod tokio {
 mod tests {
 
     use super::{blocking::PerformInference as _, AccelerationMode, InitializeOptions};
-    use crate::{
-        engine::MoraModel, macros::tests::assert_debug_fmt_eq, AccentPhraseModel, Result, StyleId,
-    };
+    use crate::{engine::Mora, macros::tests::assert_debug_fmt_eq, AccentPhrase, Result, StyleId};
     use ::test_util::OPEN_JTALK_DIC_DIR;
     use rstest::rstest;
 
@@ -1740,7 +1733,7 @@ mod tests {
         assert_eq!(accent_phrases.len(), 5);
 
         // 入力テキストに「、」や「。」などの句読点が含まれていたときに
-        // AccentPhraseModel の pause_mora に期待する値をテスト
+        // AccentPhraseの pause_mora に期待する値をテスト
 
         assert!(
             accent_phrases[0].pause_mora().is_some(),
@@ -1812,7 +1805,7 @@ mod tests {
             any_mora_param_changed(
                 &accent_phrases,
                 &modified_accent_phrases,
-                MoraModel::vowel_length
+                Mora::vowel_length
             ),
             "mora_length() does not work: mora.vowel_length() is not changed."
         );
@@ -1850,7 +1843,7 @@ mod tests {
 
         // NOTE: 一つでも音高が変わっていれば、動作しているとみなす
         assert!(
-            any_mora_param_changed(&accent_phrases, &modified_accent_phrases, MoraModel::pitch),
+            any_mora_param_changed(&accent_phrases, &modified_accent_phrases, Mora::pitch),
             "mora_pitch() does not work: mora.pitch() is not changed."
         );
     }
@@ -1887,7 +1880,7 @@ mod tests {
 
         // NOTE: 一つでも音高が変わっていれば、動作しているとみなす
         assert!(
-            any_mora_param_changed(&accent_phrases, &modified_accent_phrases, MoraModel::pitch),
+            any_mora_param_changed(&accent_phrases, &modified_accent_phrases, Mora::pitch),
             "mora_data() does not work: mora.pitch() is not changed."
         );
         // NOTE: 一つでも母音の長さが変わっていれば、動作しているとみなす
@@ -1895,16 +1888,16 @@ mod tests {
             any_mora_param_changed(
                 &accent_phrases,
                 &modified_accent_phrases,
-                MoraModel::vowel_length
+                Mora::vowel_length
             ),
             "mora_data() does not work: mora.vowel_length() is not changed."
         );
     }
 
     fn any_mora_param_changed<T: PartialEq>(
-        before: &[AccentPhraseModel],
-        after: &[AccentPhraseModel],
-        param: fn(&MoraModel) -> &T,
+        before: &[AccentPhrase],
+        after: &[AccentPhrase],
+        param: fn(&Mora) -> &T,
     ) -> bool {
         std::iter::zip(before, after)
             .flat_map(move |(before, after)| std::iter::zip(before.moras(), after.moras()))

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -712,7 +712,7 @@ pub(crate) mod blocking {
         /// # }
         /// ```
         ///
-        /// [AudioQuery]: crate::AudioQueryModel
+        /// [AudioQuery]: crate::QueryModel
         pub fn audio_query_from_kana(&self, kana: &str, style_id: StyleId) -> Result<AudioQuery> {
             let accent_phrases = self.create_accent_phrases_from_kana(kana, style_id)?;
             Ok(AudioQuery::from_accent_phrases(accent_phrases).with_kana(Some(kana.to_owned())))
@@ -789,7 +789,7 @@ pub(crate) mod blocking {
         /// # }
         /// ```
         ///
-        /// [AudioQuery]: crate::AudioQueryModel
+        /// [AudioQuery]: crate::QueryModel
         pub fn audio_query(&self, text: &str, style_id: StyleId) -> Result<AudioQuery> {
             let accent_phrases = self.create_accent_phrases(text, style_id)?;
             Ok(AudioQuery::from_accent_phrases(accent_phrases))

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -712,7 +712,7 @@ pub(crate) mod blocking {
         /// # }
         /// ```
         ///
-        /// [AudioQuery]: crate::QueryModel
+        /// [AudioQuery]: crate::AudioQuery
         pub fn audio_query_from_kana(&self, kana: &str, style_id: StyleId) -> Result<AudioQuery> {
             let accent_phrases = self.create_accent_phrases_from_kana(kana, style_id)?;
             Ok(AudioQuery::from_accent_phrases(accent_phrases).with_kana(Some(kana.to_owned())))
@@ -789,7 +789,7 @@ pub(crate) mod blocking {
         /// # }
         /// ```
         ///
-        /// [AudioQuery]: crate::QueryModel
+        /// [AudioQuery]: crate::AudioQuery
         pub fn audio_query(&self, text: &str, style_id: StyleId) -> Result<AudioQuery> {
             let accent_phrases = self.create_accent_phrases(text, style_id)?;
             Ok(AudioQuery::from_accent_phrases(accent_phrases))

--- a/crates/voicevox_core/src/text_analyzer.rs
+++ b/crates/voicevox_core/src/text_analyzer.rs
@@ -1,10 +1,10 @@
 use crate::{
     engine::{extract_full_context_label, parse_kana},
-    AccentPhraseModel, FullcontextExtractor, Result,
+    AccentPhrase, FullcontextExtractor, Result,
 };
 
 pub(crate) trait TextAnalyzer {
-    fn analyze(&self, text: &str) -> Result<Vec<AccentPhraseModel>>;
+    fn analyze(&self, text: &str) -> Result<Vec<AccentPhrase>>;
 }
 
 /// AquesTalk風記法からAccentPhraseの配列を生成するTextAnalyzer
@@ -12,7 +12,7 @@ pub(crate) trait TextAnalyzer {
 pub(crate) struct KanaAnalyzer;
 
 impl TextAnalyzer for KanaAnalyzer {
-    fn analyze(&self, text: &str) -> Result<Vec<AccentPhraseModel>> {
+    fn analyze(&self, text: &str) -> Result<Vec<AccentPhrase>> {
         if text.is_empty() {
             return Ok(Vec::new());
         }
@@ -31,7 +31,7 @@ impl<O> OpenJTalkAnalyzer<O> {
 }
 
 impl<O: FullcontextExtractor> TextAnalyzer for OpenJTalkAnalyzer<O> {
-    fn analyze(&self, text: &str) -> Result<Vec<AccentPhraseModel>> {
+    fn analyze(&self, text: &str) -> Result<Vec<AccentPhrase>> {
         if text.is_empty() {
             return Ok(Vec::new());
         }

--- a/crates/voicevox_core_c_api/src/helpers.rs
+++ b/crates/voicevox_core_c_api/src/helpers.rs
@@ -1,12 +1,12 @@
 use easy_ext::ext;
 use std::{ffi::CStr, fmt::Debug, iter};
 use uuid::Uuid;
-use voicevox_core::{AudioQueryModel, UserDictWord, VoiceModelId};
+use voicevox_core::{AudioQuery, UserDictWord, VoiceModelId};
 
 use thiserror::Error;
 use tracing::error;
 
-use voicevox_core::AccentPhraseModel;
+use voicevox_core::AccentPhrase;
 
 use crate::{
     result_code::VoicevoxResultCode, VoicevoxAccelerationMode, VoicevoxInitializeOptions,
@@ -80,11 +80,11 @@ pub(crate) enum CApiError {
     InvalidUuid(uuid::Error),
 }
 
-pub(crate) fn audio_query_model_to_json(audio_query_model: &AudioQueryModel) -> String {
+pub(crate) fn audio_query_model_to_json(audio_query_model: &AudioQuery) -> String {
     serde_json::to_string(audio_query_model).expect("should be always valid")
 }
 
-pub(crate) fn accent_phrases_to_json(audio_query_model: &[AccentPhraseModel]) -> String {
+pub(crate) fn accent_phrases_to_json(audio_query_model: &[AccentPhrase]) -> String {
     serde_json::to_string(audio_query_model).expect("should be always valid")
 }
 

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -33,7 +33,7 @@ use tracing_subscriber::fmt::format::Writer;
 use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
 use voicevox_core::__internal::interop::IdRef as _;
-use voicevox_core::{AccentPhraseModel, AudioQueryModel, TtsOptions, UserDictWord};
+use voicevox_core::{AccentPhrase, AudioQuery, TtsOptions, UserDictWord};
 use voicevox_core::{StyleId, SynthesisOptions};
 
 fn init_logger_once() {
@@ -906,7 +906,7 @@ pub unsafe extern "C" fn voicevox_synthesizer_replace_mora_data(
 ) -> VoicevoxResultCode {
     init_logger_once();
     into_result_code_with_error((|| {
-        let accent_phrases: Vec<AccentPhraseModel> =
+        let accent_phrases: Vec<AccentPhrase> =
             serde_json::from_str(ensure_utf8(CStr::from_ptr(accent_phrases_json))?)
                 .map_err(CApiError::InvalidAccentPhrase)?;
         let accent_phrases = synthesizer
@@ -946,7 +946,7 @@ pub unsafe extern "C" fn voicevox_synthesizer_replace_phoneme_length(
 ) -> VoicevoxResultCode {
     init_logger_once();
     into_result_code_with_error((|| {
-        let accent_phrases: Vec<AccentPhraseModel> =
+        let accent_phrases: Vec<AccentPhrase> =
             serde_json::from_str(ensure_utf8(CStr::from_ptr(accent_phrases_json))?)
                 .map_err(CApiError::InvalidAccentPhrase)?;
         let accent_phrases = synthesizer
@@ -986,7 +986,7 @@ pub unsafe extern "C" fn voicevox_synthesizer_replace_mora_pitch(
 ) -> VoicevoxResultCode {
     init_logger_once();
     into_result_code_with_error((|| {
-        let accent_phrases: Vec<AccentPhraseModel> =
+        let accent_phrases: Vec<AccentPhrase> =
             serde_json::from_str(ensure_utf8(CStr::from_ptr(accent_phrases_json))?)
                 .map_err(CApiError::InvalidAccentPhrase)?;
         let accent_phrases = synthesizer
@@ -1049,7 +1049,7 @@ pub unsafe extern "C" fn voicevox_synthesizer_synthesis(
         let audio_query_json = CStr::from_ptr(audio_query_json)
             .to_str()
             .map_err(|_| CApiError::InvalidUtf8Input)?;
-        let audio_query: AudioQueryModel =
+        let audio_query: AudioQuery =
             serde_json::from_str(audio_query_json).map_err(CApiError::InvalidAudioQuery)?;
         let wav = synthesizer.synthesizer().synthesis(
             &audio_query,

--- a/crates/voicevox_core_java_api/src/synthesizer.rs
+++ b/crates/voicevox_core_java_api/src/synthesizer.rs
@@ -288,7 +288,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsReplaceMo
 ) -> jobject {
     throw_if_err(env, std::ptr::null_mut(), |env| {
         let accent_phrases_json: String = env.get_string(&accent_phrases_json)?.into();
-        let accent_phrases: Vec<voicevox_core::AccentPhraseModel> =
+        let accent_phrases: Vec<voicevox_core::AccentPhrase> =
             serde_json::from_str(&accent_phrases_json).map_err(JavaApiError::DeJson)?;
         let style_id = style_id as u32;
 
@@ -319,7 +319,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsReplacePh
 ) -> jobject {
     throw_if_err(env, std::ptr::null_mut(), |env| {
         let accent_phrases_json: String = env.get_string(&accent_phrases_json)?.into();
-        let accent_phrases: Vec<voicevox_core::AccentPhraseModel> =
+        let accent_phrases: Vec<voicevox_core::AccentPhrase> =
             serde_json::from_str(&accent_phrases_json).map_err(JavaApiError::DeJson)?;
         let style_id = style_id as u32;
 
@@ -348,7 +348,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsReplaceMo
 ) -> jobject {
     throw_if_err(env, std::ptr::null_mut(), |env| {
         let accent_phrases_json: String = env.get_string(&accent_phrases_json)?.into();
-        let accent_phrases: Vec<voicevox_core::AccentPhraseModel> =
+        let accent_phrases: Vec<voicevox_core::AccentPhrase> =
             serde_json::from_str(&accent_phrases_json).map_err(JavaApiError::DeJson)?;
         let style_id = style_id as u32;
 
@@ -378,7 +378,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_Synthesizer_rsSynthesis
 ) -> jobject {
     throw_if_err(env, std::ptr::null_mut(), |env| {
         let audio_query: String = env.get_string(&query_json)?.into();
-        let audio_query: voicevox_core::AudioQueryModel =
+        let audio_query: voicevox_core::AudioQuery =
             serde_json::from_str(&audio_query).map_err(JavaApiError::DeJson)?;
         let style_id = style_id as u32;
 

--- a/crates/voicevox_core_python_api/src/convert.rs
+++ b/crates/voicevox_core_python_api/src/convert.rs
@@ -10,9 +10,7 @@ use pyo3::{
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::json;
 use uuid::Uuid;
-use voicevox_core::{
-    AccelerationMode, AccentPhraseModel, StyleId, UserDictWordType, VoiceModelMeta,
-};
+use voicevox_core::{AccelerationMode, AccentPhrase, StyleId, UserDictWordType, VoiceModelMeta};
 
 use crate::{
     ExtractFullContextLabelError, GetSupportedDevicesError, GpuSupportError, InferenceFailedError,
@@ -86,15 +84,12 @@ pub(crate) fn blocking_modify_accent_phrases<'py>(
     accent_phrases: &'py PyList,
     speaker_id: StyleId,
     py: Python<'py>,
-    method: impl FnOnce(
-        Vec<AccentPhraseModel>,
-        StyleId,
-    ) -> voicevox_core::Result<Vec<AccentPhraseModel>>,
+    method: impl FnOnce(Vec<AccentPhrase>, StyleId) -> voicevox_core::Result<Vec<AccentPhrase>>,
 ) -> PyResult<Vec<&'py PyAny>> {
     let rust_accent_phrases = accent_phrases
         .iter()
         .map(from_dataclass)
-        .collect::<PyResult<Vec<AccentPhraseModel>>>()?;
+        .collect::<PyResult<Vec<AccentPhrase>>>()?;
 
     method(rust_accent_phrases, speaker_id)
         .into_py_result(py)?
@@ -115,13 +110,13 @@ pub(crate) fn async_modify_accent_phrases<'py, Fun, Fut>(
     method: Fun,
 ) -> PyResult<&'py PyAny>
 where
-    Fun: FnOnce(Vec<AccentPhraseModel>, StyleId) -> Fut + Send + 'static,
-    Fut: Future<Output = voicevox_core::Result<Vec<AccentPhraseModel>>> + Send + 'static,
+    Fun: FnOnce(Vec<AccentPhrase>, StyleId) -> Fut + Send + 'static,
+    Fut: Future<Output = voicevox_core::Result<Vec<AccentPhrase>>> + Send + 'static,
 {
     let rust_accent_phrases = accent_phrases
         .iter()
         .map(from_dataclass)
-        .collect::<PyResult<Vec<AccentPhraseModel>>>()?;
+        .collect::<PyResult<Vec<AccentPhrase>>>()?;
     pyo3_asyncio::tokio::future_into_py_with_locals(
         py,
         pyo3_asyncio::tokio::get_current_locals(py)?,

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -151,8 +151,8 @@ mod blocking {
     };
     use uuid::Uuid;
     use voicevox_core::{
-        AccelerationMode, AudioQueryModel, InitializeOptions, StyleId, SynthesisOptions,
-        TtsOptions, UserDictWord,
+        AccelerationMode, AudioQuery, InitializeOptions, StyleId, SynthesisOptions, TtsOptions,
+        UserDictWord,
     };
 
     use crate::{convert::VoicevoxCoreResultExt as _, Closable};
@@ -497,7 +497,7 @@ mod blocking {
         ))]
         fn synthesis<'py>(
             &self,
-            #[pyo3(from_py_with = "crate::convert::from_dataclass")] audio_query: AudioQueryModel,
+            #[pyo3(from_py_with = "crate::convert::from_dataclass")] audio_query: AudioQuery,
             style_id: u32,
             enable_interrogative_upspeak: bool,
             py: Python<'py>,
@@ -651,8 +651,8 @@ mod asyncio {
     };
     use uuid::Uuid;
     use voicevox_core::{
-        AccelerationMode, AudioQueryModel, InitializeOptions, StyleId, SynthesisOptions,
-        TtsOptions, UserDictWord,
+        AccelerationMode, AudioQuery, InitializeOptions, StyleId, SynthesisOptions, TtsOptions,
+        UserDictWord,
     };
 
     use crate::{convert::VoicevoxCoreResultExt as _, Closable};
@@ -1045,7 +1045,7 @@ mod asyncio {
         #[pyo3(signature=(audio_query,style_id,enable_interrogative_upspeak = TtsOptions::default().enable_interrogative_upspeak))]
         fn synthesis<'py>(
             &self,
-            #[pyo3(from_py_with = "crate::convert::from_dataclass")] audio_query: AudioQueryModel,
+            #[pyo3(from_py_with = "crate::convert::from_dataclass")] audio_query: AudioQuery,
             style_id: u32,
             enable_interrogative_upspeak: bool,
             py: Python<'py>,


### PR DESCRIPTION
## 内容

<https://github.com/VOICEVOX/voicevox_core/pull/742#issuecomment-1961075655>

型名に"Model"と付ける意味は今だと全部消失していると思いました。

またRust APIからは`Mora`がエクスポートされていないことがわかったので、このPRではそれも修正しています。
(「`jlabel::Mora`との区別については、`jlabel::Mora`と`crate::Mora`とでもしておけば」の一部として)

## 関連 Issue

ref #388

## その他
