### PR TITLE
fix: Python APIとexample/python/run.pyの型付けを直す

### DIFF
--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
@@ -139,6 +139,12 @@ class OpenJtalk:
         """
         ...
 
+class AudioFeature:
+    @property
+    def frame_length(self) -> int: ...
+    @property
+    def frame_rate(self) -> float: ...
+
 class Synthesizer:
     """
     音声シンセサイザ。
@@ -351,6 +357,18 @@ class Synthesizer:
             スタイルID。
         """
         ...
+    def precompute_render(
+        self,
+        audio_query: AudioQuery,
+        style_id: Union[StyleId, int],
+        enable_interrogative_upspeak: bool = True,
+    ) -> AudioFeature: ...
+    def render(
+        self,
+        audio: AudioFeature,
+        start: int,
+        end: int,
+    ) -> bytes: ...
     def synthesis(
         self,
         audio_query: AudioQuery,

--- a/crates/voicevox_core_python_api/python/voicevox_core/blocking.py
+++ b/crates/voicevox_core_python_api/python/voicevox_core/blocking.py
@@ -1,5 +1,6 @@
 # pyright: reportMissingModuleSource=false
 from ._rust.blocking import (
+    AudioFeature,
     Onnxruntime,
     OpenJtalk,
     Synthesizer,
@@ -7,4 +8,11 @@ from ._rust.blocking import (
     VoiceModelFile,
 )
 
-__all__ = ["Onnxruntime", "OpenJtalk", "Synthesizer", "UserDict", "VoiceModelFile"]
+__all__ = [
+    "AudioFeature",
+    "Onnxruntime",
+    "OpenJtalk",
+    "Synthesizer",
+    "UserDict",
+    "VoiceModelFile",
+]

--- a/example/python/run.py
+++ b/example/python/run.py
@@ -71,7 +71,7 @@ def main() -> None:
     logger.info("%s", f"Wrote `{out}`")
 
 
-def parse_args() -> Tuple[AccelerationMode, Path, str, Path, str, Path, int]:
+def parse_args() -> Tuple[AccelerationMode, Path, str, Path, str, Path, int, bool]:
     argparser = ArgumentParser()
     argparser.add_argument(
         "--mode",


### PR DESCRIPTION
## 内容

## 関連 Issue

Refs: <https://github.com/VOICEVOX/voicevox_core/pull/854#discussion_r1806646080>

## その他
