### PR TITLE
ci: Renovateのdatasourceを`github-tags`にする

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,7 +35,7 @@
       ],
       "depNameTemplate": "Rust",
       "packageNameTemplate": "rust-lang/rust",
-      "datasourceTemplate": "github-releases"
+      "datasourceTemplate": "github-tags"
     }
   ]
 }


### PR DESCRIPTION
## 内容

最近rust-lang/rustの緊急パッチリリース (e.g. 最近の1.80.1)はGitHub Releaseの方から出ない傾向にあり、今のRenovateの設定だと反応しません。そのため設定の`datasourceTemplate`を[`github-releases`](https://docs.renovatebot.com/modules/datasource/github-releases/)から[`github-tags`](https://docs.renovatebot.com/modules/datasource/github-tags/)に変えることで拾えるようにします。

![image](https://github.com/user-attachments/assets/d3d29a59-55f3-4e05-95ec-91ea78c7f74f)

## 関連 Issue

#817 に依存します。

## その他
