### PR TITLE
change: minor changes for `UserDict` API

### DIFF
--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/UserDict.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/UserDict.java
@@ -108,6 +108,26 @@ public class UserDict extends Dll {
    * @param path ユーザー辞書のパス。
    * @throws SaveUserDictException ユーザー辞書を保存できなかった場合。
    */
+  public void save(Path path) throws SaveUserDictException {
+    rsSave(path.toString());
+  }
+
+  /**
+   * ユーザー辞書を保存する。
+   *
+   * @param path ユーザー辞書のパス。
+   * @throws SaveUserDictException ユーザー辞書を保存できなかった場合。
+   */
+  public void save(File path) throws SaveUserDictException {
+    rsSave(path.toString());
+  }
+
+  /**
+   * ユーザー辞書を保存する。
+   *
+   * @param path ユーザー辞書のパス。
+   * @throws SaveUserDictException ユーザー辞書を保存できなかった場合。
+   */
   public void save(String path) throws SaveUserDictException {
     rsSave(path);
   }

--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/UserDict.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/UserDict.java
@@ -7,6 +7,8 @@ import com.google.gson.internal.LinkedTreeMap;
 import jakarta.annotation.Nonnull;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import java.io.File;
+import java.nio.file.Path;
 import java.util.HashMap;
 import jp.hiroshiba.voicevoxcore.exceptions.LoadUserDictException;
 import jp.hiroshiba.voicevoxcore.exceptions.SaveUserDictException;
@@ -68,6 +70,26 @@ public class UserDict extends Dll {
    */
   public void importDict(UserDict dict) {
     rsImportDict(dict);
+  }
+
+  /**
+   * ユーザー辞書を読み込む。
+   *
+   * @param path ユーザー辞書のパス。
+   * @throws LoadUserDictException ユーザー辞書を読み込めなかった場合。
+   */
+  public void load(Path path) throws LoadUserDictException {
+    load(path.toString());
+  }
+
+  /**
+   * ユーザー辞書を読み込む。
+   *
+   * @param path ユーザー辞書のパス。
+   * @throws LoadUserDictException ユーザー辞書を読み込めなかった場合。
+   */
+  public void load(File path) throws LoadUserDictException {
+    load(path.toString());
   }
 
   /**

--- a/crates/voicevox_core_java_api/src/user_dict.rs
+++ b/crates/voicevox_core_java_api/src/user_dict.rs
@@ -124,7 +124,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_UserDict_rsLoad<'local>
             .clone();
 
         let path = env.get_string(&path)?;
-        let path = &Cow::from(&path);
+        let path = &*Cow::from(&path);
 
         internal.load(path)?;
 
@@ -144,7 +144,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_UserDict_rsSave<'local>
             .clone();
 
         let path = env.get_string(&path)?;
-        let path = &Cow::from(&path);
+        let path = &*Cow::from(&path);
 
         internal.save(path)?;
 

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/asyncio.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/asyncio.pyi
@@ -431,7 +431,7 @@ class UserDict:
         """このオプジェクトの :class:`dict` としての表現。"""
         ...
     def __init__(self) -> None: ...
-    async def load(self, path: str) -> None:
+    async def load(self, path: Union[str, PathLike[str]]) -> None:
         """ファイルに保存されたユーザー辞書を読み込む。
 
         Parameters
@@ -440,7 +440,7 @@ class UserDict:
             ユーザー辞書のパス。
         """
         ...
-    async def save(self, path: str) -> None:
+    async def save(self, path: Union[str, PathLike[str]]) -> None:
         """
         ユーザー辞書をファイルに保存する。
 

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
@@ -426,7 +426,7 @@ class UserDict:
         """このオプジェクトの :class:`dict` としての表現。"""
         ...
     def __init__(self) -> None: ...
-    def load(self, path: str) -> None:
+    def load(self, path: Union[str, PathLike[str]]) -> None:
         """ファイルに保存されたユーザー辞書を読み込む。
 
         Parameters
@@ -435,7 +435,7 @@ class UserDict:
             ユーザー辞書のパス。
         """
         ...
-    def save(self, path: str) -> None:
+    def save(self, path: Union[str, PathLike[str]]) -> None:
         """
         ユーザー辞書をファイルに保存する。
 

--- a/crates/voicevox_core_python_api/src/convert.rs
+++ b/crates/voicevox_core_python_api/src/convert.rs
@@ -37,7 +37,6 @@ pub(crate) fn from_acceleration_mode(ob: &PyAny) -> PyResult<AccelerationMode> {
     }
 }
 
-// FIXME: `UserDict`についてはこれではなく、`PathBuf::extract`を直接使うようにする
 pub(crate) fn from_utf8_path(ob: &PyAny) -> PyResult<Utf8PathBuf> {
     PathBuf::extract(ob)?
         .into_os_string()

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -734,11 +734,11 @@ mod blocking {
             Self::default()
         }
 
-        fn load(&self, path: &str, py: Python<'_>) -> PyResult<()> {
+        fn load(&self, path: PathBuf, py: Python<'_>) -> PyResult<()> {
             self.dict.load(path).into_py_result(py)
         }
 
-        fn save(&self, path: &str, py: Python<'_>) -> PyResult<()> {
+        fn save(&self, path: PathBuf, py: Python<'_>) -> PyResult<()> {
             self.dict.save(path).into_py_result(py)
         }
 
@@ -1363,9 +1363,8 @@ mod asyncio {
             Self::default()
         }
 
-        fn load<'py>(&self, path: &str, py: Python<'py>) -> PyResult<&'py PyAny> {
+        fn load<'py>(&self, path: PathBuf, py: Python<'py>) -> PyResult<&'py PyAny> {
             let this = self.dict.clone();
-            let path = path.to_owned();
 
             pyo3_asyncio::tokio::future_into_py(py, async move {
                 let result = this.load(&path).await;
@@ -1373,9 +1372,8 @@ mod asyncio {
             })
         }
 
-        fn save<'py>(&self, path: &str, py: Python<'py>) -> PyResult<&'py PyAny> {
+        fn save<'py>(&self, path: PathBuf, py: Python<'py>) -> PyResult<&'py PyAny> {
             let this = self.dict.clone();
-            let path = path.to_owned();
 
             pyo3_asyncio::tokio::future_into_py(py, async move {
                 let result = this.save(&path).await;


### PR DESCRIPTION
## 内容

`UserDict`のパブリックAPIについて以下の変更を加えます。

1. `load`と`store`が引数に取るファイルパスについて:
    * Rust APIでは`&str`から`impl AsRef<Path>`にする
    * Python APIでは[`StrPath`](https://github.com/python/typeshed/blob/6cddd30ff2a64f6a3e509c992684c4a0a357fe71/stdlib/_typeshed/__init__.pyi#L173)相当にする
    * Java APIでは`java.io.File`と`java.nio.file.Path`のオーバーロードを追加する
2. Rust APIの`with_words`から`&mut IndexMap<…>`が得られるようにします。

## 関連 Issue

## その他

本当は`dict`や`java.util.HashMap`へ変換するやつについても手を入れたかったのですが、やるならそこそこ大々的にやった方がよいかなと思い見送りました。
