### PR TITLE
feat!: `RunAsync`を使う

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4251,7 +4251,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "voicevox-ort"
 version = "2.0.0-rc.4"
-source = "git+https://github.com/VOICEVOX/ort.git?rev=17f741301db0bb08da0eafe8a338e5efd8a4b5df#17f741301db0bb08da0eafe8a338e5efd8a4b5df"
+source = "git+https://github.com/VOICEVOX/ort.git?rev=09a9fe1619c1561efafc02f68f0bda4aad879771#09a9fe1619c1561efafc02f68f0bda4aad879771"
 dependencies = [
  "anyhow",
  "half",
@@ -4268,7 +4268,7 @@ dependencies = [
 [[package]]
 name = "voicevox-ort-sys"
 version = "2.0.0-rc.4"
-source = "git+https://github.com/VOICEVOX/ort.git?rev=17f741301db0bb08da0eafe8a338e5efd8a4b5df#17f741301db0bb08da0eafe8a338e5efd8a4b5df"
+source = "git+https://github.com/VOICEVOX/ort.git?rev=09a9fe1619c1561efafc02f68f0bda4aad879771#09a9fe1619c1561efafc02f68f0bda4aad879771"
 dependencies = [
  "flate2",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ zip = "0.6.3"
 
 [workspace.dependencies.voicevox-ort]
 git = "https://github.com/VOICEVOX/ort.git"
-rev = "17f741301db0bb08da0eafe8a338e5efd8a4b5df"
+rev = "09a9fe1619c1561efafc02f68f0bda4aad879771"
 
 [workspace.dependencies.open_jtalk]
 git = "https://github.com/VOICEVOX/open_jtalk-rs.git"

--- a/crates/voicevox_core/src/infer/runtimes/onnxruntime.rs
+++ b/crates/voicevox_core/src/infer/runtimes/onnxruntime.rs
@@ -182,7 +182,7 @@ impl InferenceRuntime for self::blocking::Onnxruntime {
         Ok((sess.into(), input_param_infos, output_param_infos))
     }
 
-    fn run(
+    fn run_blocking(
         OnnxruntimeRunContext { sess, inputs }: Self::RunContext,
     ) -> anyhow::Result<Vec<OutputTensor>> {
         extract_outputs(&sess.lock_blocking().run(inputs)?)

--- a/crates/voicevox_core/src/infer/runtimes/onnxruntime.rs
+++ b/crates/voicevox_core/src/infer/runtimes/onnxruntime.rs
@@ -11,7 +11,7 @@
 // }
 // ```
 
-use std::{fmt::Debug, vec};
+use std::{fmt::Debug, sync::Arc, vec};
 
 use anyhow::{anyhow, bail, ensure};
 use duplicate::duplicate_item;
@@ -32,8 +32,8 @@ use super::super::{
 };
 
 impl InferenceRuntime for self::blocking::Onnxruntime {
-    type Session = ort::Session;
-    type RunContext<'a> = OnnxruntimeRunContext<'a>;
+    type Session = async_lock::Mutex<ort::Session>; // WASMでは`ort`を利用しないので、ここはasync-lockを用いてよいはず
+    type RunContext = OnnxruntimeRunContext;
 
     const DISPLAY_NAME: &'static str = if cfg!(feature = "load-onnxruntime") {
         "現在ロードされているONNX Runtime"
@@ -179,58 +179,44 @@ impl InferenceRuntime for self::blocking::Onnxruntime {
             })
             .collect::<anyhow::Result<_>>()?;
 
-        Ok((sess, input_param_infos, output_param_infos))
+        Ok((sess.into(), input_param_infos, output_param_infos))
     }
 
     fn run(
-        OnnxruntimeRunContext { sess, inputs }: OnnxruntimeRunContext<'_>,
+        OnnxruntimeRunContext { sess, inputs }: Self::RunContext,
     ) -> anyhow::Result<Vec<OutputTensor>> {
-        let outputs = sess.run(&*inputs)?;
+        extract_outputs(&sess.lock_blocking().run(inputs)?)
+    }
 
-        (0..outputs.len())
-            .map(|i| {
-                let output = &outputs[i];
-
-                let ValueType::Tensor { ty, .. } = output.dtype()? else {
-                    bail!(
-                        "unexpected output. currently `ONNX_TYPE_TENSOR` and \
-                         `ONNX_TYPE_SPARSETENSOR` is supported",
-                    );
-                };
-
-                match ty {
-                    TensorElementType::Float32 => {
-                        let output = output.try_extract_tensor::<f32>()?;
-                        Ok(OutputTensor::Float32(output.into_owned()))
-                    }
-                    _ => bail!("unexpected output tensor element data type"),
-                }
-            })
-            .collect()
+    async fn run_async(
+        OnnxruntimeRunContext { sess, inputs }: Self::RunContext,
+    ) -> anyhow::Result<Vec<OutputTensor>> {
+        extract_outputs(&sess.lock().await.run_async(inputs)?.await?)
     }
 }
 
-pub(crate) struct OnnxruntimeRunContext<'sess> {
-    sess: &'sess ort::Session,
-    inputs: Vec<ort::SessionInputValue<'static>>,
+pub(crate) struct OnnxruntimeRunContext {
+    sess: Arc<async_lock::Mutex<ort::Session>>,
+    inputs: Vec<(&'static str, ort::SessionInputValue<'static>)>,
 }
 
-impl OnnxruntimeRunContext<'_> {
+impl OnnxruntimeRunContext {
     fn push_input(
         &mut self,
+        name: &'static str,
         input: Array<
             impl PrimitiveTensorElementType + Debug + Clone + 'static,
             impl Dimension + 'static,
         >,
     ) -> anyhow::Result<()> {
         let input = ort::Value::from_array(input)?.into();
-        self.inputs.push(input);
+        self.inputs.push((name, input));
         Ok(())
     }
 }
 
-impl<'sess> From<&'sess mut ort::Session> for OnnxruntimeRunContext<'sess> {
-    fn from(sess: &'sess mut ort::Session) -> Self {
+impl From<Arc<async_lock::Mutex<ort::Session>>> for OnnxruntimeRunContext {
+    fn from(sess: Arc<async_lock::Mutex<ort::Session>>) -> Self {
         Self {
             sess,
             inputs: vec![],
@@ -238,15 +224,43 @@ impl<'sess> From<&'sess mut ort::Session> for OnnxruntimeRunContext<'sess> {
     }
 }
 
-impl PushInputTensor for OnnxruntimeRunContext<'_> {
+impl PushInputTensor for OnnxruntimeRunContext {
     #[duplicate_item(
         method           T;
         [ push_int64 ]   [ i64 ];
         [ push_float32 ] [ f32 ];
     )]
-    fn method(&mut self, tensor: Array<T, impl Dimension + 'static>) -> anyhow::Result<()> {
-        self.push_input(tensor)
+    fn method(
+        &mut self,
+        name: &'static str,
+        tensor: Array<T, impl Dimension + 'static>,
+    ) -> anyhow::Result<()> {
+        self.push_input(name, tensor)
     }
+}
+
+// FIXME: use ouroboros to reduce copies
+fn extract_outputs(outputs: &ort::SessionOutputs<'_, '_>) -> anyhow::Result<Vec<OutputTensor>> {
+    (0..outputs.len())
+        .map(|i| {
+            let output = &outputs[i];
+
+            let ValueType::Tensor { ty, .. } = output.dtype()? else {
+                bail!(
+                    "unexpected output. currently `ONNX_TYPE_TENSOR` and `ONNX_TYPE_SPARSETENSOR`
+                     is supported",
+                );
+            };
+
+            match ty {
+                TensorElementType::Float32 => {
+                    let output = output.try_extract_tensor::<f32>()?;
+                    Ok(OutputTensor::Float32(output.into_owned()))
+                }
+                _ => bail!("unexpected output tensor element data type"),
+            }
+        })
+        .collect()
 }
 
 pub(crate) mod blocking {

--- a/crates/voicevox_core_python_api/python/test/test_asyncio_user_dict_load.py
+++ b/crates/voicevox_core_python_api/python/test/test_asyncio_user_dict_load.py
@@ -6,6 +6,7 @@
 
 # AudioQueryのkanaを比較して変化するかどうかで判断する。
 
+import multiprocessing
 from uuid import UUID
 
 import conftest  # noqa: F401
@@ -20,7 +21,13 @@ async def test_user_dict_load() -> None:
     )
     open_jtalk = await voicevox_core.asyncio.OpenJtalk.new(conftest.open_jtalk_dic_dir)
     model = await voicevox_core.asyncio.VoiceModelFile.open(conftest.model_dir)
-    synthesizer = voicevox_core.asyncio.Synthesizer(onnxruntime, open_jtalk)
+    synthesizer = voicevox_core.asyncio.Synthesizer(
+        onnxruntime,
+        open_jtalk,
+        cpu_num_threads=max(
+            multiprocessing.cpu_count(), 2
+        ),  # https://github.com/VOICEVOX/voicevox_core/issues/888
+    )
 
     await synthesizer.load_voice_model(model)
 

--- a/example/python/run-asyncio.py
+++ b/example/python/run-asyncio.py
@@ -4,6 +4,7 @@ import asyncio
 import dataclasses
 import json
 import logging
+import multiprocessing
 from argparse import ArgumentParser
 from pathlib import Path
 
@@ -91,7 +92,12 @@ async def main() -> None:
 
     logger.info("%s", f"Initializing ({args.mode=}, {args.dict_dir=})")
     synthesizer = Synthesizer(
-        onnxruntime, await OpenJtalk.new(args.dict_dir), acceleration_mode=args.mode
+        onnxruntime,
+        await OpenJtalk.new(args.dict_dir),
+        acceleration_mode=args.mode,
+        cpu_num_threads=max(
+            multiprocessing.cpu_count(), 2
+        ),  # https://github.com/VOICEVOX/voicevox_core/issues/888
     )
 
     logger.debug("%s", f"{synthesizer.metas=}")

--- a/example/python/run.py
+++ b/example/python/run.py
@@ -1,6 +1,7 @@
 import dataclasses
 import json
 import logging
+import multiprocessing
 from argparse import ArgumentParser
 from pathlib import Path
 
@@ -95,7 +96,12 @@ def main() -> None:
 
     logger.info("%s", f"Initializing ({args.mode=}, {args.dict_dir=})")
     synthesizer = Synthesizer(
-        onnxruntime, OpenJtalk(args.dict_dir), acceleration_mode=args.mode
+        onnxruntime,
+        OpenJtalk(args.dict_dir),
+        acceleration_mode=args.mode,
+        cpu_num_threads=max(
+            multiprocessing.cpu_count(), 2
+        ),  # https://github.com/VOICEVOX/voicevox_core/issues/888
     )
 
     logger.debug("%s", f"{synthesizer.metas=}")


### PR DESCRIPTION
## 内容

非同期APIにおける推論に[`ort::Session::run_async`](https://docs.rs/ort/2.0.0-rc.4/ort/struct.Session.html#method.run_async)を使うようにする。これにより、推論がキャンセル可能になる。

#888 の影響を受け推論が失敗するので、CIを通すため、Python APIのテストとexampleについては（すべてのプラットフォームで）`cpu_num_threads=max(multiprocessing.cpu_cout(), 2)`とする。

BREAKING-CHANGE: 非同期APIにおいて、INTRA Thread Countが`1`だと推論がすべてエラーになるようになる。

## 関連 Issue

Resolves #687.

Refs: VOICEVOX/ort#11

## その他
