### PR TITLE
Update jump-to version on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VOICEVOX CORE
 
-## **現在の main ブランチは工事中なので正しく動かないことがあります。[バージョン 0.14.4](https://github.com/VOICEVOX/voicevox_core/tree/0.14.4)をご利用ください。**
+## **現在の main ブランチは工事中なので正しく動かないことがあります。[バージョン 0.15.4](https://github.com/VOICEVOX/voicevox_core/tree/0.15.4)をご利用ください。**
 
 [![releases](https://img.shields.io/github/v/release/VOICEVOX/voicevox_core?label=release)](https://github.com/VOICEVOX/voicevox_core/releases)
 [![test](https://github.com/VOICEVOX/voicevox_core/actions/workflows/test.yml/badge.svg)](https://github.com/VOICEVOX/voicevox_core/actions/workflows/test.yml)


### PR DESCRIPTION
## 内容

README の冒頭にある「現在の main ブランチは……」が参照するように言っているバージョンが古いので新しくしました．

## その他

ところで，[0.15.4](https://github.com/VOICEVOX/voicevox_core/tree/0.15.4) には「0.13.0をご利用ください」とありますけど，大丈夫なんでしょうか……？