### PR TITLE
feat: Rust APIのビルダー構造体を`#[must_use]`にする

### DIFF
--- a/crates/voicevox_core/src/infer/runtimes/onnxruntime.rs
+++ b/crates/voicevox_core/src/infer/runtimes/onnxruntime.rs
@@ -425,6 +425,7 @@ pub(crate) mod blocking {
 
     /// [`Onnxruntime::load_once`]のビルダー。
     #[cfg(feature = "load-onnxruntime")]
+    #[must_use = "this is a builder. it does nothing until `exec`uted"]
     pub struct LoadOnce {
         filename: std::ffi::OsString,
     }
@@ -586,6 +587,7 @@ pub(crate) mod nonblocking {
     /// [`Onnxruntime::load_once`]のビルダー。
     #[cfg(feature = "load-onnxruntime")]
     #[derive(Default)]
+    #[must_use = "this is a builder. it does nothing until `exec`uted"]
     pub struct LoadOnce(super::blocking::LoadOnce);
 
     #[cfg(feature = "load-onnxruntime")]

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -1746,6 +1746,7 @@ pub(crate) mod blocking {
         }
     }
 
+    #[must_use]
     pub struct Builder<O> {
         onnxruntime: &'static crate::blocking::Onnxruntime,
         open_jtalk: O,
@@ -1779,6 +1780,7 @@ pub(crate) mod blocking {
     }
 
     // TODO: この`O`は削れるはず
+    #[must_use = "this is a builder. it does nothing until `exec`uted"]
     pub struct PrecomputeRender<'a, O> {
         synthesizer: &'a Inner<O, SingleTasked>,
         audio_query: &'a AudioQuery,
@@ -1801,6 +1803,7 @@ pub(crate) mod blocking {
     }
 
     // TODO: この`O`は削れるはず
+    #[must_use = "this is a builder. it does nothing until `exec`uted"]
     pub struct Synthesis<'a, O> {
         synthesizer: &'a Inner<O, SingleTasked>,
         audio_query: &'a AudioQuery,
@@ -1823,6 +1826,7 @@ pub(crate) mod blocking {
     }
 
     // TODO: この`O`は削れるはず
+    #[must_use = "this is a builder. it does nothing until `exec`uted"]
     pub struct TtsFromKana<'a, O> {
         synthesizer: &'a Inner<O, SingleTasked>,
         kana: &'a str,
@@ -1844,6 +1848,7 @@ pub(crate) mod blocking {
         }
     }
 
+    #[must_use = "this is a builder. it does nothing until `exec`uted"]
     pub struct Tts<'a, O> {
         synthesizer: &'a Inner<O, SingleTasked>,
         text: &'a str,
@@ -2174,6 +2179,7 @@ pub(crate) mod nonblocking {
         }
     }
 
+    #[must_use]
     pub struct Builder<O> {
         onnxruntime: &'static crate::nonblocking::Onnxruntime,
         open_jtalk: O,
@@ -2214,6 +2220,7 @@ pub(crate) mod nonblocking {
     }
 
     // TODO: この`O`は削れるはず
+    #[must_use = "this is a builder. it does nothing until `exec`uted"]
     pub struct Synthesis<'a, O> {
         synthesizer: &'a Inner<O, BlockingThreadPool>,
         audio_query: &'a AudioQuery,
@@ -2236,6 +2243,7 @@ pub(crate) mod nonblocking {
     }
 
     // TODO: この`O`は削れるはず
+    #[must_use = "this is a builder. it does nothing until `exec`uted"]
     pub struct TtsFromKana<'a, O> {
         synthesizer: &'a Inner<O, BlockingThreadPool>,
         kana: &'a str,
@@ -2257,6 +2265,7 @@ pub(crate) mod nonblocking {
         }
     }
 
+    #[must_use = "this is a builder. it does nothing until `exec`uted"]
     pub struct Tts<'a, O> {
         synthesizer: &'a Inner<O, BlockingThreadPool>,
         text: &'a str,


### PR DESCRIPTION
## 内容

Rust APIを使う次のようなコードに対して警告が出るようにする。

```rs
Onnxruntime::load_once();
```

![Image](https://github.com/user-attachments/assets/494a118d-86b1-4db7-8257-624e6a911376)

## 関連 Issue

Refs: #388, #908

## その他
