### PR TITLE
[release-0.15] macos-11をmacos-12にアップデートしておく

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -72,13 +72,13 @@ jobs:
             artifact_name: linux-arm64-cpu
             whl_local_version: cpu
             use_cuda: false
-          - os: macos-11
+          - os: macos-12
             features: ""
             target: aarch64-apple-darwin
             artifact_name: osx-arm64-cpu
             whl_local_version: cpu
             use_cuda: false
-          - os: macos-11
+          - os: macos-12
             features: ""
             target: x86_64-apple-darwin
             artifact_name: osx-x64-cpu
@@ -209,10 +209,10 @@ jobs:
             os: ubuntu-20.04
           - name: download-osx-x64
             target: x86_64-apple-darwin
-            os: macos-11
+            os: macos-12
           - name: download-osx-arm64
             target: aarch64-apple-darwin
-            os: macos-11
+            os: macos-12
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Install cbindgen
         uses: ./.github/actions/cargo-binstall-cbindgen
       - name: Install cargo-edit
-        # if: ${{ env.VERSION != 'DEBUG' }} # TODO: 戻す
+        if: ${{ env.VERSION != 'DEBUG' }}
         shell: bash
         run: cargo binstall cargo-edit@^0.11 --no-confirm --log-level debug --locked # NOTE: release-0.15で追加
       - name: set cargo version

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -107,9 +107,9 @@ jobs:
       - name: Install cbindgen
         uses: ./.github/actions/cargo-binstall-cbindgen
       - name: Install cargo-edit
-        if: ${{ env.VERSION != 'DEBUG' }}
+        # if: ${{ env.VERSION != 'DEBUG' }} # TODO: 戻す
         shell: bash
-        run: cargo binstall cargo-edit@^0.11 --no-confirm --log-level debug
+        run: cargo binstall cargo-edit@^0.11 --no-confirm --log-level debug --locked # NOTE: release-0.15で追加
       - name: set cargo version
         if: ${{ env.VERSION != 'DEBUG' }}
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,9 +80,9 @@ jobs:
             features: directml
           - os: windows-2022
             features: directml
-          - os: macos-11
-            features: ""
           - os: macos-12
+            features: ""
+          - os: macos-13
             features: ""
           - os: ubuntu-20.04
             features: ""
@@ -198,7 +198,7 @@ jobs:
           cp -v target/debug/build/onnxruntime-sys-*/out/onnxruntime_*/onnxruntime-*/lib/onnxruntime.dll . || true
           cp -v target/debug/build/onnxruntime-sys-*/out/onnxruntime_*/onnxruntime-*/lib/libonnxruntime.so.* . || true
           cp -v target/debug/build/onnxruntime-sys-*/out/onnxruntime_*/onnxruntime-*/lib/libonnxruntime.*.dylib . || true
-      - name: '`maturin develop`でインストールした`voicevox_core_python_api`を実行'
+      - name: "`maturin develop`でインストールした`voicevox_core_python_api`を実行"
         shell: python
         run: |
           import voicevox_core

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -198,7 +198,7 @@ jobs:
           cp -v target/debug/build/onnxruntime-sys-*/out/onnxruntime_*/onnxruntime-*/lib/onnxruntime.dll . || true
           cp -v target/debug/build/onnxruntime-sys-*/out/onnxruntime_*/onnxruntime-*/lib/libonnxruntime.so.* . || true
           cp -v target/debug/build/onnxruntime-sys-*/out/onnxruntime_*/onnxruntime-*/lib/libonnxruntime.*.dylib . || true
-      - name: "`maturin develop`でインストールした`voicevox_core_python_api`を実行"
+      - name: '`maturin develop`でインストールした`voicevox_core_python_api`を実行'
         shell: python
         run: |
           import voicevox_core


### PR DESCRIPTION
## 概要

release-0.15でまたアップデートリリースする可能性があるので、release-0.15ブランチのmacos-11をmacos-12にアップデートしておきます。
（というより、Nemo側でmacos-12を試してエラーになったのでこちらでも試してみようかなと･･･）

## その他
