### PR TITLE
chore(deps): bump `anstream` to 0.6.18, `hashbrown@15` to 0.15.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,22 +98,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.5.0"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "colorchoice",
- "utf8parse",
-]
-
-[[package]]
-name = "anstream"
-version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -150,12 +137,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -176,7 +163,7 @@ version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d"
 dependencies = [
- "anstream 0.6.15",
+ "anstream",
  "anstyle",
  "bstr",
  "doc-comment",
@@ -627,7 +614,7 @@ version = "4.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5fbc17d3ef8278f55b282b2a2e75ae6f6c7d4bb70ed3d0382375104bfafdb4b"
 dependencies = [
- "anstream 0.6.15",
+ "anstream",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -1592,9 +1579,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
@@ -1797,7 +1784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.2",
  "serde",
 ]
 
@@ -4354,7 +4341,7 @@ dependencies = [
 name = "voicevox_core_c_api"
 version = "0.0.0"
 dependencies = [
- "anstream 0.5.0",
+ "anstream",
  "anstyle-query",
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.dependencies]
 android_logger = "0.13.1"
-anstream = { version = "0.5.0", default-features = false }
+anstream = { version = "0.6.18", default-features = false }
 anstyle-query = "1.1.1"
 anyhow = "1.0.89"
 assert_cmd = "2.0.16"

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -21,7 +21,7 @@ use self::helpers::{
 use self::object::{CApiObject as _, CApiObjectPtrExt as _};
 use self::result_code::VoicevoxResultCode;
 use self::slice_owner::U8_SLICE_OWNER;
-use anstream::{AutoStream, RawStream};
+use anstream::{stream::RawStream, AutoStream};
 use c_impls::{VoicevoxSynthesizerPtrExt as _, VoicevoxVoiceModelFilePtrExt as _};
 use chrono::SecondsFormat;
 use colorchoice::ColorChoice;


### PR DESCRIPTION
## 内容

次の二つの回避のため。

* [RUSTSEC-2024-0402](https://rustsec.org/advisories/RUSTSEC-2024-0402)
* [RUSTSEC-2024-0404](https://rustsec.org/advisories/RUSTSEC-2024-0404)

## 関連 Issue

## その他

cargo-denyが反応しているやつなので、最優先。
@Hiroshiba
