### PR TITLE
feat: `pause_length{,_scale}`をデフォルト値限定で受け入れる

### DIFF
--- a/crates/voicevox_core/src/engine/model.rs
+++ b/crates/voicevox_core/src/engine/model.rs
@@ -67,6 +67,7 @@ pub struct AudioQuery {
     pub output_sampling_rate: u32,
     /// 音声データをステレオ出力するか否か。
     pub output_stereo: bool,
+    // TODO: VOICEVOX/voicevox_engine#1308 を実装する
     /// 句読点などの無音時間。`null`のときは無視される。デフォルト値は`null`。
     #[serde(
         default,

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -1185,6 +1185,8 @@ mod inner {
                 post_phoneme_length: 0.1,
                 output_sampling_rate: DEFAULT_SAMPLING_RATE,
                 output_stereo: false,
+                pause_length: (),
+                pause_length_scale: (),
                 kana: Some(kana),
             }
         }

--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/AudioQuery.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/AudioQuery.java
@@ -55,6 +55,17 @@ public class AudioQuery {
   @Expose
   public boolean outputStereo;
 
+  /** 句読点などの無音時間。{@code null}のときは無視される。デフォルト値は{@code null}。 */
+  @SerializedName("pause_length")
+  @Expose
+  @Nullable
+  public Double pauseLength;
+
+  /** 読点などの無音時間（倍率）。デフォルト値は{@code 1.}。 */
+  @SerializedName("pause_length_scale")
+  @Expose
+  public double pauseLengthScale;
+
   /**
    * [読み取り専用] AquesTalk風記法。
    *
@@ -75,6 +86,8 @@ public class AudioQuery {
     this.prePhonemeLength = 0.1;
     this.postPhonemeLength = 0.1;
     this.outputSamplingRate = 24000;
+    this.pauseLength = null;
+    this.pauseLengthScale = 1.0;
     this.kana = null;
   }
 }

--- a/crates/voicevox_core_python_api/python/voicevox_core/_models.py
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_models.py
@@ -208,6 +208,12 @@ class AudioQuery:
     output_stereo: bool
     """音声データをステレオ出力するか否か。"""
 
+    pause_length: None = None
+    """句読点などの無音時間。 ``None`` のときは無視される。デフォルト値は ``None`` 。"""
+
+    pause_length_scale: float = 1.0
+    """読点などの無音時間（倍率）。デフォルト値は ``1.0`` 。"""
+
     kana: Optional[str] = None
     """
     [読み取り専用] AquesTalk風記法。


### PR DESCRIPTION
## 内容

`AudioQuery`に`pause_length{,_scale}`を追加する。ただしそれぞれ`null`と`1.`のみを許し、無音時間調整自体はまだ実装しない。

## 関連 Issue

Refs: VOICEVOX/voicevox_engine#1308, VOICEVOX/voicevox_engine#1425

## その他
