### PR TITLE
build: C APIにもLICENSEファイルを同梱

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -252,6 +252,7 @@ jobs:
           cp -v target/${{ matrix.target }}/release/*voicevox_core.{dll,so,dylib} "artifact/${{ env.ASSET_NAME }}" || true
           cp -v target/${{ matrix.target }}/release/voicevox_core.dll.lib "artifact/${{ env.ASSET_NAME }}/voicevox_core.lib" || true
           cp -v README.md "artifact/${{ env.ASSET_NAME }}/README.txt"
+          cp -v LICENSE "artifact/${{ env.ASSET_NAME }}/"
           echo "${{ env.VERSION }}" > "artifact/${{ env.ASSET_NAME }}/VERSION"
 
           mkdir java_artifact


### PR DESCRIPTION
## 内容

#947 に続き。

## 関連 Issue

Refs: #938

## その他

ちなみに今C APIだけREADME.mdはREADME.txtとして入っているようです。
(blameしたら #196 の初案段階からあって、誰も言及していないっぽい)

なのでPython APIやRust APIとはちょっと違う形になってるかと思います。

\[追記\] あと今Android用にだけリリースしているJava APIですが、そっちはちょっと調査が必要そう。どうもそういう文化が無い（!?）ようなので…