### PR TITLE
refactor: Rust APIの`Synthesizer`のメソッドをビルダースタイルに

### DIFF
--- a/crates/voicevox_core/src/__internal/doctest_fixtures.rs
+++ b/crates/voicevox_core/src/__internal/doctest_fixtures.rs
@@ -2,7 +2,7 @@ use std::{ffi::OsString, path::Path};
 
 use camino::Utf8Path;
 
-use crate::{AccelerationMode, InitializeOptions};
+use crate::AccelerationMode;
 
 pub use crate::synthesizer::nonblocking::IntoBlocking;
 
@@ -13,7 +13,7 @@ pub async fn synthesizer_with_sample_voice_model(
     >,
     open_jtalk_dic_dir: impl AsRef<Utf8Path>,
 ) -> anyhow::Result<crate::nonblocking::Synthesizer<crate::nonblocking::OpenJtalk>> {
-    let syntesizer = crate::nonblocking::Synthesizer::new(
+    let syntesizer = crate::nonblocking::Synthesizer::builder(
         #[cfg(feature = "load-onnxruntime")]
         crate::nonblocking::Onnxruntime::load_once()
             .filename(onnxruntime_dylib_path)
@@ -21,12 +21,10 @@ pub async fn synthesizer_with_sample_voice_model(
             .await?,
         #[cfg(feature = "link-onnxruntime")]
         crate::nonblocking::Onnxruntime::init_once().await?,
-        crate::nonblocking::OpenJtalk::new(open_jtalk_dic_dir).await?,
-        &InitializeOptions {
-            acceleration_mode: AccelerationMode::Cpu,
-            ..Default::default()
-        },
-    )?;
+    )
+    .open_jtalk(crate::nonblocking::OpenJtalk::new(open_jtalk_dic_dir).await?)
+    .acceleration_mode(AccelerationMode::Cpu)
+    .build()?;
 
     let model = &crate::nonblocking::VoiceModelFile::open(voice_model_path).await?;
     syntesizer.load_voice_model(model).await?;

--- a/crates/voicevox_core/src/__internal/interop.rs
+++ b/crates/voicevox_core/src/__internal/interop.rs
@@ -2,5 +2,8 @@ pub mod raii;
 
 pub use crate::{
     metas::merge as merge_metas,
-    synthesizer::{blocking::PerformInference, MARGIN},
+    synthesizer::{
+        blocking::PerformInference, DEFAULT_CPU_NUM_THREADS, DEFAULT_ENABLE_INTERROGATIVE_UPSPEAK,
+        MARGIN,
+    },
 };

--- a/crates/voicevox_core/src/blocking.rs
+++ b/crates/voicevox_core/src/blocking.rs
@@ -11,3 +11,10 @@ pub mod onnxruntime {
     #[cfg_attr(docsrs, doc(cfg(feature = "load-onnxruntime")))]
     pub use crate::infer::runtimes::onnxruntime::blocking::LoadOnce;
 }
+
+pub mod synthesizer {
+    pub use crate::synthesizer::blocking::{Builder, Synthesis, Tts, TtsFromKana};
+
+    // TODO: 後で封印する
+    pub use crate::synthesizer::blocking::PrecomputeRender;
+}

--- a/crates/voicevox_core/src/lib.rs
+++ b/crates/voicevox_core/src/lib.rs
@@ -90,7 +90,7 @@ pub use self::{
         VoiceModelMeta,
     },
     result::Result,
-    synthesizer::{AccelerationMode, InitializeOptions, SynthesisOptions, TtsOptions},
+    synthesizer::AccelerationMode,
     user_dict::{UserDictWord, UserDictWordType},
     version::VERSION,
     voice_model::{RawVoiceModelId, VoiceModelId},

--- a/crates/voicevox_core/src/nonblocking.rs
+++ b/crates/voicevox_core/src/nonblocking.rs
@@ -15,7 +15,7 @@
 //! [blocking]: https://docs.rs/crate/blocking
 //! [pollster]: https://docs.rs/crate/pollster
 //! [VOICEVOX/voicevox_core#902]: https://github.com/VOICEVOX/voicevox_core/issues/902
-//! [`cpu_num_threads`]: crate::InitializeOptions::cpu_num_threads
+//! [`cpu_num_threads`]: crate::nonblocking::synthesizer::Builder::cpu_num_threads
 
 pub use crate::{
     engine::open_jtalk::nonblocking::OpenJtalk,
@@ -27,4 +27,8 @@ pub mod onnxruntime {
     #[cfg(feature = "load-onnxruntime")]
     #[cfg_attr(docsrs, doc(cfg(feature = "load-onnxruntime")))]
     pub use crate::infer::runtimes::onnxruntime::nonblocking::LoadOnce;
+}
+
+pub mod synthesizer {
+    pub use crate::synthesizer::nonblocking::{Builder, Synthesis, Tts, TtsFromKana};
 }

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -32,15 +32,22 @@ use crate::{
     VoiceModelMeta,
 };
 
-/// [`blocking::Synthesizer::synthesis`]および[`nonblocking::Synthesizer::synthesis`]のオプション。
-///
-/// [`blocking::Synthesizer::synthesis`]: blocking::Synthesizer::synthesis
-/// [`nonblocking::Synthesizer::synthesis`]: nonblocking::Synthesizer::synthesis
-#[derive(Clone)]
-pub struct SynthesisOptions {
-    pub enable_interrogative_upspeak: bool,
+pub const DEFAULT_CPU_NUM_THREADS: u16 = 0;
+pub const DEFAULT_ENABLE_INTERROGATIVE_UPSPEAK: bool = true;
+
+struct SynthesisOptions {
+    enable_interrogative_upspeak: bool,
 }
 
+impl Default for SynthesisOptions {
+    fn default() -> Self {
+        Self {
+            enable_interrogative_upspeak: DEFAULT_ENABLE_INTERROGATIVE_UPSPEAK,
+        }
+    }
+}
+
+// FIXME: this is dead code
 impl AsRef<SynthesisOptions> for SynthesisOptions {
     fn as_ref(&self) -> &SynthesisOptions {
         self
@@ -55,15 +62,11 @@ impl From<&TtsOptions> for SynthesisOptions {
     }
 }
 
-/// [`blocking::Synthesizer::tts`]および[`nonblocking::Synthesizer::tts`]のオプション。
-///
-/// [`blocking::Synthesizer::tts`]: blocking::Synthesizer::tts
-/// [`nonblocking::Synthesizer::tts`]: nonblocking::Synthesizer::tts
-#[derive(Clone)]
-pub struct TtsOptions {
-    pub enable_interrogative_upspeak: bool,
+struct TtsOptions {
+    enable_interrogative_upspeak: bool,
 }
 
+// FIXME: this is dead code
 impl AsRef<TtsOptions> for TtsOptions {
     fn as_ref(&self) -> &Self {
         self
@@ -73,7 +76,7 @@ impl AsRef<TtsOptions> for TtsOptions {
 impl Default for TtsOptions {
     fn default() -> Self {
         Self {
-            enable_interrogative_upspeak: true,
+            enable_interrogative_upspeak: DEFAULT_ENABLE_INTERROGATIVE_UPSPEAK,
         }
     }
 }
@@ -90,24 +93,18 @@ pub enum AccelerationMode {
     Gpu,
 }
 
-/// [`blocking::Synthesizer::new`]および[`nonblocking::Synthesizer::new`]のオプション。
-///
-/// [`blocking::Synthesizer::new`]: blocking::Synthesizer::new
-/// [`nonblocking::Synthesizer::new`]: nonblocking::Synthesizer::new
-#[derive(Default)]
-pub struct InitializeOptions {
-    pub acceleration_mode: AccelerationMode,
+struct InitializeOptions {
+    acceleration_mode: AccelerationMode,
+    cpu_num_threads: u16,
+}
 
-    /// CPU利用数を指定。0を指定すると環境に合わせたCPUが利用される。
-    ///
-    /// # Performance
-    ///
-    /// 未調査ではあるが、[非同期版API]においては物理コアの数+1とするのが適切な可能性がある
-    /// ([VOICEVOX/voicevox_core#902])。
-    ///
-    /// [非同期版API]: crate::nonblocking
-    /// [VOICEVOX/voicevox_core#902]: https://github.com/VOICEVOX/voicevox_core/issues/902
-    pub cpu_num_threads: u16,
+impl Default for InitializeOptions {
+    fn default() -> Self {
+        Self {
+            acceleration_mode: Default::default(),
+            cpu_num_threads: DEFAULT_CPU_NUM_THREADS,
+        }
+    }
 }
 
 trait AsyncExt: infer::AsyncExt {
@@ -1304,21 +1301,22 @@ pub(crate) mod blocking {
         FullcontextExtractor, StyleId, VoiceModelId, VoiceModelMeta,
     };
 
-    use super::{InitializeOptions, Inner, SynthesisOptions, TtsOptions};
+    use super::{AccelerationMode, InitializeOptions, Inner, SynthesisOptions, TtsOptions};
 
     pub use super::AudioFeature;
 
     /// 音声シンセサイザ。
     pub struct Synthesizer<O>(pub(super) Inner<O, SingleTasked>);
 
-    impl<O> self::Synthesizer<O> {
-        /// `Synthesizer`をコンストラクトする。
+    impl self::Synthesizer<()> {
+        /// `Synthesizer`のビルダーをコンストラクトする。
         ///
         /// # Example
         ///
         #[cfg_attr(feature = "load-onnxruntime", doc = "```")]
         #[cfg_attr(not(feature = "load-onnxruntime"), doc = "```compile_fail")]
         /// # fn main() -> anyhow::Result<()> {
+        /// # // FIXME: この`ONNXRUNTIME_DYLIB_PATH`はunused import
         /// # use test_util::{ONNXRUNTIME_DYLIB_PATH, OPEN_JTALK_DIC_DIR};
         /// #
         /// # const ACCELERATION_MODE: AccelerationMode = AccelerationMode::Cpu;
@@ -1327,7 +1325,7 @@ pub(crate) mod blocking {
         ///
         /// use voicevox_core::{
         ///     blocking::{Onnxruntime, OpenJtalk, Synthesizer},
-        ///     AccelerationMode, InitializeOptions,
+        ///     AccelerationMode,
         /// };
         ///
         /// # if cfg!(windows) {
@@ -1336,26 +1334,25 @@ pub(crate) mod blocking {
         /// #         .filename(test_util::ONNXRUNTIME_DYLIB_PATH)
         /// #         .exec()?;
         /// # }
-        /// let mut syntesizer = Synthesizer::new(
-        ///     Onnxruntime::load_once().exec()?,
-        ///     Arc::new(OpenJtalk::new(OPEN_JTALK_DIC_DIR).unwrap()),
-        ///     &InitializeOptions {
-        ///         acceleration_mode: ACCELERATION_MODE,
-        ///         ..Default::default()
-        ///     },
-        /// )?;
+        /// // FIXME: `Synthesizer`には`&mut self`なメソッドはもう無いはず
+        /// let mut syntesizer = Synthesizer::builder(Onnxruntime::load_once().exec()?)
+        ///     .open_jtalk(Arc::new(OpenJtalk::new(OPEN_JTALK_DIC_DIR).unwrap())) // FIXME: `Arc`は要らないはず
+        ///     .acceleration_mode(ACCELERATION_MODE)
+        ///     .build()?;
         /// #
         /// # Ok(())
         /// # }
         /// ```
-        pub fn new(
-            onnxruntime: &'static crate::blocking::Onnxruntime,
-            open_jtalk: O,
-            options: &InitializeOptions,
-        ) -> crate::Result<Self> {
-            Inner::new(onnxruntime, open_jtalk, options).map(Self)
+        pub fn builder(onnxruntime: &'static crate::blocking::Onnxruntime) -> Builder<()> {
+            Builder {
+                onnxruntime,
+                open_jtalk: (),
+                options: Default::default(),
+            }
         }
+    }
 
+    impl<O> self::Synthesizer<O> {
         pub fn onnxruntime(&self) -> &'static crate::blocking::Onnxruntime {
             self.0.onnxruntime()
         }
@@ -1394,15 +1391,17 @@ pub(crate) mod blocking {
         }
 
         /// AudioQueryから音声合成用の中間表現を生成する。
-        pub fn precompute_render(
-            &self,
-            audio_query: &AudioQuery,
+        pub fn precompute_render<'a>(
+            &'a self,
+            audio_query: &'a AudioQuery,
             style_id: StyleId,
-            options: &SynthesisOptions,
-        ) -> crate::Result<AudioFeature> {
-            self.0
-                .precompute_render(audio_query, style_id, options)
-                .block_on()
+        ) -> PrecomputeRender<'a, O> {
+            PrecomputeRender {
+                synthesizer: &self.0,
+                audio_query,
+                style_id,
+                options: Default::default(),
+            }
         }
 
         /// 中間表現から16bit PCMで音声波形を生成する。
@@ -1411,13 +1410,17 @@ pub(crate) mod blocking {
         }
 
         /// AudioQueryから直接WAVフォーマットで音声波形を生成する。
-        pub fn synthesis(
-            &self,
-            audio_query: &AudioQuery,
+        pub fn synthesis<'a>(
+            &'a self,
+            audio_query: &'a AudioQuery,
             style_id: StyleId,
-            options: &SynthesisOptions,
-        ) -> crate::Result<Vec<u8>> {
-            self.0.synthesis(audio_query, style_id, options).block_on()
+        ) -> Synthesis<'a, O> {
+            Synthesis {
+                synthesizer: &self.0,
+                audio_query,
+                style_id,
+                options: Default::default(),
+            }
         }
 
         /// AquesTalk風記法からAccentPhrase (アクセント句)の配列を生成する。
@@ -1527,13 +1530,13 @@ pub(crate) mod blocking {
         }
 
         /// AquesTalk風記法から音声合成を行う。
-        pub fn tts_from_kana(
-            &self,
-            kana: &str,
-            style_id: StyleId,
-            options: &TtsOptions,
-        ) -> crate::Result<Vec<u8>> {
-            self.0.tts_from_kana(kana, style_id, options).block_on()
+        pub fn tts_from_kana<'a>(&'a self, kana: &'a str, style_id: StyleId) -> TtsFromKana<'a, O> {
+            TtsFromKana {
+                synthesizer: &self.0,
+                kana,
+                style_id,
+                options: TtsOptions::default(),
+            }
         }
     }
 
@@ -1607,13 +1610,13 @@ pub(crate) mod blocking {
         }
 
         /// 日本語のテキストから音声合成を行う。
-        pub fn tts(
-            &self,
-            text: &str,
-            style_id: StyleId,
-            options: &TtsOptions,
-        ) -> crate::Result<Vec<u8>> {
-            self.0.tts(text, style_id, options).block_on()
+        pub fn tts<'a>(&'a self, text: &'a str, style_id: StyleId) -> Tts<'a, O> {
+            Tts {
+                synthesizer: &self.0,
+                text,
+                style_id,
+                options: TtsOptions::default(),
+            }
         }
     }
 
@@ -1742,6 +1745,125 @@ pub(crate) mod blocking {
                 .block_on()
         }
     }
+
+    pub struct Builder<O> {
+        onnxruntime: &'static crate::blocking::Onnxruntime,
+        open_jtalk: O,
+        options: InitializeOptions,
+    }
+
+    impl<O> Builder<O> {
+        pub fn open_jtalk<O2>(self, open_jtalk: O2) -> Builder<O2> {
+            Builder {
+                open_jtalk,
+                onnxruntime: self.onnxruntime,
+                options: self.options,
+            }
+        }
+
+        pub fn acceleration_mode(mut self, acceleration_mode: AccelerationMode) -> Self {
+            self.options.acceleration_mode = acceleration_mode;
+            self
+        }
+
+        /// CPU利用数を指定。0を指定すると環境に合わせたCPUが利用される。
+        pub fn cpu_num_threads(mut self, cpu_num_threads: u16) -> Self {
+            self.options.cpu_num_threads = cpu_num_threads;
+            self
+        }
+
+        /// [`Synthesizer`]をコンストラクトする。
+        pub fn build(self) -> crate::Result<Synthesizer<O>> {
+            Inner::new(self.onnxruntime, self.open_jtalk, &self.options).map(Synthesizer)
+        }
+    }
+
+    // TODO: この`O`は削れるはず
+    pub struct PrecomputeRender<'a, O> {
+        synthesizer: &'a Inner<O, SingleTasked>,
+        audio_query: &'a AudioQuery,
+        style_id: StyleId,
+        options: SynthesisOptions,
+    }
+
+    impl<O> PrecomputeRender<'_, O> {
+        pub fn enable_interrogative_upspeak(mut self, enable_interrogative_upspeak: bool) -> Self {
+            self.options.enable_interrogative_upspeak = enable_interrogative_upspeak;
+            self
+        }
+
+        /// 実行する。
+        pub fn exec(self) -> crate::Result<AudioFeature> {
+            self.synthesizer
+                .precompute_render(self.audio_query, self.style_id, &self.options)
+                .block_on()
+        }
+    }
+
+    // TODO: この`O`は削れるはず
+    pub struct Synthesis<'a, O> {
+        synthesizer: &'a Inner<O, SingleTasked>,
+        audio_query: &'a AudioQuery,
+        style_id: StyleId,
+        options: SynthesisOptions,
+    }
+
+    impl<O> Synthesis<'_, O> {
+        pub fn enable_interrogative_upspeak(mut self, enable_interrogative_upspeak: bool) -> Self {
+            self.options.enable_interrogative_upspeak = enable_interrogative_upspeak;
+            self
+        }
+
+        /// 実行する。
+        pub fn exec(self) -> crate::Result<Vec<u8>> {
+            self.synthesizer
+                .synthesis(self.audio_query, self.style_id, &self.options)
+                .block_on()
+        }
+    }
+
+    // TODO: この`O`は削れるはず
+    pub struct TtsFromKana<'a, O> {
+        synthesizer: &'a Inner<O, SingleTasked>,
+        kana: &'a str,
+        style_id: StyleId,
+        options: TtsOptions,
+    }
+
+    impl<O> TtsFromKana<'_, O> {
+        pub fn enable_interrogative_upspeak(mut self, enable_interrogative_upspeak: bool) -> Self {
+            self.options.enable_interrogative_upspeak = enable_interrogative_upspeak;
+            self
+        }
+
+        /// 実行する。
+        pub fn exec(self) -> crate::Result<Vec<u8>> {
+            self.synthesizer
+                .tts_from_kana(self.kana, self.style_id, &self.options)
+                .block_on()
+        }
+    }
+
+    pub struct Tts<'a, O> {
+        synthesizer: &'a Inner<O, SingleTasked>,
+        text: &'a str,
+        style_id: StyleId,
+        options: TtsOptions,
+    }
+
+    impl<O: FullcontextExtractor> Tts<'_, O> {
+        pub fn enable_interrogative_upspeak(mut self, enable_interrogative_upspeak: bool) -> Self {
+            self.options.enable_interrogative_upspeak = enable_interrogative_upspeak;
+            self
+        }
+
+        /// 実行する。
+        pub fn exec(self) -> crate::Result<Vec<u8>> {
+            self.synthesizer
+                .tts(self.text, self.style_id, &self.options)
+                .block_on()
+        }
+    }
 }
 
 pub(crate) mod nonblocking {
@@ -1749,10 +1871,10 @@ pub(crate) mod nonblocking {
 
     use crate::{
         asyncs::BlockingThreadPool, AccentPhrase, AudioQuery, FullcontextExtractor, Result,
-        StyleId, SynthesisOptions, VoiceModelId, VoiceModelMeta,
+        StyleId, VoiceModelId, VoiceModelMeta,
     };
 
-    use super::{InitializeOptions, Inner, TtsOptions};
+    use super::{AccelerationMode, InitializeOptions, Inner, SynthesisOptions, TtsOptions};
 
     /// 音声シンセサイザ。
     ///
@@ -1764,8 +1886,8 @@ pub(crate) mod nonblocking {
     /// [`nonblocking`モジュールのドキュメント]: crate::nonblocking
     pub struct Synthesizer<O>(pub(super) Inner<O, BlockingThreadPool>);
 
-    impl<O: Send + Sync + 'static> self::Synthesizer<O> {
-        /// `Synthesizer`をコンストラクトする。
+    impl self::Synthesizer<()> {
+        /// `Synthesizer`のビルダーをコンストラクトする。
         ///
         /// # Example
         ///
@@ -1773,6 +1895,7 @@ pub(crate) mod nonblocking {
         #[cfg_attr(not(feature = "load-onnxruntime"), doc = "```compile_fail")]
         /// # #[pollster::main]
         /// # async fn main() -> anyhow::Result<()> {
+        /// # // FIXME: この`ONNXRUNTIME_DYLIB_PATH`はunused import
         /// # use test_util::{ONNXRUNTIME_DYLIB_PATH, OPEN_JTALK_DIC_DIR};
         /// #
         /// # const ACCELERATION_MODE: AccelerationMode = AccelerationMode::Cpu;
@@ -1781,7 +1904,7 @@ pub(crate) mod nonblocking {
         ///
         /// use voicevox_core::{
         ///     nonblocking::{Onnxruntime, OpenJtalk, Synthesizer},
-        ///     AccelerationMode, InitializeOptions,
+        ///     AccelerationMode,
         /// };
         ///
         /// # if cfg!(windows) {
@@ -1790,28 +1913,25 @@ pub(crate) mod nonblocking {
         /// #         .filename(test_util::ONNXRUNTIME_DYLIB_PATH)
         /// #         .exec()?;
         /// # }
-        /// let mut syntesizer = Synthesizer::new(
-        ///     Onnxruntime::load_once().exec().await?,
-        ///     Arc::new(OpenJtalk::new(OPEN_JTALK_DIC_DIR).await.unwrap()),
-        ///     &InitializeOptions {
-        ///         acceleration_mode: ACCELERATION_MODE,
-        ///         ..Default::default()
-        ///     },
-        /// )?;
+        /// // FIXME: `Synthesizer`には`&mut self`なメソッドはもう無いはず
+        /// let mut syntesizer = Synthesizer::builder(Onnxruntime::load_once().exec().await?)
+        ///     .open_jtalk(Arc::new(OpenJtalk::new(OPEN_JTALK_DIC_DIR).await.unwrap())) // FIXME: `Arc`は要らないはず
+        ///     .acceleration_mode(ACCELERATION_MODE)
+        ///     .build()?;
         /// #
         /// # Ok(())
         /// # }
         /// ```
-        pub fn new(
-            onnxruntime: &'static crate::nonblocking::Onnxruntime,
-            open_jtalk: O,
-            options: &InitializeOptions,
-        ) -> Result<Self> {
-            Inner::new(&onnxruntime.0, open_jtalk, options)
-                .map(Into::into)
-                .map(Self)
+        pub fn builder(onnxruntime: &'static crate::nonblocking::Onnxruntime) -> Builder<()> {
+            Builder {
+                onnxruntime,
+                open_jtalk: (),
+                options: Default::default(),
+            }
         }
+    }
 
+    impl<O: Send + Sync + 'static> self::Synthesizer<O> {
         pub fn onnxruntime(&self) -> &'static crate::nonblocking::Onnxruntime {
             crate::nonblocking::Onnxruntime::from_blocking(self.0.onnxruntime())
         }
@@ -1850,13 +1970,17 @@ pub(crate) mod nonblocking {
         }
 
         /// AudioQueryから音声合成を行う。
-        pub async fn synthesis(
-            &self,
-            audio_query: &AudioQuery,
+        pub fn synthesis<'a>(
+            &'a self,
+            audio_query: &'a AudioQuery,
             style_id: StyleId,
-            options: &SynthesisOptions,
-        ) -> Result<Vec<u8>> {
-            self.0.synthesis(audio_query, style_id, options).await
+        ) -> Synthesis<'a, O> {
+            Synthesis {
+                synthesizer: &self.0,
+                audio_query,
+                style_id,
+                options: Default::default(),
+            }
         }
 
         /// AquesTalk風記法からAccentPhrase (アクセント句)の配列を生成する。
@@ -1955,13 +2079,13 @@ pub(crate) mod nonblocking {
         }
 
         /// AquesTalk風記法から音声合成を行う。
-        pub async fn tts_from_kana(
-            &self,
-            kana: &str,
-            style_id: StyleId,
-            options: &TtsOptions,
-        ) -> Result<Vec<u8>> {
-            self.0.tts_from_kana(kana, style_id, options).await
+        pub fn tts_from_kana<'a>(&'a self, kana: &'a str, style_id: StyleId) -> TtsFromKana<'a, O> {
+            TtsFromKana {
+                synthesizer: &self.0,
+                kana,
+                style_id,
+                options: Default::default(),
+            }
         }
     }
 
@@ -2033,13 +2157,13 @@ pub(crate) mod nonblocking {
         }
 
         /// 日本語のテキストから音声合成を行う。
-        pub async fn tts(
-            &self,
-            text: &str,
-            style_id: StyleId,
-            options: &TtsOptions,
-        ) -> Result<Vec<u8>> {
-            self.0.tts(text, style_id, options).await
+        pub fn tts<'a>(&'a self, text: &'a str, style_id: StyleId) -> Tts<'a, T> {
+            Tts {
+                synthesizer: &self.0,
+                text,
+                style_id,
+                options: Default::default(),
+            }
         }
     }
 
@@ -2049,11 +2173,115 @@ pub(crate) mod nonblocking {
             super::blocking::Synthesizer(self.0.into())
         }
     }
+
+    pub struct Builder<O> {
+        onnxruntime: &'static crate::nonblocking::Onnxruntime,
+        open_jtalk: O,
+        options: InitializeOptions,
+    }
+
+    impl<O> Builder<O> {
+        pub fn open_jtalk<O2>(self, open_jtalk: O2) -> Builder<O2> {
+            Builder {
+                open_jtalk,
+                onnxruntime: self.onnxruntime,
+                options: self.options,
+            }
+        }
+
+        pub fn acceleration_mode(mut self, acceleration_mode: AccelerationMode) -> Self {
+            self.options.acceleration_mode = acceleration_mode;
+            self
+        }
+
+        /// CPU利用数を指定。0を指定すると環境に合わせたCPUが利用される。
+        ///
+        /// # Performance
+        ///
+        /// 未調査ではあるが、物理コアの数+1とするのが適切な可能性がある
+        /// ([VOICEVOX/voicevox_core#902])。
+        ///
+        /// [VOICEVOX/voicevox_core#902]: https://github.com/VOICEVOX/voicevox_core/issues/902
+        pub fn cpu_num_threads(mut self, cpu_num_threads: u16) -> Self {
+            self.options.cpu_num_threads = cpu_num_threads;
+            self
+        }
+
+        /// [`Synthesizer`]をコンストラクトする。
+        pub fn build(self) -> crate::Result<Synthesizer<O>> {
+            Inner::new(&self.onnxruntime.0, self.open_jtalk, &self.options).map(Synthesizer)
+        }
+    }
+
+    // TODO: この`O`は削れるはず
+    pub struct Synthesis<'a, O> {
+        synthesizer: &'a Inner<O, BlockingThreadPool>,
+        audio_query: &'a AudioQuery,
+        style_id: StyleId,
+        options: SynthesisOptions,
+    }
+
+    impl<O> Synthesis<'_, O> {
+        pub fn enable_interrogative_upspeak(mut self, enable_interrogative_upspeak: bool) -> Self {
+            self.options.enable_interrogative_upspeak = enable_interrogative_upspeak;
+            self
+        }
+
+        /// 実行する。
+        pub async fn exec(self) -> crate::Result<Vec<u8>> {
+            self.synthesizer
+                .synthesis(self.audio_query, self.style_id, &self.options)
+                .await
+        }
+    }
+
+    // TODO: この`O`は削れるはず
+    pub struct TtsFromKana<'a, O> {
+        synthesizer: &'a Inner<O, BlockingThreadPool>,
+        kana: &'a str,
+        style_id: StyleId,
+        options: TtsOptions,
+    }
+
+    impl<O> TtsFromKana<'_, O> {
+        pub fn enable_interrogative_upspeak(mut self, enable_interrogative_upspeak: bool) -> Self {
+            self.options.enable_interrogative_upspeak = enable_interrogative_upspeak;
+            self
+        }
+
+        /// 実行する。
+        pub async fn exec(self) -> crate::Result<Vec<u8>> {
+            self.synthesizer
+                .tts_from_kana(self.kana, self.style_id, &self.options)
+                .await
+        }
+    }
+
+    pub struct Tts<'a, O> {
+        synthesizer: &'a Inner<O, BlockingThreadPool>,
+        text: &'a str,
+        style_id: StyleId,
+        options: TtsOptions,
+    }
+
+    impl<O: FullcontextExtractor> Tts<'_, O> {
+        pub fn enable_interrogative_upspeak(mut self, enable_interrogative_upspeak: bool) -> Self {
+            self.options.enable_interrogative_upspeak = enable_interrogative_upspeak;
+            self
+        }
+
+        /// 実行する。
+        pub async fn exec(self) -> crate::Result<Vec<u8>> {
+            self.synthesizer
+                .tts(self.text, self.style_id, &self.options)
+                .await
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{AccelerationMode, InitializeOptions};
+    use super::AccelerationMode;
     use crate::{
         asyncs::BlockingThreadPool, engine::Mora, macros::tests::assert_debug_fmt_eq, AccentPhrase,
         Result, StyleId,
@@ -2065,16 +2293,13 @@ mod tests {
     #[case(Ok(()))]
     #[tokio::test]
     async fn load_model_works(#[case] expected_result_at_initialized: Result<()>) {
-        let syntesizer = super::nonblocking::Synthesizer::new(
+        let syntesizer = super::nonblocking::Synthesizer::builder(
             crate::nonblocking::Onnxruntime::from_test_util_data()
                 .await
                 .unwrap(),
-            (),
-            &InitializeOptions {
-                acceleration_mode: AccelerationMode::Cpu,
-                ..Default::default()
-            },
         )
+        .acceleration_mode(AccelerationMode::Cpu)
+        .build()
         .unwrap();
 
         let result = syntesizer
@@ -2091,16 +2316,13 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn is_use_gpu_works() {
-        let syntesizer = super::nonblocking::Synthesizer::new(
+        let syntesizer = super::nonblocking::Synthesizer::builder(
             crate::nonblocking::Onnxruntime::from_test_util_data()
                 .await
                 .unwrap(),
-            (),
-            &InitializeOptions {
-                acceleration_mode: AccelerationMode::Cpu,
-                ..Default::default()
-            },
         )
+        .acceleration_mode(AccelerationMode::Cpu)
+        .build()
         .unwrap();
         assert!(!syntesizer.is_gpu_mode());
     }
@@ -2110,16 +2332,13 @@ mod tests {
     #[tokio::test]
     async fn is_loaded_model_by_style_id_works(#[case] style_id: u32, #[case] expected: bool) {
         let style_id = StyleId::new(style_id);
-        let syntesizer = super::nonblocking::Synthesizer::new(
+        let syntesizer = super::nonblocking::Synthesizer::builder(
             crate::nonblocking::Onnxruntime::from_test_util_data()
                 .await
                 .unwrap(),
-            (),
-            &InitializeOptions {
-                acceleration_mode: AccelerationMode::Cpu,
-                ..Default::default()
-            },
         )
+        .acceleration_mode(AccelerationMode::Cpu)
+        .build()
         .unwrap();
         assert!(
             !syntesizer.is_loaded_model_by_style_id(style_id),
@@ -2141,16 +2360,13 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn predict_duration_works() {
-        let syntesizer = super::nonblocking::Synthesizer::new(
+        let syntesizer = super::nonblocking::Synthesizer::builder(
             crate::nonblocking::Onnxruntime::from_test_util_data()
                 .await
                 .unwrap(),
-            (),
-            &InitializeOptions {
-                acceleration_mode: AccelerationMode::Cpu,
-                ..Default::default()
-            },
         )
+        .acceleration_mode(AccelerationMode::Cpu)
+        .build()
         .unwrap();
 
         syntesizer
@@ -2176,16 +2392,13 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn predict_intonation_works() {
-        let syntesizer = super::nonblocking::Synthesizer::new(
+        let syntesizer = super::nonblocking::Synthesizer::builder(
             crate::nonblocking::Onnxruntime::from_test_util_data()
                 .await
                 .unwrap(),
-            (),
-            &InitializeOptions {
-                acceleration_mode: AccelerationMode::Cpu,
-                ..Default::default()
-            },
         )
+        .acceleration_mode(AccelerationMode::Cpu)
+        .build()
         .unwrap();
         syntesizer
             .load_voice_model(&crate::nonblocking::VoiceModelFile::sample().await.unwrap())
@@ -2221,16 +2434,13 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn decode_works() {
-        let syntesizer = super::nonblocking::Synthesizer::new(
+        let syntesizer = super::nonblocking::Synthesizer::builder(
             crate::nonblocking::Onnxruntime::from_test_util_data()
                 .await
                 .unwrap(),
-            (),
-            &InitializeOptions {
-                acceleration_mode: AccelerationMode::Cpu,
-                ..Default::default()
-            },
         )
+        .acceleration_mode(AccelerationMode::Cpu)
+        .build()
         .unwrap();
         syntesizer
             .load_voice_model(&crate::nonblocking::VoiceModelFile::sample().await.unwrap())
@@ -2271,16 +2481,13 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn predict_sing_f0_works() {
-        let syntesizer = super::nonblocking::Synthesizer::new(
+        let syntesizer = super::nonblocking::Synthesizer::builder(
             crate::nonblocking::Onnxruntime::from_test_util_data()
                 .await
                 .unwrap(),
-            (),
-            &InitializeOptions {
-                acceleration_mode: AccelerationMode::Cpu,
-                ..Default::default()
-            },
         )
+        .acceleration_mode(AccelerationMode::Cpu)
+        .build()
         .unwrap();
         syntesizer
             .load_voice_model(&crate::nonblocking::VoiceModelFile::sample().await.unwrap())
@@ -2309,16 +2516,13 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn predict_sing_volume_works() {
-        let syntesizer = super::nonblocking::Synthesizer::new(
+        let syntesizer = super::nonblocking::Synthesizer::builder(
             crate::nonblocking::Onnxruntime::from_test_util_data()
                 .await
                 .unwrap(),
-            (),
-            &InitializeOptions {
-                acceleration_mode: AccelerationMode::Cpu,
-                ..Default::default()
-            },
         )
+        .acceleration_mode(AccelerationMode::Cpu)
+        .build()
         .unwrap();
         syntesizer
             .load_voice_model(&crate::nonblocking::VoiceModelFile::sample().await.unwrap())
@@ -2349,16 +2553,13 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn sf_decode_works() {
-        let syntesizer = super::nonblocking::Synthesizer::new(
+        let syntesizer = super::nonblocking::Synthesizer::builder(
             crate::nonblocking::Onnxruntime::from_test_util_data()
                 .await
                 .unwrap(),
-            (),
-            &InitializeOptions {
-                acceleration_mode: AccelerationMode::Cpu,
-                ..Default::default()
-            },
         )
+        .acceleration_mode(AccelerationMode::Cpu)
+        .build()
         .unwrap();
         syntesizer
             .load_voice_model(&crate::nonblocking::VoiceModelFile::sample().await.unwrap())
@@ -2456,18 +2657,18 @@ mod tests {
         #[case] expected_text_consonant_vowel_data: &TextConsonantVowelData,
         #[case] expected_kana_text: &str,
     ) {
-        let syntesizer = super::nonblocking::Synthesizer::new(
+        let syntesizer = super::nonblocking::Synthesizer::builder(
             crate::nonblocking::Onnxruntime::from_test_util_data()
                 .await
                 .unwrap(),
+        )
+        .open_jtalk(
             crate::nonblocking::OpenJtalk::new(OPEN_JTALK_DIC_DIR)
                 .await
                 .unwrap(),
-            &InitializeOptions {
-                acceleration_mode: AccelerationMode::Cpu,
-                ..Default::default()
-            },
         )
+        .acceleration_mode(AccelerationMode::Cpu)
+        .build()
         .unwrap();
 
         let model = &crate::nonblocking::VoiceModelFile::sample().await.unwrap();
@@ -2527,18 +2728,18 @@ mod tests {
         #[case] input: Input,
         #[case] expected_text_consonant_vowel_data: &TextConsonantVowelData,
     ) {
-        let syntesizer = super::nonblocking::Synthesizer::new(
+        let syntesizer = super::nonblocking::Synthesizer::builder(
             crate::nonblocking::Onnxruntime::from_test_util_data()
                 .await
                 .unwrap(),
+        )
+        .open_jtalk(
             crate::nonblocking::OpenJtalk::new(OPEN_JTALK_DIC_DIR)
                 .await
                 .unwrap(),
-            &InitializeOptions {
-                acceleration_mode: AccelerationMode::Cpu,
-                ..Default::default()
-            },
         )
+        .acceleration_mode(AccelerationMode::Cpu)
+        .build()
         .unwrap();
 
         let model = &crate::nonblocking::VoiceModelFile::sample().await.unwrap();
@@ -2595,18 +2796,18 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn create_accent_phrases_works_for_japanese_commas_and_periods() {
-        let syntesizer = super::nonblocking::Synthesizer::new(
+        let syntesizer = super::nonblocking::Synthesizer::builder(
             crate::nonblocking::Onnxruntime::from_test_util_data()
                 .await
                 .unwrap(),
+        )
+        .open_jtalk(
             crate::nonblocking::OpenJtalk::new(OPEN_JTALK_DIC_DIR)
                 .await
                 .unwrap(),
-            &InitializeOptions {
-                acceleration_mode: AccelerationMode::Cpu,
-                ..Default::default()
-            },
         )
+        .acceleration_mode(AccelerationMode::Cpu)
+        .build()
         .unwrap();
 
         let model = &crate::nonblocking::VoiceModelFile::sample().await.unwrap();
@@ -2658,18 +2859,18 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn mora_length_works() {
-        let syntesizer = super::nonblocking::Synthesizer::new(
+        let syntesizer = super::nonblocking::Synthesizer::builder(
             crate::nonblocking::Onnxruntime::from_test_util_data()
                 .await
                 .unwrap(),
+        )
+        .open_jtalk(
             crate::nonblocking::OpenJtalk::new(OPEN_JTALK_DIC_DIR)
                 .await
                 .unwrap(),
-            &InitializeOptions {
-                acceleration_mode: AccelerationMode::Cpu,
-                ..Default::default()
-            },
         )
+        .acceleration_mode(AccelerationMode::Cpu)
+        .build()
         .unwrap();
 
         let model = &crate::nonblocking::VoiceModelFile::sample().await.unwrap();
@@ -2699,18 +2900,18 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn mora_pitch_works() {
-        let syntesizer = super::nonblocking::Synthesizer::new(
+        let syntesizer = super::nonblocking::Synthesizer::builder(
             crate::nonblocking::Onnxruntime::from_test_util_data()
                 .await
                 .unwrap(),
+        )
+        .open_jtalk(
             crate::nonblocking::OpenJtalk::new(OPEN_JTALK_DIC_DIR)
                 .await
                 .unwrap(),
-            &InitializeOptions {
-                acceleration_mode: AccelerationMode::Cpu,
-                ..Default::default()
-            },
         )
+        .acceleration_mode(AccelerationMode::Cpu)
+        .build()
         .unwrap();
 
         let model = &crate::nonblocking::VoiceModelFile::sample().await.unwrap();
@@ -2740,18 +2941,18 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn mora_data_works() {
-        let syntesizer = super::nonblocking::Synthesizer::new(
+        let syntesizer = super::nonblocking::Synthesizer::builder(
             crate::nonblocking::Onnxruntime::from_test_util_data()
                 .await
                 .unwrap(),
+        )
+        .open_jtalk(
             crate::nonblocking::OpenJtalk::new(OPEN_JTALK_DIC_DIR)
                 .await
                 .unwrap(),
-            &InitializeOptions {
-                acceleration_mode: AccelerationMode::Cpu,
-                ..Default::default()
-            },
         )
+        .acceleration_mode(AccelerationMode::Cpu)
+        .build()
         .unwrap();
 
         let model = &crate::nonblocking::VoiceModelFile::sample().await.unwrap();

--- a/crates/voicevox_core_c_api/src/compatible_engine.rs
+++ b/crates/voicevox_core_c_api/src/compatible_engine.rs
@@ -117,18 +117,14 @@ fn set_message(message: &str) {
 pub extern "C" fn initialize(use_gpu: bool, cpu_num_threads: c_int, load_all_models: bool) -> bool {
     init_logger_once();
     let result = (|| {
-        let synthesizer = voicevox_core::blocking::Synthesizer::new(
-            *ONNXRUNTIME,
-            (),
-            &voicevox_core::InitializeOptions {
-                acceleration_mode: if use_gpu {
-                    voicevox_core::AccelerationMode::Gpu
-                } else {
-                    voicevox_core::AccelerationMode::Cpu
-                },
-                cpu_num_threads: cpu_num_threads as u16,
-            },
-        )?;
+        let synthesizer = voicevox_core::blocking::Synthesizer::builder(*ONNXRUNTIME)
+            .acceleration_mode(if use_gpu {
+                voicevox_core::AccelerationMode::Gpu
+            } else {
+                voicevox_core::AccelerationMode::Cpu
+            })
+            .cpu_num_threads(cpu_num_threads as u16)
+            .build()?;
 
         if load_all_models {
             for model in &voice_model_set().all_vvms {

--- a/crates/voicevox_core_c_api/src/helpers.rs
+++ b/crates/voicevox_core_c_api/src/helpers.rs
@@ -1,7 +1,7 @@
 use easy_ext::ext;
 use std::{ffi::CStr, fmt::Debug, iter};
 use uuid::Uuid;
-use voicevox_core::{AudioQuery, UserDictWord, VoiceModelId};
+use voicevox_core::{AccelerationMode, AudioQuery, UserDictWord, VoiceModelId};
 
 use thiserror::Error;
 use tracing::error;
@@ -92,14 +92,6 @@ pub(crate) fn ensure_utf8(s: &CStr) -> CApiResult<&str> {
     s.to_str().map_err(|_| CApiError::InvalidUtf8Input)
 }
 
-impl From<VoicevoxSynthesisOptions> for voicevox_core::SynthesisOptions {
-    fn from(options: VoicevoxSynthesisOptions) -> Self {
-        Self {
-            enable_interrogative_upspeak: options.enable_interrogative_upspeak,
-        }
-    }
-}
-
 impl From<voicevox_core::AccelerationMode> for VoicevoxAccelerationMode {
     fn from(mode: voicevox_core::AccelerationMode) -> Self {
         use voicevox_core::AccelerationMode::*;
@@ -124,44 +116,27 @@ impl From<VoicevoxAccelerationMode> for voicevox_core::AccelerationMode {
 
 impl Default for VoicevoxInitializeOptions {
     fn default() -> Self {
-        let options = voicevox_core::InitializeOptions::default();
         Self {
-            acceleration_mode: options.acceleration_mode.into(),
-            cpu_num_threads: options.cpu_num_threads,
-        }
-    }
-}
-
-impl From<VoicevoxInitializeOptions> for voicevox_core::InitializeOptions {
-    fn from(value: VoicevoxInitializeOptions) -> Self {
-        voicevox_core::InitializeOptions {
-            acceleration_mode: value.acceleration_mode.into(),
-            cpu_num_threads: value.cpu_num_threads,
-        }
-    }
-}
-
-impl From<voicevox_core::TtsOptions> for VoicevoxTtsOptions {
-    fn from(options: voicevox_core::TtsOptions) -> Self {
-        Self {
-            enable_interrogative_upspeak: options.enable_interrogative_upspeak,
-        }
-    }
-}
-
-impl From<VoicevoxTtsOptions> for voicevox_core::TtsOptions {
-    fn from(options: VoicevoxTtsOptions) -> Self {
-        Self {
-            enable_interrogative_upspeak: options.enable_interrogative_upspeak,
+            acceleration_mode: AccelerationMode::default().into(),
+            cpu_num_threads: voicevox_core::__internal::interop::DEFAULT_CPU_NUM_THREADS,
         }
     }
 }
 
 impl Default for VoicevoxSynthesisOptions {
     fn default() -> Self {
-        let options = voicevox_core::TtsOptions::default();
         Self {
-            enable_interrogative_upspeak: options.enable_interrogative_upspeak,
+            enable_interrogative_upspeak:
+                voicevox_core::__internal::interop::DEFAULT_ENABLE_INTERROGATIVE_UPSPEAK,
+        }
+    }
+}
+
+impl Default for VoicevoxTtsOptions {
+    fn default() -> Self {
+        Self {
+            enable_interrogative_upspeak:
+                voicevox_core::__internal::interop::DEFAULT_ENABLE_INTERROGATIVE_UPSPEAK,
         }
     }
 }

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -38,8 +38,7 @@ use std::sync::Once;
 use tracing_subscriber::fmt::format::Writer;
 use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
-use voicevox_core::{AccentPhrase, AudioQuery, TtsOptions, UserDictWord};
-use voicevox_core::{StyleId, SynthesisOptions};
+use voicevox_core::{AccentPhrase, AudioQuery, StyleId, UserDictWord};
 
 fn init_logger_once() {
     static ONCE: Once = Once::new();
@@ -362,7 +361,7 @@ pub extern "C" fn voicevox_open_jtalk_rc_delete(open_jtalk: *mut OpenJtalkRc) {
 
 /// ハードウェアアクセラレーションモードを設定する設定値。
 #[repr(i32)]
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[allow(
     non_camel_case_types,
     reason = "実際に公開するC APIとの差異をできるだけ少なくするため"
@@ -544,9 +543,7 @@ pub unsafe extern "C" fn voicevox_synthesizer_new(
 ) -> VoicevoxResultCode {
     init_logger_once();
     into_result_code_with_error((|| {
-        let options = options.into();
-
-        let synthesizer = VoicevoxSynthesizer::new(onnxruntime, open_jtalk, &options)?;
+        let synthesizer = VoicevoxSynthesizer::new(onnxruntime, open_jtalk, options)?;
         out_synthesizer.write_unaligned(synthesizer);
         Ok(())
     })())
@@ -1083,11 +1080,14 @@ pub unsafe extern "C" fn voicevox_synthesizer_synthesis(
             .map_err(|_| CApiError::InvalidUtf8Input)?;
         let audio_query: AudioQuery =
             serde_json::from_str(audio_query_json).map_err(CApiError::InvalidAudioQuery)?;
-        let wav = synthesizer.body().synthesis(
-            &audio_query,
-            StyleId::new(style_id),
-            &SynthesisOptions::from(options),
-        )?;
+        let VoicevoxSynthesisOptions {
+            enable_interrogative_upspeak,
+        } = options;
+        let wav = synthesizer
+            .body()
+            .synthesis(&audio_query, StyleId::new(style_id))
+            .enable_interrogative_upspeak(enable_interrogative_upspeak)
+            .exec()?;
         U8_SLICE_OWNER.own_and_lend(wav, output_wav, output_wav_length);
         Ok(())
     })())
@@ -1107,7 +1107,7 @@ pub struct VoicevoxTtsOptions {
 #[no_mangle]
 pub extern "C" fn voicevox_make_default_tts_options() -> VoicevoxTtsOptions {
     init_logger_once();
-    voicevox_core::TtsOptions::default().into()
+    VoicevoxTtsOptions::default()
 }
 
 // TODO: cbindgenが`#[unsafe(no_mangle)]`に対応したら`#[no_mangle]`を置き換える
@@ -1142,11 +1142,14 @@ pub unsafe extern "C" fn voicevox_synthesizer_tts_from_kana(
     init_logger_once();
     into_result_code_with_error((|| {
         let kana = ensure_utf8(CStr::from_ptr(kana))?;
-        let output = synthesizer.body().tts_from_kana(
-            kana,
-            StyleId::new(style_id),
-            &TtsOptions::from(options),
-        )?;
+        let VoicevoxTtsOptions {
+            enable_interrogative_upspeak,
+        } = options;
+        let output = synthesizer
+            .body()
+            .tts_from_kana(kana, StyleId::new(style_id))
+            .enable_interrogative_upspeak(enable_interrogative_upspeak)
+            .exec()?;
         U8_SLICE_OWNER.own_and_lend(output, output_wav, output_wav_length);
         Ok(())
     })())
@@ -1184,10 +1187,14 @@ pub unsafe extern "C" fn voicevox_synthesizer_tts(
     init_logger_once();
     into_result_code_with_error((|| {
         let text = ensure_utf8(CStr::from_ptr(text))?;
-        let output =
-            synthesizer
-                .body()
-                .tts(text, StyleId::new(style_id), &TtsOptions::from(options))?;
+        let VoicevoxTtsOptions {
+            enable_interrogative_upspeak,
+        } = options;
+        let output = synthesizer
+            .body()
+            .tts(text, StyleId::new(style_id))
+            .enable_interrogative_upspeak(enable_interrogative_upspeak)
+            .exec()?;
         U8_SLICE_OWNER.own_and_lend(output, output_wav, output_wav_length);
         Ok(())
     })())


### PR DESCRIPTION
## 内容

api-design.mdでの方針に従い、Rust APIの表層から`{Initialize,Synthesis,Tts}Options`を消してビルダースタイルにする。

<https://github.com/VOICEVOX/voicevox_core/blob/babb3b764313ee43cef57e1006a8500785c96064/docs/guide/dev/api-design.md?plain=1#L13>

## 関連 Issue

Refs: #388

## その他

帰省の途中、航空機内で実装しました。これが丁度よさそうだったので…
