### PR TITLE
chore: voicevox.github.io/voicevox_core/apis内のリンクを置き換え

### DIFF
--- a/docs/apis/index.html
+++ b/docs/apis/index.html
@@ -7,8 +7,8 @@
     <!-- TODO: まともなページを用意する -->
     <ul>
       <li><a href="./rust_api/voicevox_core">Rust API</a></li>
-      <li><a href="./c_api">C API</a></li>
-      <li><a href="./python_api">Python API</a></li>
+      <li><a href="./c_api/voicevox__core_8h.html">C API</a></li>
+      <li><a href="./python_api/autoapi/voicevox_core/index.html">Python API</a></li>
       <li><a href="./java_api">Java API</a></li>
     </ul>
   </body>


### PR DESCRIPTION
## 内容

<https://voicevox.github.io/voicevox_core/apis/>のC APIとPython APIのリンク先が不親切なことになっているので、置き換えます。

## 関連 Issue

#496 (?)

## その他
