### PR TITLE
feat!: ストリーミングAPIを封印する

### DIFF
--- a/crates/voicevox_core/src/blocking.rs
+++ b/crates/voicevox_core/src/blocking.rs
@@ -2,10 +2,14 @@
 
 pub use crate::{
     engine::open_jtalk::blocking::OpenJtalk, infer::runtimes::onnxruntime::blocking::Onnxruntime,
-    synthesizer::blocking::AudioFeature, synthesizer::blocking::Synthesizer,
-    text_analyzer::blocking::TextAnalyzer, user_dict::dict::blocking::UserDict,
-    voice_model::blocking::VoiceModelFile,
+    synthesizer::blocking::Synthesizer, text_analyzer::blocking::TextAnalyzer,
+    user_dict::dict::blocking::UserDict, voice_model::blocking::VoiceModelFile,
 };
+
+// TODO: 後で復活させる
+// https://github.com/VOICEVOX/voicevox_core/issues/970
+#[doc(hidden)]
+pub use crate::synthesizer::blocking::AudioFeature as __AudioFeature;
 
 pub mod onnxruntime {
     #[cfg(feature = "load-onnxruntime")]
@@ -16,6 +20,7 @@ pub mod onnxruntime {
 pub mod synthesizer {
     pub use crate::synthesizer::blocking::{Builder, Synthesis, Tts, TtsFromKana};
 
-    // TODO: 後で封印する
-    pub use crate::synthesizer::blocking::PrecomputeRender;
+    // TODO: 後で復活させる
+    // https://github.com/VOICEVOX/voicevox_core/issues/970
+    //pub use crate::synthesizer::blocking::PrecomputeRender;
 }

--- a/crates/voicevox_core/src/engine/audio_file.rs
+++ b/crates/voicevox_core/src/engine/audio_file.rs
@@ -29,6 +29,9 @@ pub(crate) fn to_s16le_pcm<const BASE_SAMPLING_RATE: u32>(
 }
 
 /// 16bit PCMにヘッダを付加しWAVフォーマットのバイナリを生成する。
+// TODO: 後で復活させる
+// https://github.com/VOICEVOX/voicevox_core/issues/970
+#[doc(hidden)]
 pub fn wav_from_s16le(pcm: &[u8], sampling_rate: u32, is_stereo: bool) -> Vec<u8> {
     let num_channels: u16 = if is_stereo { 2 } else { 1 };
     let bit_depth: u16 = 16;

--- a/crates/voicevox_core/src/lib.rs
+++ b/crates/voicevox_core/src/lib.rs
@@ -85,7 +85,7 @@ use rstest_reuse;
 
 pub use self::{
     devices::SupportedDevices,
-    engine::{wav_from_s16le, AccentPhrase, AudioQuery, Mora},
+    engine::{AccentPhrase, AudioQuery, Mora},
     error::{Error, ErrorKind},
     metas::{CharacterMeta, CharacterVersion, StyleId, StyleMeta, StyleType, VoiceModelMeta},
     result::Result,
@@ -94,3 +94,8 @@ pub use self::{
     version::VERSION,
     voice_model::VoiceModelId,
 };
+
+// TODO: 後で復活させる
+// https://github.com/VOICEVOX/voicevox_core/issues/970
+#[doc(hidden)]
+pub use self::engine::wav_from_s16le as __wav_from_s16le;

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -166,6 +166,9 @@ fn trim_margin_from_wave(wave_with_margin: ndarray::Array1<f32>) -> ndarray::Arr
 }
 
 /// 音声の中間表現。
+// TODO: 後で復活させる
+// https://github.com/VOICEVOX/voicevox_core/issues/970
+#[doc(hidden)]
 pub struct AudioFeature {
     /// (フレーム数, 特徴数)の形を持つ音声特徴量。
     internal_state: ndarray::Array2<f32>,
@@ -1291,7 +1294,10 @@ pub(crate) mod blocking {
         }
 
         /// AudioQueryから音声合成用の中間表現を生成する。
-        pub fn precompute_render<'a>(
+        // TODO: 後で復活させる
+        // https://github.com/VOICEVOX/voicevox_core/issues/970
+        #[doc(hidden)]
+        pub fn __precompute_render<'a>(
             &'a self,
             audio_query: &'a AudioQuery,
             style_id: StyleId,
@@ -1305,7 +1311,14 @@ pub(crate) mod blocking {
         }
 
         /// 中間表現から16bit PCMで音声波形を生成する。
-        pub fn render(&self, audio: &AudioFeature, range: Range<usize>) -> crate::Result<Vec<u8>> {
+        // TODO: 後で復活させる
+        // https://github.com/VOICEVOX/voicevox_core/issues/970
+        #[doc(hidden)]
+        pub fn __render(
+            &self,
+            audio: &AudioFeature,
+            range: Range<usize>,
+        ) -> crate::Result<Vec<u8>> {
             self.0.render(audio, range).block_on()
         }
 

--- a/crates/voicevox_core_python_api/python/voicevox_core/__init__.py
+++ b/crates/voicevox_core_python_api/python/voicevox_core/__init__.py
@@ -1,5 +1,8 @@
 """無料で使える中品質なテキスト読み上げソフトウェア、VOICEVOXのコア。"""
 
+# TODO: `wav_from_s16le`を復活させる
+# https://github.com/VOICEVOX/voicevox_core/issues/970
+
 from ._models import (  # noqa: F401
     AccelerationMode,
     AccentPhrase,
@@ -36,14 +39,12 @@ from ._rust import (  # noqa: F401
     UseUserDictError,
     WordNotFoundError,
     __version__,
-    wav_from_s16le,
 )
 
 from . import asyncio, blocking  # noqa: F401 isort: skip
 
 __all__ = [
     "__version__",
-    "wav_from_s16le",
     "AccelerationMode",
     "AccentPhrase",
     "AnalyzeTextError",

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
@@ -364,13 +364,13 @@ class Synthesizer:
             スタイルID。
         """
         ...
-    def precompute_render(
+    def __precompute_render(
         self,
         audio_query: AudioQuery,
         style_id: StyleId | int,
         enable_interrogative_upspeak: bool = True,
     ) -> AudioFeature: ...
-    def render(
+    def __render(
         self,
         audio: AudioFeature,
         start: int,

--- a/crates/voicevox_core_python_api/python/voicevox_core/blocking.py
+++ b/crates/voicevox_core_python_api/python/voicevox_core/blocking.py
@@ -1,8 +1,10 @@
 # TODO: Rust API同様のmodule levelのdocstringを書く
 
+# TODO: `AudioFeature`を復活させる
+# https://github.com/VOICEVOX/voicevox_core/issues/970
+
 # pyright: reportMissingModuleSource=false
 from ._rust.blocking import (
-    AudioFeature,
     Onnxruntime,
     OpenJtalk,
     Synthesizer,
@@ -11,7 +13,6 @@ from ._rust.blocking import (
 )
 
 __all__ = [
-    "AudioFeature",
     "Onnxruntime",
     "OpenJtalk",
     "Synthesizer",

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -285,7 +285,7 @@ fn wav_from_s16le<'py>(
 ) -> &'py PyBytes {
     PyBytes::new(
         py,
-        &voicevox_core::wav_from_s16le(pcm, sampling_rate, is_stereo),
+        &voicevox_core::__wav_from_s16le(pcm, sampling_rate, is_stereo),
     )
 }
 
@@ -447,7 +447,7 @@ mod blocking {
 
     #[pyclass]
     pub(crate) struct AudioFeature {
-        audio: voicevox_core::blocking::AudioFeature,
+        audio: voicevox_core::blocking::__AudioFeature,
     }
 
     #[pymethods]
@@ -677,13 +677,16 @@ mod blocking {
             )
         }
 
+        // TODO: 後で復活させる
+        // https://github.com/VOICEVOX/voicevox_core/issues/970
+        #[allow(non_snake_case)]
         #[pyo3(signature=(
             audio_query,
             style_id,
             enable_interrogative_upspeak =
                 voicevox_core::__internal::interop::DEFAULT_ENABLE_INTERROGATIVE_UPSPEAK,
         ))]
-        fn precompute_render(
+        fn _Synthesizer__precompute_render(
             &self,
             #[pyo3(from_py_with = "crate::convert::from_dataclass")] audio_query: AudioQuery,
             style_id: u32,
@@ -693,14 +696,17 @@ mod blocking {
             let audio = self
                 .synthesizer
                 .read()?
-                .precompute_render(&audio_query, StyleId::new(style_id))
+                .__precompute_render(&audio_query, StyleId::new(style_id))
                 .enable_interrogative_upspeak(enable_interrogative_upspeak)
                 .perform()
                 .into_py_result(py)?;
             Ok(AudioFeature { audio })
         }
 
-        fn render<'py>(
+        // TODO: 後で復活させる
+        // https://github.com/VOICEVOX/voicevox_core/issues/970
+        #[allow(non_snake_case)]
+        fn _Synthesizer__render<'py>(
             &self,
             audio: &AudioFeature,
             start: usize,
@@ -721,7 +727,7 @@ mod blocking {
             let wav = &self
                 .synthesizer
                 .read()?
-                .render(&audio.audio, start..stop)
+                .__render(&audio.audio, start..stop)
                 .into_py_result(py)?;
             Ok(PyBytes::new(py, wav))
         }

--- a/example/python/run.py
+++ b/example/python/run.py
@@ -5,7 +5,7 @@ from argparse import ArgumentParser
 from pathlib import Path
 
 from pydantic import TypeAdapter
-from voicevox_core import AccelerationMode, AudioQuery, wav_from_s16le
+from voicevox_core import AccelerationMode, AudioQuery
 from voicevox_core.blocking import Onnxruntime, OpenJtalk, Synthesizer, VoiceModelFile
 
 
@@ -18,7 +18,8 @@ class Args:
     text: str
     out: Path
     style_id: int
-    streaming: bool
+    # https://github.com/VOICEVOX/voicevox_core/issues/970
+    # streaming: bool
 
     @staticmethod
     def parse_args() -> "Args":
@@ -62,11 +63,11 @@ class Args:
             type=int,
             help="話者IDを指定",
         )
-        argparser.add_argument(
-            "--streaming",
-            action="store_true",
-            help="ストリーミング生成",
-        )
+        # argparser.add_argument(
+        #     "--streaming",
+        #     action="store_true",
+        #     help="ストリーミング生成",
+        # )
         args = argparser.parse_args()
         return Args(
             args.mode,
@@ -76,7 +77,7 @@ class Args:
             args.text,
             args.out,
             args.style_id,
-            args.streaming,
+            # args.streaming,
         )
 
 
@@ -115,24 +116,27 @@ def main() -> None:
     audio_query = synthesizer.create_audio_query(args.text, args.style_id)
 
     logger.info("%s", f"Synthesizing with {display_as_json(audio_query)}")
-    if args.streaming:
-        logger.info("%s", "In streaming mode")
-        chunk_sec = 1.0
-        audio_feature = synthesizer.precompute_render(audio_query, args.style_id)
-        chunk_frames = int(audio_feature.frame_rate * chunk_sec)
-        pcm = b""
-        for i in range(0, audio_feature.frame_length, chunk_frames):
-            logger.info("%s", f"{i/audio_feature.frame_length:.2%}")
-            pcm += synthesizer.render(
-                audio_feature, i, min(i + chunk_frames, audio_feature.frame_length)
-            )
-        logger.info("%s", f"100%")
-        wav = wav_from_s16le(
-            pcm, audio_query.output_sampling_rate, audio_query.output_stereo
-        )
 
-    else:
-        wav = synthesizer.synthesis(audio_query, args.style_id)
+    # https://github.com/VOICEVOX/voicevox_core/issues/970
+    # if args.streaming:
+    #     logger.info("%s", "In streaming mode")
+    #     chunk_sec = 1.0
+    #     audio_feature = synthesizer._Synthesizer__precompute_render(audio_query, args.style_id)
+    #     chunk_frames = int(audio_feature.frame_rate * chunk_sec)
+    #     pcm = b""
+    #     for i in range(0, audio_feature.frame_length, chunk_frames):
+    #         logger.info("%s", f"{i/audio_feature.frame_length:.2%}")
+    #         pcm += synthesizer._Synthesizer__render(
+    #             audio_feature, i, min(i + chunk_frames, audio_feature.frame_length)
+    #         )
+    #     logger.info("%s", f"100%")
+    #     wav = wav_from_s16le(
+    #         pcm, audio_query.output_sampling_rate, audio_query.output_stereo
+    #     )
+    #
+    # else:
+    #     wav = synthesizer.synthesis(audio_query, args.style_id)
+    wav = synthesizer.synthesis(audio_query, args.style_id)
 
     args.out.write_bytes(wav)
     logger.info("%s", f"Wrote `{args.out}`")

--- a/example/python/run.py
+++ b/example/python/run.py
@@ -8,6 +8,7 @@ from pydantic import TypeAdapter
 from voicevox_core import AccelerationMode, AudioQuery
 from voicevox_core.blocking import Onnxruntime, OpenJtalk, Synthesizer, VoiceModelFile
 
+# TODO: https://github.com/VOICEVOX/voicevox_core/pull/972 をリバートする
 
 @dataclasses.dataclass
 class Args:
@@ -18,8 +19,6 @@ class Args:
     text: str
     out: Path
     style_id: int
-    # https://github.com/VOICEVOX/voicevox_core/issues/970
-    # streaming: bool
 
     @staticmethod
     def parse_args() -> "Args":
@@ -63,11 +62,6 @@ class Args:
             type=int,
             help="話者IDを指定",
         )
-        # argparser.add_argument(
-        #     "--streaming",
-        #     action="store_true",
-        #     help="ストリーミング生成",
-        # )
         args = argparser.parse_args()
         return Args(
             args.mode,
@@ -77,7 +71,6 @@ class Args:
             args.text,
             args.out,
             args.style_id,
-            # args.streaming,
         )
 
 
@@ -117,25 +110,6 @@ def main() -> None:
 
     logger.info("%s", f"Synthesizing with {display_as_json(audio_query)}")
 
-    # https://github.com/VOICEVOX/voicevox_core/issues/970
-    # if args.streaming:
-    #     logger.info("%s", "In streaming mode")
-    #     chunk_sec = 1.0
-    #     audio_feature = synthesizer._Synthesizer__precompute_render(audio_query, args.style_id)
-    #     chunk_frames = int(audio_feature.frame_rate * chunk_sec)
-    #     pcm = b""
-    #     for i in range(0, audio_feature.frame_length, chunk_frames):
-    #         logger.info("%s", f"{i/audio_feature.frame_length:.2%}")
-    #         pcm += synthesizer._Synthesizer__render(
-    #             audio_feature, i, min(i + chunk_frames, audio_feature.frame_length)
-    #         )
-    #     logger.info("%s", f"100%")
-    #     wav = wav_from_s16le(
-    #         pcm, audio_query.output_sampling_rate, audio_query.output_stereo
-    #     )
-    #
-    # else:
-    #     wav = synthesizer.synthesis(audio_query, args.style_id)
     wav = synthesizer.synthesis(audio_query, args.style_id)
 
     args.out.write_bytes(wav)

--- a/example/python/run.py
+++ b/example/python/run.py
@@ -10,6 +10,7 @@ from voicevox_core.blocking import Onnxruntime, OpenJtalk, Synthesizer, VoiceMod
 
 # TODO: https://github.com/VOICEVOX/voicevox_core/pull/972 をリバートする
 
+
 @dataclasses.dataclass
 class Args:
     mode: AccelerationMode


### PR DESCRIPTION
## 内容

以下のRust APIのアイテムと、それらに対応するPython APIのものを封印する。

- `voicevox_core::wav_from_file`
- `voicevox_core::blocking::Synthesizer::{,precompute_}render`
- `voicevox_core::blocking::synthesizer::PrecomputeRender`

## 関連 Issue

Resolves: #970

## その他

CC: @Yosshi999