### PR TITLE
fix: `IndexMap::`{`remove`→`shift_remove`}

### DIFF
--- a/crates/voicevox_core/src/status.rs
+++ b/crates/voicevox_core/src/status.rs
@@ -271,7 +271,7 @@ impl<R: InferenceRuntime> LoadedModels<R> {
     }
 
     fn remove(&mut self, model_id: VoiceModelId) -> Result<()> {
-        if self.0.remove(&model_id).is_none() {
+        if self.0.shift_remove(&model_id).is_none() {
             return Err(ErrorRepr::ModelNotFound { model_id }.into());
         }
         Ok(())

--- a/crates/voicevox_core/src/user_dict/dict.rs
+++ b/crates/voicevox_core/src/user_dict/dict.rs
@@ -61,7 +61,7 @@ impl<A: Async> Inner<A> {
     }
 
     fn remove_word(&self, word_uuid: Uuid) -> crate::Result<UserDictWord> {
-        let Some(word) = self.with_words(|words| words.remove(&word_uuid)) else {
+        let Some(word) = self.with_words(|words| words.shift_remove(&word_uuid)) else {
             return Err(ErrorRepr::WordNotFound(word_uuid).into());
         };
         Ok(word)


### PR DESCRIPTION
## 内容

indexmapを新しいバージョンに上げると以下の警告が出るため、その対応です。
（このPRではindexmapのバージョンはそのままにして、アップデートはRenovateに任せます）

```console
warning: use of deprecated method `indexmap::IndexMap::<K, V, S>::remove`: `remove` disrupts the map order -- use `swap_remove` or `shift_remove` for explicit behavior.
   --> crates/voicevox_core/src/status.rs:274:19
    |
274 |         if self.0.remove(&model_id).is_none() {
    |                   ^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default

warning: use of deprecated method `indexmap::IndexMap::<K, V, S>::remove`: `remove` disrupts the map order -- use `swap_remove` or `shift_remove` for explicit behavior.
  --> crates/voicevox_core/src/user_dict/dict.rs:64:56
   |
64 |         let Some(word) = self.with_words(|words| words.remove(&word_uuid)) else {
   |                                                        ^^^^^^
```

現在使っているindexmap v2.0.0の時点で`remove`と`swap_remove`と`shift_remove`の三つは存在しており、`remove`は`swap_remove`のエイリアスです。v2.1.0から`remove`が`#[deprecated]`になって上記の警告が出るようになったようです。

`swap_remove`と`shift_remove`の違いは何なのかと言うと、`[a, b, c, d, e]`のようなキーの並びから`swap_remove`で`b`を抜き取ると`[a, e, c, d]`のような並びになります。`shift_remove`はPythonの`dict.__delitem__`のような一般的な挙動です。

`UserDict::remove_word`とかのパブリックAPIの挙動にも関わってくるため、一般的な挙動の方がよいかと思い`swap_remove`ではなく`shift_remove`の方にしました。これが本PRのcommit prefixを"improve:"にしている理由です。
（"fix:"にしようか迷ったのですが、~~ドキュメント上で順序の保証はしてなかったかなと思ったので"improve:"にしてしまいました~~）
\[追記\] いや書いてた！！ということで、"fix:"にしました。

## 関連 Issue

#841

## その他
