### PR TITLE
chore: Rust 1.81で追加された機能を利用する

### DIFF
--- a/crates/test_util/src/lib.rs
+++ b/crates/test_util/src/lib.rs
@@ -8,7 +8,9 @@ include!(concat!(env!("OUT_DIR"), "/sample_voice_model_file.rs"));
     non_upper_case_globals,
     unused_extern_crates,
     clippy::missing_safety_doc,
-    clippy::too_many_arguments
+    clippy::too_many_arguments,
+    reason = "bindgenが生成するコードのため。`#[expect]`ではなく`#[allow]`なのは、bindgenが生成\
+              するコードがOSにより変わるため"
 )]
 pub mod c_api {
     include!(concat!(env!("OUT_DIR"), "/c_api.rs"));

--- a/crates/voicevox_core/src/devices.rs
+++ b/crates/voicevox_core/src/devices.rs
@@ -225,7 +225,10 @@ mod tests {
 
         assert_eq!(
             {
-                #[forbid(unused_variables)]
+                #[forbid(
+                    unused_variables,
+                    reason = "比較対象としてここは網羅されてなければなりません"
+                )]
                 let SupportedDevices { cpu: _, cuda, dml } = &SUPPORTED_DEVICES;
                 [cuda as *const _, dml as *const _]
             },

--- a/crates/voicevox_core/src/engine/acoustic_feature_extractor.rs
+++ b/crates/voicevox_core/src/engine/acoustic_feature_extractor.rs
@@ -63,9 +63,8 @@ static PHONEME_MAP: LazyLock<HashMap<&str, i64>> = LazyLock::new(|| {
 #[derive(Debug, Clone, PartialEq, new, Default, Getters)]
 pub(crate) struct OjtPhoneme {
     phoneme: String,
-    #[allow(dead_code)]
+    // FIXME: derive-getters(多分)が警告を覆い隠しているが、以下の二つは使っていないはず
     start: f32,
-    #[allow(dead_code)]
     end: f32,
 }
 

--- a/crates/voicevox_core/src/infer.rs
+++ b/crates/voicevox_core/src/infer.rs
@@ -30,7 +30,11 @@ pub(crate) trait InferenceRuntime: 'static {
     /// GPUが実際に利用できそうかどうか判定する。
     fn test_gpu(&self, gpu: GpuSpec) -> anyhow::Result<()>;
 
-    #[allow(clippy::type_complexity)]
+    #[expect(
+        clippy::type_complexity,
+        reason = "ここを呼び出すのは現状一箇所なので、可読性が著しく落ちてはいないことを考えると\
+                  別にこのままでいいはず"
+    )]
     fn new_session(
         &self,
         model: impl FnOnce() -> std::result::Result<Vec<u8>, DecryptModelError>,
@@ -64,7 +68,11 @@ pub(crate) trait InferenceDomain: Sized {
 /// `::macros::InferenceOperation`により導出される。
 pub(crate) trait InferenceOperation: Copy + Enum {
     /// `{InferenceInputSignature,InferenceOutputSignature}::PARAM_INFOS`を集めたもの。
-    #[allow(clippy::type_complexity)]
+    #[expect(
+        clippy::type_complexity,
+        reason = "ここを参照するのは現状一箇所なので、可読性が著しく落ちてはいないことを考えると\
+                  別にこのままでいいはず"
+    )]
     const PARAM_INFOS: EnumMap<
         Self,
         (

--- a/crates/voicevox_core/src/lib.rs
+++ b/crates/voicevox_core/src/lib.rs
@@ -72,8 +72,10 @@ pub mod tokio;
 #[cfg(test)]
 mod test_util;
 
-// https://crates.io/crates/rstest_reuse#use-rstest_resuse-at-the-top-of-your-crate
-#[allow(clippy::single_component_path_imports)]
+#[expect(
+    clippy::single_component_path_imports,
+    reason = "https://crates.io/crates/rstest_reuse/0.6.0#use-rstest_resuse-at-the-top-of-your-crate"
+)]
 #[cfg(test)]
 use rstest_reuse;
 

--- a/crates/voicevox_core/src/manifest.rs
+++ b/crates/voicevox_core/src/manifest.rs
@@ -67,7 +67,7 @@ impl Display for InnerVoiceId {
 
 #[derive(Deserialize, Getters, Clone)]
 pub struct Manifest {
-    #[allow(dead_code)]
+    #[expect(dead_code, reason = "現状はバリデーションのためだけに存在")]
     vvm_format_version: FormatVersionV1,
     pub(crate) id: VoiceModelId,
     metas_filename: String,
@@ -125,7 +125,7 @@ mod tests {
 
         #[derive(Deserialize)]
         struct ManifestPart {
-            #[allow(dead_code)]
+            #[expect(dead_code, reason = "バリデーションのためだけに存在")]
             vvm_format_version: FormatVersionV1,
         }
     }

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -808,7 +808,11 @@ pub(crate) mod blocking {
         /// # Performance
         ///
         /// CPU-boundな操作であるため、非同期ランタイム上では直接実行されるべきではない。
-        #[allow(clippy::too_many_arguments)]
+        #[expect(
+            clippy::too_many_arguments,
+            reason = "compatible_engineでの`predict_intonation`の形を考えると、ここの引数を構造体に\
+                      まとめたりしても可読性に寄与しない"
+        )]
         fn predict_intonation(
             &self,
             length: usize,

--- a/crates/voicevox_core/src/user_dict/word.rs
+++ b/crates/voicevox_core/src/user_dict/word.rs
@@ -55,7 +55,7 @@ impl<'de> Deserialize<'de> for UserDictWord {
     }
 }
 
-#[allow(clippy::enum_variant_names)] // FIXME
+#[expect(clippy::enum_variant_names, reason = "特に理由はないので正されるべき")] // FIXME
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub(crate) enum InvalidWordError {
     #[error("{}: 無効な発音です({_1}): {_0:?}", Self::BASE_MSG)]

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -354,7 +354,10 @@ pub extern "C" fn voicevox_open_jtalk_rc_delete(open_jtalk: Box<OpenJtalkRc>) {
 /// ハードウェアアクセラレーションモードを設定する設定値。
 #[repr(i32)]
 #[derive(Debug, PartialEq, Eq)]
-#[allow(non_camel_case_types)]
+#[allow(
+    non_camel_case_types,
+    reason = "実際に公開するC APIとの差異をできるだけ少なくするため"
+)]
 pub enum VoicevoxAccelerationMode {
     /// 実行環境に合った適切なハードウェアアクセラレーションモードを選択する
     VOICEVOX_ACCELERATION_MODE_AUTO = 0,
@@ -1247,7 +1250,10 @@ pub struct VoicevoxUserDictWord {
 
 /// ユーザー辞書の単語の種類。
 #[repr(i32)]
-#[allow(non_camel_case_types)]
+#[allow(
+    non_camel_case_types,
+    reason = "実際に公開するC APIとの差異をできるだけ少なくするため"
+)]
 #[derive(Copy, Clone)]
 pub enum VoicevoxUserDictWordType {
     /// 固有名詞。

--- a/crates/voicevox_core_c_api/src/result_code.rs
+++ b/crates/voicevox_core_c_api/src/result_code.rs
@@ -5,10 +5,11 @@ use cstr::cstr;
 /// 処理結果を示す結果コード。
 #[repr(i32)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-#[allow(non_camel_case_types)]
+#[allow(
+    non_camel_case_types,
+    reason = "実際に公開するC APIとの差異をできるだけ少なくするため"
+)]
 pub enum VoicevoxResultCode {
-    // C でのenum定義に合わせて大文字で定義している
-    // 出力フォーマットを変更すればRustでよく使われているUpperCamelにできるが、実際に出力されるコードとの差異をできるだけ少なくするため
     /// 成功
     VOICEVOX_RESULT_OK = 0,
     /// open_jtalk辞書ファイルが読み込まれていない

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -322,9 +322,9 @@ mod blocking {
 
         fn __exit__(
             &mut self,
-            #[allow(unused_variables)] exc_type: &PyAny,
-            #[allow(unused_variables)] exc_value: &PyAny,
-            #[allow(unused_variables)] traceback: &PyAny,
+            #[expect(unused_variables, reason = "`__exit__`としては必要")] exc_type: &PyAny,
+            #[expect(unused_variables, reason = "`__exit__`としては必要")] exc_value: &PyAny,
+            #[expect(unused_variables, reason = "`__exit__`としては必要")] traceback: &PyAny,
         ) {
             self.close();
         }
@@ -759,7 +759,7 @@ mod asyncio {
 
     #[pymethods]
     impl OpenJtalk {
-        #[allow(clippy::new_ret_no_self)]
+        #[expect(clippy::new_ret_no_self, reason = "これはPython API")]
         #[staticmethod]
         fn new(
             #[pyo3(from_py_with = "crate::convert::from_utf8_path")]
@@ -829,9 +829,9 @@ mod asyncio {
 
         fn __exit__(
             &mut self,
-            #[allow(unused_variables)] exc_type: &PyAny,
-            #[allow(unused_variables)] exc_value: &PyAny,
-            #[allow(unused_variables)] traceback: &PyAny,
+            #[expect(unused_variables, reason = "`__exit__`としては必要")] exc_type: &PyAny,
+            #[expect(unused_variables, reason = "`__exit__`としては必要")] exc_value: &PyAny,
+            #[expect(unused_variables, reason = "`__exit__`としては必要")] traceback: &PyAny,
         ) {
             self.close();
         }


### PR DESCRIPTION
## 内容

[Announcing Rust 1.81.0 | Rust Blog](https://blog.rust-lang.org/2024/09/05/Rust-1.81.0.html)

- `#[allow(…)]`を`#[expect(…)]`に置き換えます。不要になった警告抑制をすみやかに消せるようにするためです。
    - C APIの`non_camel_case_types`だけ、Rust Analyzerがまだ`#[expect(…)]`に対応していなくてClippyとは別に文句を言ってくるため`#[allow(…)]`のままにしています。
        \[追記\] test_utilで生成しているc_api.rsについても、OSによってbindgenの生成コードが変わって管理が面倒なので`#[expect(…)]`にするのは諦めました。
- `#[allow(…)]`, `#[expect(…)]`, `#[forbid(…)]`のすべてに`reason = "…"`を書きます。
    - `allow`と`expect`の`reason`をどういう文体で書くか迷ったのですが、コメントのような感じで書くことにしました。`forbid`の方はエラーメッセージとしての文体に。

## 関連 Issue

Rust 1.81: #826
前回: #816

## その他
