### PR TITLE
fix: 非同期関連のtodoとfixmeを解消

### DIFF
--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -248,9 +248,11 @@ mod inner {
             &self,
             model: &voice_model::Inner<A>,
         ) -> crate::Result<()> {
-            let model_bytes = &model.read_inference_models().await?;
-            // TODO: 重い操作なので、asyncにする
-            self.status.insert_model(model.header(), model_bytes)
+            let model_bytes = model.read_inference_models().await?;
+
+            let status = self.status.clone();
+            let header = model.header().clone();
+            A::unblock(move || status.insert_model(&header, &model_bytes)).await
         }
 
         pub(super) fn unload_voice_model(&self, voice_model_id: VoiceModelId) -> Result<()> {

--- a/crates/voicevox_core/src/voice_model.rs
+++ b/crates/voicevox_core/src/voice_model.rs
@@ -63,7 +63,7 @@ impl VoiceModelId {
 
 #[self_referencing]
 pub(crate) struct Inner<A: Async> {
-    header: VoiceModelHeader,
+    header: Arc<VoiceModelHeader>,
 
     #[borrows(header)]
     #[not_covariant]
@@ -126,11 +126,12 @@ impl<A: Async> Inner<A> {
             )
         })?;
 
-        let header = VoiceModelHeader::new(manifest, metas, path)?;
+        let header = VoiceModelHeader::new(manifest, metas, path)?.into();
 
         InnerTryBuilder {
             header,
-            inference_model_entries_builder: |VoiceModelHeader { manifest, .. }| {
+            inference_model_entries_builder: |header| {
+                let VoiceModelHeader { manifest, .. } = &**header;
                 manifest
                     .domains()
                     .each_ref()
@@ -182,7 +183,7 @@ impl<A: Async> Inner<A> {
         &self.borrow_header().metas
     }
 
-    pub(crate) fn header(&self) -> &VoiceModelHeader {
+    pub(crate) fn header(&self) -> &Arc<VoiceModelHeader> {
         self.borrow_header()
     }
 

--- a/crates/voicevox_core_python_api/src/convert.rs
+++ b/crates/voicevox_core_python_api/src/convert.rs
@@ -111,7 +111,7 @@ pub(crate) fn async_modify_accent_phrases<'py, Fun, Fut>(
 ) -> PyResult<&'py PyAny>
 where
     Fun: FnOnce(Vec<AccentPhrase>, StyleId) -> Fut + Send + 'static,
-    Fut: Future<Output = voicevox_core::Result<Vec<AccentPhrase>>> + Send + 'static,
+    Fut: Future<Output = PyResult<Vec<AccentPhrase>>> + Send + 'static,
 {
     let rust_accent_phrases = accent_phrases
         .iter()
@@ -121,10 +121,9 @@ where
         py,
         pyo3_asyncio::tokio::get_current_locals(py)?,
         async move {
-            let replaced_accent_phrases = method(rust_accent_phrases, speaker_id).await;
+            let replaced_accent_phrases = method(rust_accent_phrases, speaker_id).await?;
             Python::with_gil(|py| {
                 let replaced_accent_phrases = replaced_accent_phrases
-                    .into_py_result(py)?
                     .iter()
                     .map(move |accent_phrase| {
                         to_pydantic_dataclass(


### PR DESCRIPTION
## 内容

非同期APIに関して以下の二つを行う。

* `load_voice_model`にて、ONNX Runtimeの`Session`作成（結構重い）をスレッドプール上でやるようにする。
* Python APIの`Synthesizer`にて、`Closable`の機構が適切に役割を果たすようにする。

## 関連 Issue

## その他
