### PR TITLE
add: [release-0.15] macos-12 to macos-13

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -72,13 +72,13 @@ jobs:
             artifact_name: linux-arm64-cpu
             whl_local_version: cpu
             use_cuda: false
-          - os: macos-12
+          - os: macos-13
             features: ""
             target: aarch64-apple-darwin
             artifact_name: osx-arm64-cpu
             whl_local_version: cpu
             use_cuda: false
-          - os: macos-12
+          - os: macos-13
             features: ""
             target: x86_64-apple-darwin
             artifact_name: osx-x64-cpu
@@ -209,10 +209,10 @@ jobs:
             os: ubuntu-20.04
           - name: download-osx-x64
             target: x86_64-apple-darwin
-            os: macos-12
+            os: macos-13
           - name: download-osx-arm64
             target: aarch64-apple-darwin
-            os: macos-12
+            os: macos-13
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,9 +80,9 @@ jobs:
             features: directml
           - os: windows-2022
             features: directml
-          - os: macos-12
-            features: ""
           - os: macos-13
+            features: ""
+          - os: macos-14
             features: ""
           - os: ubuntu-20.04
             features: ""


### PR DESCRIPTION
## 内容

release-0.15ブランチにmacos-12部分が残っていたので、macos-13にアップデートします。

## その他

また`release`始まりにしてしまったのでブランチプロテクションかかってしまったかも･･･。
あとで消しておきます･･･。

メインブランチの変更は↓

- https://github.com/VOICEVOX/voicevox_core/pull/884/files
