### PR TITLE
feat: whlにLICENSEファイルを含める

### DIFF
--- a/crates/voicevox_core_python_api/pyproject.toml
+++ b/crates/voicevox_core_python_api/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 requires-python = ">=3.10"
 dependencies = ["pydantic>=2.5.2,<3"]
 description = "VOICEVOX CORE の Python バインディングです。"
+license = { file = "../../LICENSE" }
 authors = [{ name = "Hiroshiba", email = "hihokaruta@gmail.com" }]
 classifiers = [
     "Programming Language :: Python",


### PR DESCRIPTION
## 内容

Maturinの機能で埋め込む。whlの内容は次のようになる。

```diff
 ├── voicevox_core
 │   └── …
 └── voicevox_core-{version}.dist-info
+    ├── licenses
+    │   └── LICENSE
     ├── METADATA
     ├── RECORD
     └── WHEEL
```

## 関連 Issue

Refs: #938

## その他

ちなみにONNX Runtimeのwhlでは、dist-infoではなくonnxruntime/下に無造作に置かれていました。

あとreadmeについては今こうなっていますが、

<https://github.com/VOICEVOX/voicevox_core/blob/8112ecb297e96d20aa1aa203ae7f9886b98456ea/crates/voicevox_core_python_api/pyproject.toml#L16-L17>

どうもMaturinが自動でREADME.mdを見つけて埋め込むようで、今METADATAには[crates/voicevox_core_python_api/README.md](https://github.com/VOICEVOX/voicevox_core/blob/8112ecb297e96d20aa1aa203ae7f9886b98456ea/crates/voicevox_core_python_api/README.md)がそのまま埋め込まれています。
