### PR TITLE
docs: READMEのライセンス周りの表記をわかりやすくする

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,6 @@ typos
 
 ## ライセンス
 
-ソースコードのライセンスは [MIT LICENSE](./LICENSE) です。
+VOICEVOX CORE のソースコード及びビルド成果物のライセンスは [MIT LICENSE](./LICENSE) です。
 
-[Releases](https://github.com/VOICEVOX/voicevox_core/releases) にあるビルド済みのコアライブラリは別ライセンスなのでご注意ください。
+[Releases](https://github.com/VOICEVOX/voicevox_core/releases) にあるバージョン 0.16 未満のビルド済みのコアライブラリは別ライセンスなのでご注意ください。


### PR DESCRIPTION
## 内容

タイトルの通りで

- https://github.com/VOICEVOX/voicevox_core/issues/938

の解決プルリクエストです。

VOICEVOX COREのソースコードとビルド成果物はMITライセンスだということがわかりやすくなりました。
あとこのREADMEを`c_api`ディレクトリに放り込んでおけば、`voicevox_core.dll`とか`voiecvox_core.so`とかもちゃんとMITライセンスだということが分かりやすいはず！

## 関連 Issue

#938 

## その他

「VOICEVOX CORE のソースコード及びビルド成果物のライセンスは」
と書いてるけど、これは多分もっと短くして
「VOICEVOX CORE のライセンスは」
でも問題ない気はしてます。どっちの方がいいですかねぇ。。

あとreleasesに置いてある過去のコアライブラリはライセンスが違うことを残しておいてみました。
ここに書く必要があるかわからないけど、差分が少なくなるのでとりあえず書き換えただけです。
（この文面じゃないとダメという意図ではない）
