### PR TITLE
feat!: `render`の引数の範囲指定部分を各言語の慣習に合わせる

### DIFF
--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
@@ -367,7 +367,7 @@ class Synthesizer:
         self,
         audio: AudioFeature,
         start: int,
-        end: int,
+        stop: int,
     ) -> bytes: ...
     def synthesis(
         self,

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -713,32 +713,28 @@ mod blocking {
             Ok(AudioFeature { audio })
         }
 
-        #[pyo3(signature=(audio, start, end))]
         fn render<'py>(
             &self,
             audio: &AudioFeature,
             start: usize,
-            end: usize,
+            stop: usize,
             py: Python<'py>,
         ) -> PyResult<&'py PyBytes> {
-            if start > audio.frame_length() || end > audio.frame_length() {
+            if start > audio.frame_length() || stop > audio.frame_length() {
                 return Err(PyIndexError::new_err(format!(
-                    "({}, {}) is out of range for audio feature of length {}",
-                    start,
-                    end,
-                    audio.frame_length(),
+                    "({start}, {stop}) is out of range for audio feature of length {len}",
+                    len = audio.frame_length(),
                 )));
             }
-            if start > end {
+            if start > stop {
                 return Err(PyValueError::new_err(format!(
-                    "({}, {}) is invalid range because start > end",
-                    start, end,
+                    "({start}, {stop}) is invalid range because start > end",
                 )));
             }
             let wav = &self
                 .synthesizer
                 .read()?
-                .render(&audio.audio, start, end)
+                .render(&audio.audio, start..stop)
                 .into_py_result(py)?;
             Ok(PyBytes::new(py, wav))
         }

--- a/docs/guide/dev/api-design.md
+++ b/docs/guide/dev/api-design.md
@@ -11,5 +11,6 @@ VOICEVOX CORE の主要機能は Rust で実装されることを前提として
 * [`StyleId`](https://voicevox.github.io/voicevox_core/apis/rust_api/voicevox_core/struct.StyleId.html)といった[newtype](https://rust-unofficial.github.io/patterns/patterns/behavioural/newtype.html)は、そのままnewtypeとして表現するべきです。
     * 例えばPythonなら[`typing.NewType`](https://docs.python.org/ja/3/library/typing.html#newtype)で表現します。
 * オプショナルな引数は、キーワード引数がある言語であればキーワード引数で、ビルダースタイルが一般的な言語であればビルダースタイルで表現すべきです。
-
-<!-- TODO: `render`の引数について: https://github.com/VOICEVOX/voicevox_core/pull/870#discussion_r1835601477 -->
+* `Synthesizer::render`は`range: std::ops::Range<usize>`を引数に取っています。`Range<usize>`にあたる型が標準で存在し、かつそれが配列の範囲指定として用いられるようなものであれば、それを使うべきです。
+    * ただし例えばPythonでは、`slice`を引数に取るのは慣習にそぐわないため`start: int, stop: int`のようにすべきです。
+    * もし`Range<usize>`にあたる型が標準で無く、かつRustの"start"/"end"やPythonの"start"/"stop"にあたる明確な言葉が無いのであれば、誤解が生じないよう"end_exclusive"のように命名するべきです。


### PR DESCRIPTION
## 内容

`Synthesizer::render`の引数の範囲指定部分を次のようにする。

Rust API: `range: Range<usize>`
Python API: `start: int, stop: int`

以前の議論:
<https://github.com/VOICEVOX/voicevox_core/pull/870#discussion_r1835573095>

## 関連 Issue

## その他

CC: @Yosshi999