### PR TITLE
ci: `-vv` → `-v`

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -237,7 +237,7 @@ jobs:
             ios-xcframework) linking=link-onnxruntime ;;
           esac
           function build() {
-            cargo build -p voicevox_core_c_api -vv --features "$linking" --target ${{ matrix.target }} --release
+            cargo build -p voicevox_core_c_api -v --features "$linking" --target ${{ matrix.target }} --release
           }
           if ${{ !inputs.is_production }}; then
             build
@@ -267,7 +267,7 @@ jobs:
         if: contains(matrix.target, 'android')
         run: |
           function build() {
-            cargo build -p voicevox_core_java_api -vv --target ${{ matrix.target }} --release
+            cargo build -p voicevox_core_java_api -v --target ${{ matrix.target }} --release
           }
           if ${{ !inputs.is_production }}; then
             build

--- a/.github/workflows/build_and_deploy_downloader.yml
+++ b/.github/workflows/build_and_deploy_downloader.yml
@@ -83,7 +83,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Build downloader
-        run: cargo build -vv --release -p downloader --target ${{ matrix.target }}
+        run: cargo build -v --release -p downloader --target ${{ matrix.target }}
 
       - name: Rename the binary
         run: |

--- a/.github/workflows/download_test.yml
+++ b/.github/workflows/download_test.yml
@@ -33,7 +33,7 @@ jobs:
         include:
           - name: 通常ダウンロード
             os: windows-latest
-            download_command: cargo run -vv -p downloader -- # バージョン指定のために -- が必要
+            download_command: cargo run -v -p downloader -- # バージョン指定のために -- が必要
             download_dir: voicevox_core
             check_items: |
               voicevox_core.dll
@@ -51,7 +51,7 @@ jobs:
               *curand*
           - name: CpuArch指定
             os: windows-latest
-            download_command: cargo run -vv -p downloader -- --cpu-arch x86
+            download_command: cargo run -v -p downloader -- --cpu-arch x86
             download_dir: voicevox_core
             check_items: |
               voicevox_core.dll
@@ -68,7 +68,7 @@ jobs:
               *curand*
           - name: output先指定ダウンロード
             os: windows-latest
-            download_command: cargo run -vv -p downloader -- -o other_output
+            download_command: cargo run -v -p downloader -- -o other_output
             download_dir: other_output
             check_items: |
               voicevox_core.dll
@@ -85,7 +85,7 @@ jobs:
               *curand*
           - name: Min option確認
             os: windows-latest
-            download_command: cargo run -vv -p downloader -- --min
+            download_command: cargo run -v -p downloader -- --min
             download_dir: voicevox_core
             check_items: |
               voicevox_core.dll
@@ -102,7 +102,7 @@ jobs:
               open_jtalk_dic_utf_8-1.11
           - name: DirectML option確認
             os: windows-latest
-            download_command: cargo run -vv -p downloader -- --devices directml
+            download_command: cargo run -v -p downloader -- --devices directml
             download_dir: voicevox_core
             check_items: |
               voicevox_core.dll
@@ -121,7 +121,7 @@ jobs:
               *curand*
           - name: DirectMLかつMin option確認
             os: windows-latest
-            download_command: cargo run -vv -p downloader -- --devices directml --min
+            download_command: cargo run -v -p downloader -- --devices directml --min
             download_dir: voicevox_core
             check_items: |
               voicevox_core.dll
@@ -139,7 +139,7 @@ jobs:
               open_jtalk_dic_utf_8-1.11
           - name: cuda option確認
             os: windows-latest
-            download_command: cargo run -vv -p downloader -- --devices cuda
+            download_command: cargo run -v -p downloader -- --devices cuda
             download_dir: voicevox_core
             check_items: |
               voicevox_core.dll
@@ -161,7 +161,7 @@ jobs:
               *directml*
           - name: cudaかつmin option確認
             os: windows-latest
-            download_command: cargo run -vv -p downloader -- --devices cuda --min
+            download_command: cargo run -v -p downloader -- --devices cuda --min
             download_dir: voicevox_core
             check_items: |
               voicevox_core.dll

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,10 +72,10 @@ jobs:
         with:
           python-version: "3.8"
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy -vv --tests -- -D clippy::all -D warnings --no-deps
-      - run: cargo clippy -vv -- -D clippy::all -D warnings --no-deps
-      - run: cargo clippy -vv -p voicevox_core -p voicevox_core_c_api --features link-onnxruntime --tests -- -D clippy::all -D warnings --no-deps
-      - run: cargo clippy -vv -p voicevox_core -p voicevox_core_c_api --features link-onnxruntime -- -D clippy::all -D warnings --no-deps
+      - run: cargo clippy -v --tests -- -D clippy::all -D warnings --no-deps
+      - run: cargo clippy -v -- -D clippy::all -D warnings --no-deps
+      - run: cargo clippy -v -p voicevox_core -p voicevox_core_c_api --features link-onnxruntime --tests -- -D clippy::all -D warnings --no-deps
+      - run: cargo clippy -v -p voicevox_core -p voicevox_core_c_api --features link-onnxruntime -- -D clippy::all -D warnings --no-deps
       - run: cargo fmt -- --check
 
   rust-unit-test:
@@ -88,9 +88,9 @@ jobs:
         with:
           key: "cargo-unit-test-cache"
       - name: Run cargo unit test
-        run: RUST_BACKTRACE=full cargo test --lib --bins -vv -- --include-ignored
+        run: RUST_BACKTRACE=full cargo test --lib --bins -v -- --include-ignored
       - name: Run cargo documentation test
-        run: RUST_BACKTRACE=full cargo test --doc -vv
+        run: RUST_BACKTRACE=full cargo test --doc -v
 
   rust-integration-test-strategy-matrix: # 実行対象の条件をフィルタリングする
     runs-on: ubuntu-latest
@@ -135,7 +135,7 @@ jobs:
         with:
           key: "cargo-integration-test-cache-${{ matrix.os }}"
       - name: Run cargo integration test (load-onnxruntime)
-        run: RUST_BACKTRACE=full cargo test --test "*" -vv -- --include-ignored
+        run: RUST_BACKTRACE=full cargo test --test "*" -v -- --include-ignored
 
   c-header:
     runs-on: ubuntu-latest
@@ -193,7 +193,7 @@ jobs:
       - name: Install cargo-binstall
         uses: taiki-e/install-action@cargo-binstall
       - name: build voicevox_core_c_api
-        run: cargo build -p voicevox_core_c_api --features load-onnxruntime -vv
+        run: cargo build -p voicevox_core_c_api --features load-onnxruntime -v
       - name: 必要なfileをunix用exampleのディレクトリに移動させる
         run: |
           mkdir -p example/cpp/unix/voicevox_core/
@@ -237,7 +237,7 @@ jobs:
       - name: Install cargo-binstall
         uses: taiki-e/install-action@cargo-binstall
       - name: build voicevox_core_c_api
-        run: cargo build -p voicevox_core_c_api --features load-onnxruntime -vv
+        run: cargo build -p voicevox_core_c_api --features load-onnxruntime -v
       - name: 必要なfileをexampleのディレクトリに移動させる
         shell: bash
         run: |
@@ -281,7 +281,7 @@ jobs:
       - run: |
           pip install --upgrade poetry
           poetry install --with dev --with test
-      - run: cargo build -p test_util -vv # build scriptにより/crates/test_util/data/の生成
+      - run: cargo build -p test_util -v # build scriptにより/crates/test_util/data/の生成
       - run: poetry run maturin build --locked
       - run: poetry run maturin develop --locked
       - name: 必要なDLLをコピーしてpytestを実行
@@ -316,8 +316,8 @@ jobs:
           distribution: "adopt"
       - name: Build
         run: |
-          cargo build -p voicevox_core_java_api -vv
-          cargo build -p test_util -vv # build scriptにより/crates/test_util/data/の生成
+          cargo build -p voicevox_core_java_api -v
+          cargo build -p test_util -v # build scriptにより/crates/test_util/data/の生成
       - name: 必要なDLLをコピーしてテストを実行
         working-directory: crates/voicevox_core_java_api
         run: |


### PR DESCRIPTION
## 内容

#323 以降Cargoコマンドに付けていた`-vv` (`--verbose --verbose`)を`-v` (`--verbose`)にする。理由としてはこの二年で依存ライブラリが増大したことにより、ログ出力の量がMB単位になる場合が出てきたため。

![image](https://github.com/user-attachments/assets/cff334a7-5813-4b18-af9c-e1512898e5b2)

Cargoコマンドによってはギリギリプレビューできる範囲に収まっているが、個々について考えるのも面倒だし、一貫性の観点からも一括して置き換えてしまう。

## 関連 Issue

Refs: #323

## その他
