### PR TITLE
test: Java APIの`tts`のテストが動いてなかったのを修正

### DIFF
--- a/crates/voicevox_core_java_api/lib/src/test/java/jp/hiroshiba/voicevoxcore/blocking/SynthesizerTest.java
+++ b/crates/voicevox_core_java_api/lib/src/test/java/jp/hiroshiba/voicevoxcore/blocking/SynthesizerTest.java
@@ -124,6 +124,6 @@ class SynthesizerTest extends TestUtils {
     try (VoiceModelFile model = openModel()) {
       synthesizer.loadVoiceModel(model);
     }
-    synthesizer.tts("こんにちは", synthesizer.metas()[0].styles[0].id);
+    synthesizer.tts("こんにちは", synthesizer.metas()[0].styles[0].id).execute();
   }
 }


### PR DESCRIPTION
## 内容

## 関連 Issue

## その他

#908 の本文を書いてるときに発見しました。
