### PR TITLE
fix: [release-0.15] os to runner_os

### DIFF
--- a/.github/actions/cargo-binstall-cbindgen/action.yml
+++ b/.github/actions/cargo-binstall-cbindgen/action.yml
@@ -9,7 +9,7 @@ runs:
     - name: Install cbindgen
       shell: bash
       run: |
-        case "$OS" in
+        case "$RUNNER_OS" in
           Windows)
             cargo install cbindgen --version ${{ inputs.version }};;
           macOS | Linux )

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -231,7 +231,7 @@ jobs:
       - name: Rename the binary
         shell: bash
         run: |
-          case "$OS" in
+          case "$RUNNER_OS" in
             Windows) exe_suffix=.exe;;
             Linux | macOS) exe_suffix=;;
           esac


### PR DESCRIPTION
## 内容

`$OS`となってますが、おそらく正解は`$RUNNER_OS`です。
release-0.15でビルドするとなぜかcbindgenがインストールされておらず、いろいろ調べたところここじゃないかとなりました。
よくよく確認すると、この前[macos-12をmacos-13に上げるrelease-0.15へのPRのGithub Workflow](https://github.com/VOICEVOX/voicevox_core/actions/runs/12459741230/job/34776980065)でもそこで落ちてました。

２箇所変更していますが、`.github/actions/cargo-binstall-cbindgen/action.yml`側は現在のmainブランチには存在してません。

`.github/workflows/build_and_deploy.yml`側の`.exe`を付けるか判定はこれでより正しくなるはず。
でも`$OS`はWindowsでだけ`Windows_NT`と値が入ってるので、switch caseの仕様によっては正しく動作してるかも。
試してみた結果が[こちら](https://github.com/Hiroshiba/test_actions/actions/runs/12496485243/job/34868255598#:~:text=6s,OS%3A%20windows%2Dlatest%22)

## その他

なんで以前はちゃんとOS判定できてた？のか不明。
判定はできてなくて、cbindgenがなぜか入ってたのか、あるいはキャッシュがヒットしてたとか･･･？
