### PR TITLE
chore: READMEからvoicevox.github.io/voicevox_core/apisにリンク

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## API
 
-[API ドキュメント](https://voicevox.github.io/voicevox_core/apis/c_api/globals_func.html)をご覧ください。
+[API ドキュメント](https://voicevox.github.io/voicevox_core/apis/)をご覧ください。
 
 ## ユーザーガイド
 

--- a/docs/apis/index.html
+++ b/docs/apis/index.html
@@ -4,7 +4,8 @@
     <meta charset="utf-8" />
   </head>
   <body>
-    <!-- TODO: まともなページを用意する -->
+    <p>TODO: まともなページを用意する</p>
+    <p><a href="https://github.com/VOICEVOX/voicevox_core/pull/496">VOICEVOX/voicevox_core#496</a></p>
     <ul>
       <li><a href="./rust_api/voicevox_core">Rust API</a></li>
       <li><a href="./c_api">C API</a></li>


### PR DESCRIPTION
## 内容

#269 の頃からあるリンクの宛先を<https://voicevox.github.io/voicevox_core/apis/>直下にします。

## 関連 Issue

#496 (Discordの会話: <https://discord.com/channels/879570910208733277/893889888208977960/1109301082502484108>)

## その他
