### PR TITLE
feat(java)!: com.microsoft.onnxruntime/onnxruntime{,_gpu}を削除

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -470,7 +470,7 @@ jobs:
           cp ${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/x86_64-linux-android/libc++_shared.so crates/voicevox_core_java_api/lib/src/main/resources/jniLibs/x86_64/
 
           cd crates/voicevox_core_java_api
-          OS=android DEVICE=cpu gradle publishToMavenLocal
+          OS=android gradle publishToMavenLocal
 
       - name: Package
         run: |

--- a/crates/voicevox_core_java_api/README.md
+++ b/crates/voicevox_core_java_api/README.md
@@ -44,7 +44,7 @@ Java プロジェクトを動かすには、
 - `lib/src/main/resources/dll/[target]/libvoicevox_core_java_api.so` を作成する（`libvoicevox_core_java_api.so`はプラットフォームによって異なります、詳細は後述）。
 
 必要があります。
-また、ハードウェアアクセラレーションを有効にする時は`DEVICE`環境変数を`cuda`または`directml`にし、Android 版をビルドする時は`OS`環境変数を`android`にしてください。
+また、Android 版をビルドする時は`OS`環境変数を`android`にしてください。
 
 ```console
 ❯ cargo build
@@ -53,7 +53,6 @@ Java プロジェクトを動かすには、
 # または
 ❯ cp ../../target/debug/libvoicevox_core_java_api.so lib/src/main/resources/dll/[target]/libvoicevox_core_java_api.so
 ❯ ./gradlew test
-❯ DEVICE=cuda ./gradlew test
 ❯ OS=android ./gradlew test
 ```
 
@@ -61,13 +60,12 @@ Java プロジェクトを動かすには、
 
 `cargo build --release` で Rust 側を、`./gradlew build` で Java 側をビルドできます。
 パッケージ化する時は lib/src/main/resources/dll 内に dll をコピーしてください。
-`DEVICE`、`OS`環境変数は開発時と同様です。
+`OS`環境変数は開発時と同様です。
 
 ```console
 ❯ cargo build --release
 ❯ cp ../../target/release/libvoicevox_core_java_api.so lib/src/main/resources/dll/[target]/libvoicevox_core_java_api.so
 ❯ ./gradlew build
-❯ DEVICE=cuda ./gradlew build
 ❯ OS=android ./gradlew build
 ```
 

--- a/crates/voicevox_core_java_api/lib/build-android.gradle
+++ b/crates/voicevox_core_java_api/lib/build-android.gradle
@@ -25,8 +25,6 @@ dependencies {
 
     // https://mvnrepository.com/artifact/jakarta.annotation/jakarta.annotation-api
     implementation group: 'jakarta.annotation', name: 'jakarta.annotation-api', version: gradle.ext.jakartaAnnotationVersion
-
-    implementation group: 'com.microsoft.onnxruntime', name: 'onnxruntime-android', version: gradle.ext.onnxruntimeVersion
 }
 
 // Apply a specific Java toolchain to ease working on different environments.
@@ -65,7 +63,7 @@ publishing {
     publications {
         maven(MavenPublication) {
             groupId = 'jp.hiroshiba.voicevoxcore'
-            artifactId = gradle.ext.targetDevice == 'cpu' ? 'voicevoxcore-android' : "voicevoxcore-android-${gradle.ext.targetDevice}"
+            artifactId = 'voicevoxcore-android'
             version = gradle.ext.version
 
             afterEvaluate {

--- a/crates/voicevox_core_java_api/lib/build.gradle
+++ b/crates/voicevox_core_java_api/lib/build.gradle
@@ -12,8 +12,6 @@ plugins {
     id "com.diffplug.spotless" version "6.25.0"
 }
 
-def boolean isGpu = ['cuda', 'directml'].contains(gradle.ext.targetDevice)
-
 version = gradle.ext.version
 
 repositories {
@@ -35,12 +33,6 @@ dependencies {
 
     // https://mvnrepository.com/artifact/jakarta.annotation/jakarta.annotation-api
     implementation group: 'jakarta.annotation', name: 'jakarta.annotation-api', version: gradle.ext.jakartaAnnotationVersion
-
-    if (isGpu) {
-        implementation group: 'com.microsoft.onnxruntime', name: 'onnxruntime_gpu', version: gradle.ext.onnxruntimeVersion
-    } else {
-        implementation group: 'com.microsoft.onnxruntime', name: 'onnxruntime', version: gradle.ext.onnxruntimeVersion
-    }
 }
 
 // Apply a specific Java toolchain to ease working on different environments.
@@ -70,7 +62,7 @@ publishing {
     publications {
         maven(MavenPublication) {
             groupId = 'jp.hiroshiba.voicevoxcore'
-            artifactId = gradle.ext.targetDevice == 'cpu' ? 'voicevoxcore' : "voicevoxcore-${gradle.ext.targetDevice}"
+            artifactId = 'voicevoxcore'
             version = gradle.ext.version
             from components.java
         }

--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/Dll.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/Dll.java
@@ -1,6 +1,5 @@
 package jp.hiroshiba.voicevoxcore;
 
-import ai.onnxruntime.OrtEnvironment;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -42,8 +41,6 @@ abstract class Dll {
       }
 
       String target = osName + "-" + osArch;
-      // ONNX Runtime の DLL を読み込む。
-      OrtEnvironment.getEnvironment();
       try (InputStream in = Dll.class.getResourceAsStream("/dll/" + target + "/" + dllName)) {
         if (in == null) {
           try {

--- a/crates/voicevox_core_java_api/settings.gradle
+++ b/crates/voicevox_core_java_api/settings.gradle
@@ -35,7 +35,6 @@ gradle.ext {
   version = cargoTomlVersion
 
   targetOs = targetOs
-  targetDevice = System.getenv('DEVICE') ?: 'cpu'
 
   gsonVersion = '2.10.1'
   jakartaValidationVersion = '3.0.2'


### PR DESCRIPTION
## 内容

#802 により不要になり、また #825 の支障になるであろうJavaの`onnxruntime{,_gpu}`パッケージを削除する。

またそれに伴い、`artifactId`をEPごとにリネームするのをやめる。

## 関連 Issue

Refs: #802, #764, #858

## その他

Cc: @sevenc-nanashi
