### PR TITLE
ci: Renovate v38に適応する

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,12 +8,19 @@
     {
       "groupSlug": "rust",
       "groupName": "Rust",
-      "matchDepPatterns": "^Rust$"
+      "matchPackagePatterns": [
+        "^rust-lang/rust$"
+      ]
     },
     {
       "groupSlug": "others",
       "groupName": "Others",
-      "excludeDepPatterns": "^Rust$",
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "excludePackagePatterns": [
+        "^rust-lang/rust$"
+      ],
       "dependencyDashboardApproval": true
     }
   ],


### PR DESCRIPTION
## 内容

#814 を調べたら、[GitHub App](https://github.com/apps/renovate)上で動くRenovate本体のバージョンが8月6日に37.440.7から38.18.17に上がったことがわかりました。そのため[Renovate v37 → v38での破壊的変更](https://docs.renovatebot.com/release-notes-for-major-versions/#breaking-changes-for-38)に対応することで問題を解決します。

ただ、changelogを見てもよくわからなかったのでエラーメッセージの内容から推察して適当に弄って直しました。qryxip/voicevox\_core上で動かしましたが、おそらく以前の通りに動きます。

## 関連 Issue

ref #814 (設定として直り次第Renovate側からcloseされるはず)

## その他
