### PR TITLE
ci: non-major dependenciesでは`dependencyDashboardApproval=true`

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,7 +5,7 @@
   ],
   timezone: "Asia/Tokyo",
   separateMajorMinor: false,
-  dependencyDashboardApproval: true, // 万が一`packageRules`の網羅性に穴ができた場合に備え
+  dependencyDashboardApproval: true,
   packageRules: [
     // `separateMajorMinor`を無効化した上で次の二つのgroupにすべてをまとめる。
     //
@@ -46,7 +46,6 @@
         "minor",
       ],
       matchCurrentVersion: "!/^v?0\\./",
-      dependencyDashboardApproval: false,
     },
     {
       groupName: "non-major dependencies",
@@ -54,7 +53,6 @@
         "patch",
       ],
       matchCurrentVersion: "!/^v?0\\.0\\./",
-      dependencyDashboardApproval: false,
     },
 
     // GHAのrunnerに対しては無効化する


### PR DESCRIPTION
## 内容

Renovateのpush通知がノイズになるのを軽減するため、"non-major dependencies"のPRは出しっぱなしにせず、必要に応じて手動トリガーで作成して即マージする運用にする。
<https://github.com/VOICEVOX/voicevox_core/issues/470#issuecomment-2386511058>

これによりRust本体のバージョンについては自動PRは作られなくなるが、 @qryxip が手動で"non-major dependencies"を起動することによりアップデートするようにする。

Discordでの会話:
<https://discord.com/channels/879570910208733277/893889888208977960/1291727262445469878>

## 関連 Issue

## その他

#841 はちょうど今CIが通っている状態になっていてマージ可能なので、本PRのマージ後に続けてマージすれば片付く。