### PR TITLE
feat!: Rust APIのnewtypeをopenなstructにし、`Raw`を消す

### DIFF
--- a/crates/voicevox_core/src/lib.rs
+++ b/crates/voicevox_core/src/lib.rs
@@ -87,13 +87,10 @@ pub use self::{
     devices::SupportedDevices,
     engine::{wav_from_s16le, AccentPhrase, AudioQuery, Mora},
     error::{Error, ErrorKind},
-    metas::{
-        RawSpeakerVersion, RawStyleId, SpeakerMeta, SpeakerVersion, StyleId, StyleMeta, StyleType,
-        VoiceModelMeta,
-    },
+    metas::{SpeakerMeta, SpeakerVersion, StyleId, StyleMeta, StyleType, VoiceModelMeta},
     result::Result,
     synthesizer::AccelerationMode,
     user_dict::{UserDictWord, UserDictWordType},
     version::VERSION,
-    voice_model::{RawVoiceModelId, VoiceModelId},
+    voice_model::VoiceModelId,
 };

--- a/crates/voicevox_core/src/metas.rs
+++ b/crates/voicevox_core/src/metas.rs
@@ -37,11 +37,6 @@ pub fn merge<'a>(metas: impl IntoIterator<Item = &'a SpeakerMeta>) -> Vec<Speake
     }
 }
 
-/// [`StyleId`]の実体。
-///
-/// [`StyleId`]: StyleId
-pub type RawStyleId = u32;
-
 /// スタイルID。
 ///
 /// VOICEVOXにおける、ある[**話者**(_speaker_)]のある[**スタイル**(_style_)]を指す。
@@ -62,38 +57,23 @@ pub type RawStyleId = u32;
     new,
     Debug,
 )]
-pub struct StyleId(RawStyleId);
-
-impl StyleId {
-    pub fn raw_id(self) -> RawStyleId {
-        self.0
-    }
-}
+pub struct StyleId(pub u32);
 
 impl Display for StyleId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.raw_id())
+        write!(f, "{}", self.0)
     }
 }
-
-/// [`SpeakerVersion`]の実体。
-pub type RawSpeakerVersion = String;
 
 /// [**話者**(_speaker_)]のバージョン。
 ///
 /// [**話者**(_speaker_)]: SpeakerMeta
 #[derive(PartialEq, Eq, Clone, Ord, PartialOrd, Deserialize, Serialize, new, Debug)]
-pub struct SpeakerVersion(RawSpeakerVersion);
-
-impl SpeakerVersion {
-    pub fn raw_version(&self) -> &RawSpeakerVersion {
-        &self.0
-    }
-}
+pub struct SpeakerVersion(pub String);
 
 impl Display for SpeakerVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.raw_version())
+        write!(f, "{}", self.0)
     }
 }
 

--- a/crates/voicevox_core/src/status.rs
+++ b/crates/voicevox_core/src/status.rs
@@ -175,7 +175,7 @@ impl<R: InferenceRuntime> LoadedModels<R> {
             .get::<D>()
             .as_ref()
             .and_then(|(inner_voice_ids, _)| inner_voice_ids.get(&style_id).copied())
-            .unwrap_or_else(|| InnerVoiceId::new(style_id.raw_id()));
+            .unwrap_or_else(|| InnerVoiceId::new(style_id.0));
 
         Ok((*model_id, inner_voice_id))
     }

--- a/crates/voicevox_core/src/voice_model.rs
+++ b/crates/voicevox_core/src/voice_model.rs
@@ -33,11 +33,6 @@ use crate::{
     SpeakerMeta, StyleMeta, StyleType, VoiceModelMeta,
 };
 
-/// [`VoiceModelId`]の実体。
-///
-/// [`VoiceModelId`]: VoiceModelId
-pub type RawVoiceModelId = Uuid;
-
 pub(crate) type ModelBytesWithInnerVoiceIdsByDomain = inference_domain_map_values!(
     for<D> Option<(StyleIdToInnerVoiceId, EnumMap<D::Operation, ModelBytes>)>
 );
@@ -56,13 +51,7 @@ pub(crate) type ModelBytesWithInnerVoiceIdsByDomain = inference_domain_map_value
     Debug,
     From,
 )]
-pub struct VoiceModelId(RawVoiceModelId);
-
-impl VoiceModelId {
-    pub fn raw_voice_model_id(self) -> RawVoiceModelId {
-        self.0
-    }
-}
+pub struct VoiceModelId(pub Uuid);
 
 #[self_referencing]
 pub(crate) struct Inner<A: Async> {

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -474,7 +474,7 @@ pub unsafe extern "C" fn voicevox_voice_model_file_id(
     output_voice_model_id: NonNull<[u8; 16]>,
 ) {
     init_logger_once();
-    let id = model.body().id().raw_voice_model_id().into_bytes();
+    let id = model.body().id().0.into_bytes();
     unsafe { output_voice_model_id.write_unaligned(id) };
 }
 

--- a/crates/voicevox_core_java_api/src/voice_model.rs
+++ b/crates/voicevox_core_java_api/src/voice_model.rs
@@ -44,7 +44,7 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_blocking_VoiceModelFile
             .clone();
         let internal = internal.read()?;
 
-        let id = env.new_uuid(internal.id().raw_voice_model_id())?;
+        let id = env.new_uuid(internal.id().0)?;
 
         Ok(id.into_raw())
     })

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -319,7 +319,7 @@ mod blocking {
         fn open(py: Python<'_>, path: PathBuf) -> PyResult<Self> {
             let model = voicevox_core::blocking::VoiceModelFile::open(path).into_py_result(py)?;
 
-            let id = crate::convert::to_py_uuid(py, model.id().raw_voice_model_id())?;
+            let id = crate::convert::to_py_uuid(py, model.id().0)?;
             let metas = crate::convert::to_pydantic_voice_model_meta(model.metas(), py)?.into();
 
             let model = Closable::new(model).into();
@@ -905,7 +905,7 @@ mod asyncio {
                 let model = voicevox_core::nonblocking::VoiceModelFile::open(path).await;
                 let (model, id, metas) = Python::with_gil(|py| {
                     let model = Python::with_gil(|py| model.into_py_result(py))?;
-                    let id = crate::convert::to_py_uuid(py, model.id().raw_voice_model_id())?;
+                    let id = crate::convert::to_py_uuid(py, model.id().0)?;
                     let metas =
                         crate::convert::to_pydantic_voice_model_meta(model.metas(), py)?.into();
                     Ok::<_, PyErr>((model, id, metas))


### PR DESCRIPTION
## 内容

#370 から続いている、Rust APIのnewtypeの形を変える。

当時どういう意図だったのかは正確にはわかりませんが、二年経っての現状を鑑みても、「透過的」であるように振る舞った方がよいのではないかと思った次第です。
（一応当時の時点で私はVOICEVOX ONNX Runtimeのアイデアを思い付いて提案してたと思うので、Rust APIを前提にしていたとは思います）

See-also: https://rust-lang.github.io/api-guidelines/type-safety.html#newtypes-provide-static-distinctions-c-newtype

## 関連 Issue

## その他
