### PR TITLE
fix: fix up #915: bump the PyO3's `abi3` feature to `abi3-py310`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Rust
         uses: ./.github/actions/rust-toolchain-from-file
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
       - uses: Swatinem/rust-cache@v2
         with:
           key: "cargo-unit-test-cache"

--- a/crates/voicevox_core_python_api/Cargo.toml
+++ b/crates/voicevox_core_python_api/Cargo.toml
@@ -14,7 +14,7 @@ easy-ext.workspace = true
 futures-lite.workspace = true
 log.workspace = true
 once_cell.workspace = true
-pyo3 = { workspace = true, features = ["abi3-py38", "extension-module"] }
+pyo3 = { workspace = true, features = ["abi3-py310", "extension-module"] }
 pyo3-asyncio = { workspace = true, features = ["tokio-runtime"] }
 pyo3-log.workspace = true
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
## 内容

これをやらないとwhl名が"…-cp38-abi3-…"のままになり、誤解を生じさせることが予想できるため。

See-also: https://pyo3.rs/v0.23.4/building-and-distribution#minimum-python-version-for-abi3

## 関連 Issue

## その他
