### PR TITLE
docs: READMEのビルド周りの記載を更新し、自分でビルドした場合は製品版のVVMが読めないことをわかるように

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,9 @@ VOICEVOX CORE の主要機能は Rust で実装されることを前提として
 
 ## コアライブラリのビルド
 
-[Releases](https://github.com/VOICEVOX/voicevox_core/releases) にあるビルド済みのコアライブラリを利用せず、自分で一からビルドする場合こちらを参照してください。ビルドには [Rust](https://www.rust-lang.org/ja) ([Windows での Rust 開発環境構築手順はこちら](https://docs.microsoft.com/ja-jp/windows/dev-environment/rust/setup)) と [cmake](https://cmake.org/download/) が必要です。
-
-model フォルダにある onnx モデルはダミーのため、ノイズの混じった音声が出力されます
+ビルドには [Rust](https://www.rust-lang.org/ja) ([Windows での Rust 開発環境構築手順はこちら](https://docs.microsoft.com/ja-jp/windows/dev-environment/rust/setup)) と [cmake](https://cmake.org/download/) が必要です。
+[Releases](https://github.com/VOICEVOX/voicevox_core/releases) にあるビルド済みのコアライブラリを利用せず、自分で一からビルドした場合は、model フォルダにある onnx モデルのみが利用できます。
+このモデルはダミーのため、ノイズの混じった音声が出力されます。
 
 ```bash
 # DLLをビルド


### PR DESCRIPTION
## 内容

頂いたコメントをもとに、自分でビルドした場合はサンプルモデルしか読み込めないことがわかるようにしてみました。

- https://github.com/VOICEVOX/voicevox_core/issues/492#issuecomment-2377448309

## 関連 Issue

close #492 

## その他

書き方をちょっと迷いました。
「自分で一からビルドした場合は、model フォルダにある onnx モデルのみが利用できます。」と書いていますが、実際は自分で作ったonnxモデルとかも読み込めるといえば読み込めるので･･･。
「製品版VOICEVOXのvvmは読み込めません。」の方がよければそっちにしても良いかも。
ただまぁどちらにせよ voicevox_onnxrutime 構想になれば不要になる一文なので、あまり考えすぎる必要もないかなと思って、元の文章からほとんど変わらない形を採用してみた次第です。
