### PR TITLE
refactor: Rust APIにおけるgetterをパブリックAPIとして整える

### DIFF
--- a/crates/voicevox_core/src/devices.rs
+++ b/crates/voicevox_core/src/devices.rs
@@ -1,11 +1,10 @@
-use derive_getters::Getters;
 use serde::{Deserialize, Serialize};
 
 /// このライブラリで利用可能なデバイスの情報。
 ///
 /// あくまで本ライブラリが対応しているデバイスの情報であることに注意。GPUが使える環境ではなかったと
 /// しても`cuda`や`dml`は`true`を示しうる。
-#[derive(Getters, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct SupportedDevices {
     /// CPUが利用可能。
     ///

--- a/crates/voicevox_core/src/engine/full_context_label.rs
+++ b/crates/voicevox_core/src/engine/full_context_label.rs
@@ -88,14 +88,14 @@ fn generate_accent_phrases(
         let pause_mora = if ap_curr.accent_phrase_position_backward == 1
             && bg_curr.breath_group_position_backward != 1
         {
-            Some(crate::Mora::new(
-                "、".into(),
-                None,
-                None,
-                "pau".into(),
-                0.,
-                0.,
-            ))
+            Some(crate::Mora {
+                text: "、".into(),
+                consonant: None,
+                consonant_length: None,
+                vowel: "pau".into(),
+                vowel_length: 0.,
+                pitch: 0.,
+            })
         } else {
             None
         };
@@ -103,12 +103,12 @@ fn generate_accent_phrases(
         // workaround for VOICEVOX/voicevox_engine#55
         let accent = usize::from(ap_curr.accent_position).min(moras.len());
 
-        accent_phrases.push(AccentPhrase::new(
+        accent_phrases.push(AccentPhrase {
             moras,
             accent,
             pause_mora,
-            ap_curr.is_interrogative,
-        ))
+            is_interrogative: ap_curr.is_interrogative,
+        })
     }
     Ok(accent_phrases)
 }
@@ -153,15 +153,15 @@ fn generate_moras(accent_phrase: &[Label]) -> std::result::Result<Vec<crate::Mor
 
 fn generate_mora(consonant: Option<&Label>, vowel: &Label) -> crate::Mora {
     let consonant_phoneme = consonant.and_then(|c| c.phoneme.c.to_owned());
-    let vowel_phoneme = vowel.phoneme.c.as_deref().unwrap();
-    crate::Mora::new(
-        mora_to_text(consonant_phoneme.as_deref(), vowel_phoneme),
-        consonant_phoneme,
-        consonant.and(Some(0.0)),
-        vowel_phoneme.to_string(),
-        0.0,
-        0.0,
-    )
+    let vowel = vowel.phoneme.c.clone().unwrap();
+    crate::Mora {
+        text: mora_to_text(consonant_phoneme.as_deref(), &vowel),
+        consonant: consonant_phoneme,
+        consonant_length: consonant.and(Some(0.0)),
+        vowel,
+        vowel_length: 0.0,
+        pitch: 0.0,
+    }
 }
 
 pub fn mora_to_text(consonant: Option<&str>, vowel: &str) -> String {
@@ -197,14 +197,14 @@ mod tests {
     use jlabel::Label;
 
     fn mora(text: &str, consonant: Option<&str>, vowel: &str) -> Mora {
-        Mora::new(
-            text.into(),
-            consonant.map(|c| c.into()),
-            consonant.and(Some(0.0)),
-            vowel.into(),
-            0.0,
-            0.0,
-        )
+        Mora {
+            text: text.into(),
+            consonant: consonant.map(|c| c.into()),
+            consonant_length: consonant.and(Some(0.0)),
+            vowel: vowel.into(),
+            vowel_length: 0.0,
+            pitch: 0.0,
+        }
     }
 
     #[template]
@@ -218,12 +218,12 @@ mod tests {
             "y^e-sil+xx=xx/A:xx+xx+xx/B:xx-xx_xx/C:xx_xx+xx/D:xx+xx_xx/E:1_1!0_xx-xx/F:xx_xx#xx_xx@xx_xx|xx_xx/G:xx_xx%xx_xx_xx/H:1_1/I:xx-xx@xx+xx&xx-xx|xx+xx/J:xx_xx/K:1+1-1",
         ],
         &[
-            AccentPhrase::new(
-                vec![mora("イェ", Some("y"), "e")],
-                1,
-                None,
-                false,
-            )
+            AccentPhrase {
+                moras: vec![mora("イェ", Some("y"), "e")],
+                accent: 1,
+                pause_mora: None,
+                is_interrogative: false,
+            }
         ]
     )]
     #[case(
@@ -236,16 +236,16 @@ mod tests {
             "N^cl-sil+xx=xx/A:xx+xx+xx/B:09-xx_xx/C:xx_xx+xx/D:xx+xx_xx/E:3_3!0_xx-xx/F:xx_xx#xx_xx@xx_xx|xx_xx/G:xx_xx%xx_xx_xx/H:1_3/I:xx-xx@xx+xx&xx-xx|xx+xx/J:xx_xx/K:1+1-3",
         ],
         &[
-            AccentPhrase::new(
-                vec![
+            AccentPhrase {
+                moras: vec![
                     mora("ン", None, "N"),
                     mora("ン", None, "N"),
                     mora("ッ", None, "cl"),
                 ],
-                3,
-                None,
-                false,
-            ),
+                accent: 3,
+                pause_mora: None,
+                is_interrogative: false,
+            },
         ]
     )]
     #[case(
@@ -271,28 +271,28 @@ mod tests {
             "s^U-sil+xx=xx/A:xx+xx+xx/B:10-7_2/C:xx_xx+xx/D:xx+xx_xx/E:5_1!0_xx-xx/F:xx_xx#xx_xx@xx_xx|xx_xx/G:xx_xx%xx_xx_xx/H:2_8/I:xx-xx@xx+xx&xx-xx|xx+xx/J:xx_xx/K:1+2-8",
         ],
         &[
-            AccentPhrase::new(
-                vec![
+            AccentPhrase {
+                moras: vec![
                     mora("コ", Some("k"), "o"),
                     mora("レ", Some("r"), "e"),
                     mora("ワ", Some("w"), "a"),
                 ],
-                3,
-                None,
-                false,
-            ),
-            AccentPhrase::new(
-                vec![
+                accent: 3,
+                pause_mora: None,
+                is_interrogative: false,
+            },
+            AccentPhrase {
+                moras: vec![
                     mora("テ", Some("t"), "e"),
                     mora("ス", Some("s"), "U"),
                     mora("ト", Some("t"), "o"),
                     mora("デ", Some("d"), "e"),
                     mora("ス", Some("s"), "U"),
                 ],
-                1,
-                None,
-                false,
-            ),
+                accent: 1,
+                pause_mora: None,
+                is_interrogative: false,
+            },
         ]
     )]
     #[case(
@@ -324,46 +324,46 @@ mod tests {
             "k^u-sil+xx=xx/A:xx+xx+xx/B:05-xx_xx/C:xx_xx+xx/D:xx+xx_xx/E:4_2!1_xx-xx/F:xx_xx#xx_xx@xx_xx|xx_xx/G:xx_xx%xx_xx_xx/H:1_4/I:xx-xx@xx+xx&xx-xx|xx+xx/J:xx_xx/K:4+4-12",
         ],
         &[
-            AccentPhrase::new(
-                vec![
+            AccentPhrase {
+                moras: vec![
                     mora("イ", None, "i"),
                     mora("チ", Some("ch"), "i"),
                 ],
-                2,
-                Some(mora("、", None, "pau")),
-                false,
-            ),
-            AccentPhrase::new(
-                vec![
+                accent: 2,
+                pause_mora: Some(mora("、", None, "pau")),
+                is_interrogative: false,
+            },
+            AccentPhrase {
+                moras: vec![
                     mora("セ", Some("s"), "e"),
                     mora("ン", None, "N"),
                 ],
-                1,
-                Some(mora("、", None, "pau")),
-                false,
-            ),
-            AccentPhrase::new(
-                vec![
+                accent: 1,
+                pause_mora: Some(mora("、", None, "pau")),
+                is_interrogative: false,
+            },
+            AccentPhrase {
+                moras: vec![
                     mora("ヒャ", Some("hy"), "a"),
                     mora("ク", Some("k"), "u"),
                     mora("マ", Some("m"), "a"),
                     mora("ン", None, "N"),
                 ],
-                3,
-                Some(mora("、", None, "pau")),
-                false,
-            ),
-            AccentPhrase::new(
-                vec![
+                accent: 3,
+                pause_mora: Some(mora("、", None, "pau")),
+                is_interrogative: false,
+            },
+            AccentPhrase {
+                moras: vec![
                     mora("イ", None, "i"),
                     mora("チ", Some("ch"), "i"),
                     mora("オ", None, "o"),
                     mora("ク", Some("k"), "u"),
                 ],
-                2,
-                None,
-                true,
-            ),
+                accent: 2,
+                pause_mora: None,
+                is_interrogative: true,
+            },
         ]
     )]
     #[case(
@@ -386,33 +386,33 @@ mod tests {
             "a^a-sil+xx=xx/A:xx+xx+xx/B:09-xx_xx/C:xx_xx+xx/D:xx+xx_xx/E:1_1!0_xx-xx/F:xx_xx#xx_xx@xx_xx|xx_xx/G:xx_xx%xx_xx_xx/H:2_3/I:xx-xx@xx+xx&xx-xx|xx+xx/J:xx_xx/K:2+3-8",
         ],
         &[
-            AccentPhrase::new(
-                vec![
+            AccentPhrase {
+                moras: vec![
                     mora("クヮ", Some("kw"), "a"),
                     mora("ル", Some("r"), "u"),
                     mora("テ", Some("t"), "e"),
                     mora("ッ", None, "cl"),
                     mora("ト", Some("t"), "o"),
                 ],
-                3,
-                Some(mora("、", None, "pau")),
-                false,
-            ),
-            AccentPhrase::new(
-                vec![
+                accent: 3,
+                pause_mora: Some(mora("、", None, "pau")),
+                is_interrogative: false,
+            },
+            AccentPhrase {
+                moras: vec![
                     mora("ア", None, "a"),
                     mora("ア", None, "a"),
                 ],
-                1,
-                None,
-                false,
-            ),
-            AccentPhrase::new(
-                vec![mora("ア", None, "a")],
-                1,
-                None,
-                false,
-            ),
+                accent: 1,
+                pause_mora: None,
+                is_interrogative: false,
+            },
+            AccentPhrase {
+                moras: vec![mora("ア", None, "a")],
+                accent: 1,
+                pause_mora: None,
+                is_interrogative: false,
+            },
         ]
     )]
     fn label_cases(

--- a/crates/voicevox_core/src/engine/model.rs
+++ b/crates/voicevox_core/src/engine/model.rs
@@ -1,38 +1,36 @@
-use derive_getters::Getters;
-use derive_new::new;
 use serde::{Deserialize, Serialize};
 
 /* 各フィールドのjsonフィールド名はsnake_caseとする*/
 
 /// モーラ（子音＋母音）ごとの情報。
-#[derive(Clone, Debug, new, Getters, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct Mora {
     /// 文字。
-    text: String,
+    pub text: String,
     /// 子音の音素。
-    consonant: Option<String>,
+    pub consonant: Option<String>,
     /// 子音の音長。
-    consonant_length: Option<f32>,
+    pub consonant_length: Option<f32>,
     /// 母音の音素。
-    vowel: String,
+    pub vowel: String,
     /// 母音の音長。
-    vowel_length: f32,
+    pub vowel_length: f32,
     /// 音高。
-    pitch: f32,
+    pub pitch: f32,
 }
 
 /// AccentPhrase (アクセント句ごとの情報)。
-#[derive(Clone, Debug, new, Getters, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct AccentPhrase {
     /// モーラの配列。
-    moras: Vec<Mora>,
+    pub moras: Vec<Mora>,
     /// アクセント箇所。
-    accent: usize,
+    pub accent: usize,
     /// 後ろに無音を付けるかどうか。
-    pause_mora: Option<Mora>,
+    pub pause_mora: Option<Mora>,
     /// 疑問系かどうか。
     #[serde(default)]
-    is_interrogative: bool,
+    pub is_interrogative: bool,
 }
 
 impl AccentPhrase {
@@ -46,34 +44,33 @@ impl AccentPhrase {
 }
 
 /// AudioQuery (音声合成用のクエリ)。
-#[allow(clippy::too_many_arguments)]
-#[derive(Clone, new, Getters, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct AudioQuery {
     /// アクセント句の配列。
-    accent_phrases: Vec<AccentPhrase>,
+    pub accent_phrases: Vec<AccentPhrase>,
     /// 全体の話速。
-    speed_scale: f32,
+    pub speed_scale: f32,
     /// 全体の音高。
-    pitch_scale: f32,
+    pub pitch_scale: f32,
     /// 全体の抑揚。
-    intonation_scale: f32,
+    pub intonation_scale: f32,
     /// 全体の音量。
-    volume_scale: f32,
+    pub volume_scale: f32,
     /// 音声の前の無音時間。
-    pre_phoneme_length: f32,
+    pub pre_phoneme_length: f32,
     /// 音声の後の無音時間。
-    post_phoneme_length: f32,
+    pub post_phoneme_length: f32,
     /// 音声データの出力サンプリングレート。
-    output_sampling_rate: u32,
+    pub output_sampling_rate: u32,
     /// 音声データをステレオ出力するか否か。
-    output_stereo: bool,
+    pub output_stereo: bool,
     /// \[読み取り専用\] AquesTalk風記法。
     ///
     /// [`Synthesizer::audio_query`]が返すもののみ`Some`となる。入力としてのAudioQueryでは無視され
     /// る。
     ///
-    /// [`Synthesizer::audio_query`]: crate::Synthesizer::audio_query
-    kana: Option<String>,
+    /// [`Synthesizer::audio_query`]: crate::blocking::Synthesizer::audio_query
+    pub kana: Option<String>,
 }
 
 impl AudioQuery {
@@ -92,8 +89,18 @@ mod tests {
 
     #[rstest]
     fn check_audio_query_model_json_field_snake_case() {
-        let audio_query_model =
-            AudioQuery::new(vec![], 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0, false, None);
+        let audio_query_model = AudioQuery {
+            accent_phrases: vec![],
+            speed_scale: 0.0,
+            pitch_scale: 0.0,
+            intonation_scale: 0.0,
+            volume_scale: 0.0,
+            pre_phoneme_length: 0.0,
+            post_phoneme_length: 0.0,
+            output_sampling_rate: 0,
+            output_stereo: false,
+            kana: None,
+        };
         let val = serde_json::to_value(audio_query_model).unwrap();
         check_json_field_snake_case(&val);
     }

--- a/crates/voicevox_core/src/metas.rs
+++ b/crates/voicevox_core/src/metas.rs
@@ -1,6 +1,5 @@
 use std::fmt::{Debug, Display};
 
-use derive_getters::Getters;
 use derive_new::new;
 use indexmap::IndexMap;
 use itertools::Itertools as _;
@@ -102,20 +101,20 @@ impl Display for StyleVersion {
 pub type VoiceModelMeta = Vec<SpeakerMeta>;
 
 /// **話者**(_speaker_)のメタ情報。
-#[derive(Deserialize, Serialize, Getters, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct SpeakerMeta {
     /// 話者名。
-    name: String,
+    pub name: String,
     /// 話者に属するスタイル。
-    styles: Vec<StyleMeta>,
+    pub styles: Vec<StyleMeta>,
     /// 話者のバージョン。
-    version: StyleVersion,
+    pub version: StyleVersion,
     /// 話者のUUID。
-    speaker_uuid: String,
+    pub speaker_uuid: String,
     /// 話者の順番。
     ///
     /// `SpeakerMeta`の列は、この値に対して昇順に並んでいるべきである。
-    order: Option<u32>,
+    pub order: Option<u32>,
 }
 
 impl SpeakerMeta {
@@ -161,19 +160,19 @@ impl SpeakerMeta {
 }
 
 /// **スタイル**(_style_)のメタ情報。
-#[derive(Deserialize, Serialize, Getters, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct StyleMeta {
     /// スタイルID。
-    id: StyleId,
+    pub id: StyleId,
     /// スタイル名。
-    name: String,
+    pub name: String,
     /// スタイルに対応するモデルの種類。
     #[serde(default)]
-    r#type: StyleType,
+    pub r#type: StyleType,
     /// スタイルの順番。
     ///
     /// [`SpeakerMeta::styles`]は、この値に対して昇順に並んでいるべきである。
-    order: Option<u32>,
+    pub order: Option<u32>,
 }
 
 /// **スタイル**(_style_)に対応するモデルの種類。

--- a/crates/voicevox_core/src/user_dict/word.rs
+++ b/crates/voicevox_core/src/user_dict/word.rs
@@ -5,25 +5,24 @@ use crate::{
         priority2cost, MAX_PRIORITY, MIN_PRIORITY, PART_OF_SPEECH_DETAIL,
     },
 };
-use derive_getters::Getters;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{de::Error as _, Deserialize, Serialize};
 use std::ops::RangeToInclusive;
 
 /// ユーザー辞書の単語。
-#[derive(Clone, Debug, Getters, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct UserDictWord {
     /// 単語の表記。
-    pub surface: String,
+    surface: String,
     /// 単語の読み。
-    pub pronunciation: String,
+    pronunciation: String,
     /// アクセント型。
-    pub accent_type: usize,
+    accent_type: usize,
     /// 単語の種類。
-    pub word_type: UserDictWordType,
+    word_type: UserDictWordType,
     /// 単語の優先度。
-    pub priority: u32,
+    priority: u32,
 
     /// モーラ数。
     mora_count: usize,
@@ -127,6 +126,31 @@ impl UserDictWord {
             mora_count,
         })
     }
+
+    /// 単語の表記。
+    pub fn surface(&self) -> &str {
+        &self.surface
+    }
+
+    /// 単語の読み。
+    pub fn pronunciation(&self) -> &str {
+        &self.pronunciation
+    }
+
+    /// アクセント型。
+    pub fn accent_type(&self) -> usize {
+        self.accent_type
+    }
+
+    /// 単語の種類。
+    pub fn word_type(&self) -> UserDictWordType {
+        self.word_type
+    }
+
+    /// 単語の優先度。
+    pub fn priority(&self) -> u32 {
+        self.priority
+    }
 }
 
 /// カタカナの文字列が発音として有効かどうかを判定する。
@@ -203,7 +227,7 @@ pub(crate) fn to_zenkaku(surface: &str) -> String {
         .collect()
 }
 /// ユーザー辞書の単語の種類。
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum UserDictWordType {
     /// 固有名詞。

--- a/crates/voicevox_core/src/voice_model.rs
+++ b/crates/voicevox_core/src/voice_model.rs
@@ -3,9 +3,7 @@
 //! VVM ファイルの定義と形式は[ドキュメント](../../../docs/vvm.md)を参照。
 
 use anyhow::anyhow;
-use derive_getters::Getters;
 use derive_more::From;
-use derive_new::new;
 use easy_ext::ext;
 use enum_map::EnumMap;
 use itertools::Itertools as _;
@@ -41,15 +39,16 @@ pub(crate) type ModelBytesWithInnerVoiceIdsByDomain =
     Hash,
     PartialOrd,
     Deserialize,
-    new,
-    Getters,
     derive_more::Display,
     Debug,
     From,
 )]
-#[serde(transparent)]
-pub struct VoiceModelId {
-    raw_voice_model_id: RawVoiceModelId,
+pub struct VoiceModelId(RawVoiceModelId);
+
+impl VoiceModelId {
+    pub fn raw_voice_model_id(self) -> RawVoiceModelId {
+        self.0
+    }
 }
 
 // FIXME: "header"といいつつ、VVMのファイルパスを持っている状態になっている。
@@ -106,9 +105,8 @@ impl ManifestDomains {
     fn check_acceptable(&self, metas: &[SpeakerMeta]) -> std::result::Result<(), StyleType> {
         let err = metas
             .iter()
-            .flat_map(SpeakerMeta::styles)
-            .map(StyleMeta::r#type)
-            .copied()
+            .flat_map(|SpeakerMeta { styles, .. }| styles)
+            .map(|StyleMeta { r#type, .. }| *r#type)
             .unique()
             .find(|&style_type| !self.accepts(style_type));
 
@@ -153,6 +151,7 @@ pub(crate) mod blocking {
     use ouroboros::self_referencing;
     use rayon::iter::{IntoParallelIterator as _, ParallelIterator as _};
     use serde::de::DeserializeOwned;
+    use uuid::Uuid;
 
     use crate::{
         error::{LoadModelError, LoadModelErrorKind, LoadModelResult},
@@ -288,8 +287,8 @@ pub(crate) mod blocking {
 
     #[ext(IdRef)]
     pub impl VoiceModel {
-        fn id_ref(&self) -> &VoiceModelId {
-            &self.header.manifest.id
+        fn id_ref(&self) -> &Uuid {
+            &self.header.manifest.id.0
         }
     }
 }

--- a/crates/voicevox_core_c_api/src/compatible_engine.rs
+++ b/crates/voicevox_core_c_api/src/compatible_engine.rs
@@ -51,8 +51,8 @@ static VOICE_MODEL_SET: Lazy<VoiceModelSet> = Lazy::new(|| {
     let mut style_model_map = BTreeMap::default();
     for vvm in all_vvms.iter() {
         for meta in vvm.metas().iter() {
-            for style in meta.styles().iter() {
-                style_model_map.insert(*style.id(), vvm.id());
+            for style in meta.styles.iter() {
+                style_model_map.insert(style.id, vvm.id());
             }
         }
     }

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -449,7 +449,7 @@ pub unsafe extern "C" fn voicevox_voice_model_new_from_path(
 #[no_mangle]
 pub extern "C" fn voicevox_voice_model_id(model: &VoicevoxVoiceModel) -> VoicevoxVoiceModelId<'_> {
     init_logger_once();
-    model.model.id_ref().raw_voice_model_id().as_bytes()
+    model.model.id_ref().as_bytes()
 }
 
 /// ::VoicevoxVoiceModel からメタ情報を取得する。
@@ -1281,9 +1281,9 @@ pub extern "C" fn voicevox_user_dict_word_make(
     VoicevoxUserDictWord {
         surface,
         pronunciation,
-        accent_type: UserDictWord::default().accent_type,
-        word_type: UserDictWord::default().word_type.into(),
-        priority: UserDictWord::default().priority,
+        accent_type: UserDictWord::default().accent_type(),
+        word_type: UserDictWord::default().word_type().into(),
+        priority: UserDictWord::default().priority(),
     }
 }
 

--- a/crates/voicevox_core_java_api/src/voice_model.rs
+++ b/crates/voicevox_core_java_api/src/voice_model.rs
@@ -35,7 +35,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_VoiceModel_rsGetId<'loc
             .get_rust_field::<_, _, Arc<voicevox_core::blocking::VoiceModel>>(&this, "handle")?
             .clone();
 
-        let id = env.new_uuid(*internal.id().raw_voice_model_id())?;
+        let id = env.new_uuid(internal.id().raw_voice_model_id())?;
 
         Ok(id.into_raw())
     })

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -173,7 +173,7 @@ mod blocking {
 
         #[getter]
         fn id(&self, py: Python<'_>) -> PyResult<PyObject> {
-            let id = *self.model.id().raw_voice_model_id();
+            let id = self.model.id().raw_voice_model_id();
             crate::convert::to_py_uuid(py, id)
         }
 
@@ -676,7 +676,7 @@ mod asyncio {
 
         #[getter]
         fn id(&self, py: Python<'_>) -> PyResult<PyObject> {
-            let id = *self.model.id().raw_voice_model_id();
+            let id = self.model.id().raw_voice_model_id();
             crate::convert::to_py_uuid(py, id)
         }
 


### PR DESCRIPTION
## 内容

題の通りです。

- `SupportedDevices`, `SpeakerMeta`系: VOICEVOX CORE側から一方的に返すものなので[open struct](https://chatgpt.com/share/7b23fd9b-3db3-48d7-bd3d-0199f97e4ff2)でよい
- `AudioQuery`系: 「不正な`AudioQuery`」という概念は一応今は定義されていないため、open structでよい
- `UserDictWord`: 上記とは異なり、「不正な`UserDictWord`」という概念が存在するためgetterを定義
    - `surface`と`pronunciation`と`priority`だけだったら`UserDictWord{Surface,…}`を作ればよいのだが、「`accent_type`は単語のモーラ数を超過してはならない」という制約もある

## 関連 Issue

ref #388

## その他
