### PR TITLE
feat: fix up #875 about `MARGIN_WIDTH` and `FEATURE_SIZE`

### DIFF
--- a/crates/voicevox_core/src/__internal/interop.rs
+++ b/crates/voicevox_core/src/__internal/interop.rs
@@ -1,3 +1,6 @@
 pub mod raii;
 
-pub use crate::{metas::merge as merge_metas, synthesizer::blocking::PerformInference};
+pub use crate::{
+    metas::merge as merge_metas,
+    synthesizer::{blocking::PerformInference, MARGIN},
+};

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -1,5 +1,7 @@
 use crate::asyncs::{Async, BlockingThreadPool, SingleTasked};
 
+pub use self::inner::MARGIN;
+
 /// [`blocking::Synthesizer::synthesis`]および[`nonblocking::Synthesizer::synthesis`]のオプション。
 ///
 /// [`blocking::Synthesizer::synthesis`]: blocking::Synthesizer::synthesis
@@ -132,7 +134,7 @@ mod inner {
     const PADDING_FRAME_LENGTH: usize = 38; // (0.4秒 * 24000Hz / 256.0).round()
     /// 音声生成の際、音声特徴量の前後に確保すべきマージン幅（フレーム数）
     /// モデルの受容野から計算される
-    const MARGIN: usize = 14;
+    pub const MARGIN: usize = 14;
     /// 指定した音声区間に対応する特徴量を両端にマージンを追加した上で切り出す
     fn crop_with_margin(audio: &AudioFeature, range: Range<usize>) -> ndarray::ArrayView2<'_, f32> {
         if range.start > audio.frame_length || range.end > audio.frame_length {


### PR DESCRIPTION
## 内容

#875 で追加された以下のコードに対し、

<https://github.com/VOICEVOX/voicevox_core/blob/d8e021e1f132582c6167a8ab948bf5dfed059ed9/crates/voicevox_core_c_api/src/compatible_engine.rs#L384-L385>

以下の変更を加える。

`MARGIN_WIDTH`: Rust APIのものを持って来るようにすることで重複を避ける
`FEATURE_SIZE`: 出力サイズのチェック時に失敗したとき、`ncols`が`FEATURE_SIZE`と異なるならパニックメッセージを別のものにする

## 関連 Issue

Refs: #875

## その他

Cc: @Yosshi999
