### PR TITLE
fix!: 間違って消していた`__internal`の`#[doc(hidden)]`を復活

### DIFF
--- a/crates/voicevox_core/src/lib.rs
+++ b/crates/voicevox_core/src/lib.rs
@@ -68,6 +68,7 @@ mod user_dict;
 mod version;
 mod voice_model;
 
+#[doc(hidden)]
 pub mod __internal;
 pub mod blocking;
 pub mod nonblocking;


### PR DESCRIPTION
## 内容

## 関連 Issue

## その他

確か何かをしているときに間違えて消したままコミットしてしまい、レビューも素通りしてしまったという経緯だったような記憶。
