### PR TITLE
feat!: [downloader] rename `core` to `c-api`

### DIFF
--- a/.github/workflows/download_test.yml
+++ b/.github/workflows/download_test.yml
@@ -198,7 +198,7 @@ jobs:
           )
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
       - name: Execute download command
-        run: ${{ matrix.download_command }} --version ${{ env.VERSION }} --core-repo ${{ github.repository }}
+        run: ${{ matrix.download_command }} --c-api-version ${{ env.VERSION }} --c-api-repo ${{ github.repository }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Check downloaded version


### PR DESCRIPTION
## 内容

VVMやVOICEVOX ONNX Runtimeのみをダウンロードする(`--only models onnxruntime`)用途が見えてきてる今、「コア」とはC APIのことであるとはっきりと明示した方がよいかなと思った次第です。

BREAKING-CHANGE: `core` → `c-api`。
BREAKING-CHANGE: `-v, --version` → `--c-api-version`。
BREAKING-CHANGE: `--core-repo` → `--c-api-repo`。

## 関連 Issue

## その他
