### PR TITLE
docs: [C] 各アイテムからRust APIにリンクを張る

### DIFF
--- a/crates/voicevox_core/src/engine/open_jtalk.rs
+++ b/crates/voicevox_core/src/engine/open_jtalk.rs
@@ -44,10 +44,12 @@ pub(crate) mod blocking {
     };
 
     /// テキスト解析器としてのOpen JTalk。
+    #[doc(alias = "OpenJtalkRc")]
     #[derive(Clone)]
     pub struct OpenJtalk(pub(super) Arc<Inner>);
 
     impl self::OpenJtalk {
+        #[doc(alias = "voicevox_open_jtalk_rc_new")]
         pub fn new(open_jtalk_dict_dir: impl AsRef<Utf8Path>) -> crate::result::Result<Self> {
             let dict_dir = open_jtalk_dict_dir.as_ref().to_owned();
 
@@ -73,6 +75,7 @@ pub(crate) mod blocking {
         /// ユーザー辞書を設定する。
         ///
         /// この関数を呼び出した後にユーザー辞書を変更した場合は、再度この関数を呼ぶ必要がある。
+        #[doc(alias = "voicevox_open_jtalk_rc_use_user_dict")]
         pub fn use_user_dict(
             &self,
             user_dict: &crate::blocking::UserDict,

--- a/crates/voicevox_core/src/error.rs
+++ b/crates/voicevox_core/src/error.rs
@@ -127,6 +127,7 @@ pub(crate) enum ErrorRepr {
     clippy::manual_non_exhaustive,
     reason = "バインディングを作るときはexhaustiveとして扱いたい"
 )]
+#[doc(alias = "VoicevoxResultCode")]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum ErrorKind {
     /// open_jtalk辞書ファイルが読み込まれていない。

--- a/crates/voicevox_core/src/infer/runtimes/onnxruntime.rs
+++ b/crates/voicevox_core/src/infer/runtimes/onnxruntime.rs
@@ -306,6 +306,7 @@ pub(crate) mod blocking {
     /// ```
     ///
     /// [voicevox-ort]: https://github.com/VOICEVOX/ort
+    #[doc(alias = "VoicevoxOnnxruntime")]
     #[derive(Debug, RefCastCustom)]
     #[repr(transparent)]
     pub struct Onnxruntime {
@@ -330,6 +331,7 @@ pub(crate) mod blocking {
         /// [`LIB_NAME`]: Self::LIB_NAME
         /// [`LIB_VERSION`]: Self::LIB_VERSION
         /// [`LIB_UNVERSIONED_FILENAME`]: Self::LIB_UNVERSIONED_FILENAME
+        #[doc(alias = "voicevox_get_onnxruntime_lib_versioned_filename")]
         #[cfg(feature = "load-onnxruntime")]
         #[cfg_attr(docsrs, doc(cfg(feature = "load-onnxruntime")))]
         pub const LIB_VERSIONED_FILENAME: &'static str = if cfg!(target_os = "linux") {
@@ -354,6 +356,7 @@ pub(crate) mod blocking {
         /// [`LIB_NAME`]からなる動的ライブラリのファイル名。
         ///
         /// [`LIB_NAME`]: Self::LIB_NAME
+        #[doc(alias = "voicevox_get_onnxruntime_lib_unversioned_filename")]
         #[cfg(feature = "load-onnxruntime")]
         #[cfg_attr(docsrs, doc(cfg(feature = "load-onnxruntime")))]
         pub const LIB_UNVERSIONED_FILENAME: &'static str = const_format::concatcp!(
@@ -368,6 +371,7 @@ pub(crate) mod blocking {
         /// インスタンスが既に作られているならそれを得る。
         ///
         /// 作られていなければ`None`を返す。
+        #[doc(alias = "voicevox_onnxruntime_get")]
         pub fn get() -> Option<&'static Self> {
             EnvHandle::get().map(Self::new)
         }
@@ -385,6 +389,7 @@ pub(crate) mod blocking {
         /// ONNX Runtimeをロードして初期化する。
         ///
         /// 一度成功したら、以後は引数を無視して同じ参照を返す。
+        #[doc(alias = "voicevox_onnxruntime_load_once")]
         #[cfg(feature = "load-onnxruntime")]
         #[cfg_attr(docsrs, doc(cfg(feature = "load-onnxruntime")))]
         pub fn load_once() -> LoadOnce {
@@ -396,6 +401,7 @@ pub(crate) mod blocking {
         /// 一度成功したら以後は同じ参照を返す。
         #[cfg(feature = "link-onnxruntime")]
         #[cfg_attr(docsrs, doc(cfg(feature = "link-onnxruntime")))]
+        #[doc(alias = "voicevox_onnxruntime_init_once")]
         pub fn init_once() -> crate::Result<&'static Self> {
             Self::once(|| ort::try_init(None))
         }
@@ -417,6 +423,7 @@ pub(crate) mod blocking {
         }
 
         /// ONNX Runtimeとして利用可能なデバイスの情報を取得する。
+        #[doc(alias = "voicevox_onnxruntime_create_supported_devices_json")]
         pub fn supported_devices(&self) -> crate::Result<SupportedDevices> {
             <Self as InferenceRuntime>::supported_devices(self)
         }

--- a/crates/voicevox_core/src/infer/runtimes/onnxruntime.rs
+++ b/crates/voicevox_core/src/infer/runtimes/onnxruntime.rs
@@ -399,9 +399,9 @@ pub(crate) mod blocking {
         /// ONNX Runtimeを初期化する。
         ///
         /// 一度成功したら以後は同じ参照を返す。
+        #[doc(alias = "voicevox_onnxruntime_init_once")]
         #[cfg(feature = "link-onnxruntime")]
         #[cfg_attr(docsrs, doc(cfg(feature = "link-onnxruntime")))]
-        #[doc(alias = "voicevox_onnxruntime_init_once")]
         pub fn init_once() -> crate::Result<&'static Self> {
             Self::once(|| ort::try_init(None))
         }

--- a/crates/voicevox_core/src/lib.rs
+++ b/crates/voicevox_core/src/lib.rs
@@ -48,6 +48,54 @@ const _: () = {
     );
 };
 
+/// ```compile_fail
+/// use voicevox_core::__doc;
+/// ```
+#[cfg(doc)]
+#[cfg_attr(docsrs, doc(cfg(doc)))]
+pub mod __doc {
+    /// [C API]にある以下のアイテムは、Rust API、つまりこのクレートには存在しない。
+    ///
+    /// | | 理由 |
+    /// | :- | :- |
+    /// | `VoicevoxLoadOnnxruntimeOptions` | ビルダースタイルであるため |
+    /// | `VoicevoxInitializeOptions` | 〃 |
+    /// | `VoicevoxSynthesisOptions` | 〃 |
+    /// | `VoicevoxTtsOptions` | 〃 |
+    /// | `voicevox_make_default_load_onnxruntime_options` | 〃 |
+    /// | `voicevox_make_default_initialize_options` | 〃 |
+    /// | `voicevox_make_default_synthesis_options` | 〃 |
+    /// | `voicevox_make_default_tts_options` | 〃 |
+    /// | `voicevox_json_free` | [Rustのデストラクタ機構]があるため |
+    /// | `voicevox_wav_free` | 〃 |
+    /// | `voicevox_open_jtalk_rc_delete` | 〃 |
+    /// | `voicevox_synthesizer_delete` | 〃 |
+    /// | `voicevox_voice_model_file_delete` | 〃 |
+    /// | `voicevox_user_dict_delete` | 〃 |
+    /// | `voicevox_error_result_to_message` | [`std::error::Error`]としてのエラー表示があるため |
+    ///
+    /// [C API]: https://voicevox.github.io/voicevox_core/apis/c_api/voicevox__core_8h.html
+    /// [Rustのデストラクタ機構]: https://doc.rust-lang.org/reference/destructors.html
+    #[doc(alias(
+        "VoicevoxLoadOnnxruntimeOptions",
+        "VoicevoxInitializeOptions",
+        "VoicevoxSynthesisOptions",
+        "VoicevoxTtsOptions",
+        "voicevox_make_default_load_onnxruntime_options",
+        "voicevox_make_default_initialize_options",
+        "voicevox_make_default_synthesis_options",
+        "voicevox_make_default_tts_options",
+        "voicevox_json_free",
+        "voicevox_wav_free",
+        "voicevox_open_jtalk_rc_delete",
+        "voicevox_synthesizer_delete",
+        "voicevox_voice_model_file_delete",
+        "voicevox_user_dict_delete",
+        "voicevox_error_result_to_message"
+    ))]
+    pub mod C_APIには存在するがRust_APIには存在しないアイテム {}
+}
+
 mod asyncs;
 mod core;
 mod devices;

--- a/crates/voicevox_core/src/metas.rs
+++ b/crates/voicevox_core/src/metas.rs
@@ -57,6 +57,7 @@ pub fn merge<'a>(metas: impl IntoIterator<Item = &'a CharacterMeta>) -> Vec<Char
     new,
     Debug,
 )]
+#[doc(alias = "VoicevoxStyleId")]
 pub struct StyleId(pub u32);
 
 impl Display for StyleId {

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -81,6 +81,7 @@ impl Default for TtsOptions {
 }
 
 /// ハードウェアアクセラレーションモードを設定する設定値。
+#[doc(alias = "VoicevoxAccelerationMode")]
 #[expect(
     clippy::manual_non_exhaustive,
     reason = "バインディングを作るときはexhaustiveとして扱いたい"
@@ -1211,6 +1212,7 @@ pub(crate) mod blocking {
     pub use super::AudioFeature;
 
     /// 音声シンセサイザ。
+    #[doc(alias = "VoicevoxSynthesizer")]
     pub struct Synthesizer<T>(pub(super) Inner<AssumeSingleTasked<T>, SingleTasked>);
 
     impl self::Synthesizer<()> {
@@ -1246,6 +1248,7 @@ pub(crate) mod blocking {
         /// # Ok(())
         /// # }
         /// ```
+        #[doc(alias = "voicevox_synthesizer_new")]
         pub fn builder(onnxruntime: &'static crate::blocking::Onnxruntime) -> Builder<()> {
             Builder {
                 onnxruntime,
@@ -1256,16 +1259,19 @@ pub(crate) mod blocking {
     }
 
     impl<T> self::Synthesizer<T> {
+        #[doc(alias = "voicevox_synthesizer_get_onnxruntime")]
         pub fn onnxruntime(&self) -> &'static crate::blocking::Onnxruntime {
             self.0.onnxruntime()
         }
 
         /// ハードウェアアクセラレーションがGPUモードか判定する。
+        #[doc(alias = "voicevox_synthesizer_is_gpu_mode")]
         pub fn is_gpu_mode(&self) -> bool {
             self.0.is_gpu_mode()
         }
 
         /// 音声モデルを読み込む。
+        #[doc(alias = "voicevox_synthesizer_load_voice_model")]
         pub fn load_voice_model(
             &self,
             model: &crate::blocking::VoiceModelFile,
@@ -1274,11 +1280,13 @@ pub(crate) mod blocking {
         }
 
         /// 音声モデルの読み込みを解除する。
+        #[doc(alias = "voicevox_synthesizer_unload_voice_model")]
         pub fn unload_voice_model(&self, voice_model_id: VoiceModelId) -> crate::Result<()> {
             self.0.unload_voice_model(voice_model_id)
         }
 
         /// 指定したIDの音声モデルが読み込まれているか判定する。
+        #[doc(alias = "voicevox_synthesizer_is_loaded_voice_model")]
         pub fn is_loaded_voice_model(&self, voice_model_id: VoiceModelId) -> bool {
             self.0.is_loaded_voice_model(voice_model_id)
         }
@@ -1289,6 +1297,7 @@ pub(crate) mod blocking {
         }
 
         /// 今読み込んでいる音声モデルのメタ情報を返す。
+        #[doc(alias = "voicevox_synthesizer_create_metas_json")]
         pub fn metas(&self) -> VoiceModelMeta {
             self.0.metas()
         }
@@ -1323,6 +1332,7 @@ pub(crate) mod blocking {
         }
 
         /// AudioQueryから直接WAVフォーマットで音声波形を生成する。
+        #[doc(alias = "voicevox_synthesizer_synthesis")]
         pub fn synthesis<'a>(
             &'a self,
             audio_query: &'a AudioQuery,
@@ -1362,6 +1372,7 @@ pub(crate) mod blocking {
         /// # Ok(())
         /// # }
         /// ```
+        #[doc(alias = "voicevox_synthesizer_create_accent_phrases_from_kana")]
         pub fn create_accent_phrases_from_kana(
             &self,
             kana: &str,
@@ -1373,6 +1384,7 @@ pub(crate) mod blocking {
         }
 
         /// AccentPhraseの配列の音高・音素長を、特定の声で生成しなおす。
+        #[doc(alias = "voicevox_synthesizer_replace_mora_data")]
         pub fn replace_mora_data(
             &self,
             accent_phrases: &[AccentPhrase],
@@ -1384,6 +1396,7 @@ pub(crate) mod blocking {
         }
 
         /// AccentPhraseの配列の音素長を、特定の声で生成しなおす。
+        #[doc(alias = "voicevox_synthesizer_replace_phoneme_length")]
         pub fn replace_phoneme_length(
             &self,
             accent_phrases: &[AccentPhrase],
@@ -1395,6 +1408,7 @@ pub(crate) mod blocking {
         }
 
         /// AccentPhraseの配列の音高を、特定の声で生成しなおす。
+        #[doc(alias = "voicevox_synthesizer_replace_mora_pitch")]
         pub fn replace_mora_pitch(
             &self,
             accent_phrases: &[AccentPhrase],
@@ -1432,6 +1446,7 @@ pub(crate) mod blocking {
         /// ```
         ///
         /// [AudioQuery]: crate::AudioQuery
+        #[doc(alias = "voicevox_synthesizer_create_audio_query_from_kana")]
         pub fn create_audio_query_from_kana(
             &self,
             kana: &str,
@@ -1443,6 +1458,7 @@ pub(crate) mod blocking {
         }
 
         /// AquesTalk風記法から音声合成を行う。
+        #[doc(alias = "voicevox_synthesizer_tts_from_kana")]
         pub fn tts_from_kana<'a>(&'a self, kana: &'a str, style_id: StyleId) -> TtsFromKana<'a> {
             TtsFromKana {
                 synthesizer: self.0.without_text_analyzer(),
@@ -1479,6 +1495,7 @@ pub(crate) mod blocking {
         /// # Ok(())
         /// # }
         /// ```
+        #[doc(alias = "voicevox_synthesizer_create_accent_phrases")]
         pub fn create_accent_phrases(
             &self,
             text: &str,
@@ -1514,6 +1531,7 @@ pub(crate) mod blocking {
         /// ```
         ///
         /// [AudioQuery]: crate::AudioQuery
+        #[doc(alias = "voicevox_synthesizer_create_audio_query")]
         pub fn create_audio_query(
             &self,
             text: &str,
@@ -1523,6 +1541,7 @@ pub(crate) mod blocking {
         }
 
         /// 日本語のテキストから音声合成を行う。
+        #[doc(alias = "voicevox_synthesizer_tts")]
         pub fn tts<'a>(&'a self, text: &'a str, style_id: StyleId) -> Tts<'a, T> {
             Tts {
                 synthesizer: &self.0,

--- a/crates/voicevox_core/src/user_dict/dict.rs
+++ b/crates/voicevox_core/src/user_dict/dict.rs
@@ -121,15 +121,18 @@ pub(crate) mod blocking {
     /// ユーザー辞書。
     ///
     /// 単語はJSONとの相互変換のために挿入された順序を保つ。
+    #[doc(alias = "VoicevoxUserDict")]
     #[derive(Debug, Default)]
     pub struct UserDict(Inner<SingleTasked>);
 
     impl self::UserDict {
         /// ユーザー辞書を作成する。
+        #[doc(alias = "voicevox_user_dict_new")]
         pub fn new() -> Self {
             Default::default()
         }
 
+        #[doc(alias = "voicevox_user_dict_to_json")]
         pub fn to_json(&self) -> String {
             self.0.to_json()
         }
@@ -143,31 +146,37 @@ pub(crate) mod blocking {
         /// # Errors
         ///
         /// ファイルが読めなかった、または内容が不正だった場合はエラーを返す。
+        #[doc(alias = "voicevox_user_dict_load")]
         pub fn load(&self, store_path: impl AsRef<Path>) -> Result<()> {
             self.0.load(store_path).block_on()
         }
 
         /// ユーザー辞書に単語を追加する。
+        #[doc(alias = "voicevox_user_dict_add_word")]
         pub fn add_word(&self, word: UserDictWord) -> Result<Uuid> {
             self.0.add_word(word)
         }
 
         /// ユーザー辞書の単語を変更する。
+        #[doc(alias = "voicevox_user_dict_update_word")]
         pub fn update_word(&self, word_uuid: Uuid, new_word: UserDictWord) -> Result<()> {
             self.0.update_word(word_uuid, new_word)
         }
 
         /// ユーザー辞書から単語を削除する。
+        #[doc(alias = "voicevox_user_dict_remove_word")]
         pub fn remove_word(&self, word_uuid: Uuid) -> Result<UserDictWord> {
             self.0.remove_word(word_uuid)
         }
 
         /// 他のユーザー辞書をインポートする。
+        #[doc(alias = "voicevox_user_dict_import")]
         pub fn import(&self, other: &Self) -> Result<()> {
             self.0.import(&other.0)
         }
 
         /// ユーザー辞書を保存する。
+        #[doc(alias = "voicevox_user_dict_save")]
         pub fn save(&self, store_path: impl AsRef<Path>) -> Result<()> {
             self.0.save(store_path).block_on()
         }

--- a/crates/voicevox_core/src/user_dict/word.rs
+++ b/crates/voicevox_core/src/user_dict/word.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 
 /// ユーザー辞書の単語。
+#[doc(alias = "VoicevoxUserDictWord")]
 #[derive(Clone, Debug, Serialize)]
 pub struct UserDictWord {
     /// 単語の表記。
@@ -107,6 +108,8 @@ impl Default for UserDictWord {
 }
 
 impl UserDictWord {
+    // TODO: これビルダースタイルにすべきでは？
+    #[doc(alias = "voicevox_user_dict_word_make")]
     pub fn new(
         surface: &str,
         pronunciation: String,
@@ -231,6 +234,7 @@ pub(crate) fn to_zenkaku(surface: &str) -> String {
         .collect()
 }
 /// ユーザー辞書の単語の種類。
+#[doc(alias = "VoicevoxUserDictWordType")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum UserDictWordType {

--- a/crates/voicevox_core/src/version.rs
+++ b/crates/voicevox_core/src/version.rs
@@ -2,6 +2,7 @@
 ///
 /// C APIやPython API側からこの値が使われるべきではない。
 /// 現在はまだRust APIを外部提供していないため、この定数はどこからも参照されていないはずである。
+#[doc(alias = "voicevox_get_version")]
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg(test)]

--- a/crates/voicevox_core/src/voice_model.rs
+++ b/crates/voicevox_core/src/voice_model.rs
@@ -38,6 +38,7 @@ pub(crate) type ModelBytesWithInnerVoiceIdsByDomain = inference_domain_map_value
 );
 
 /// 音声モデルID。
+#[doc(alias = "VoicevoxVoiceModelId")]
 #[derive(
     PartialEq,
     Eq,
@@ -592,10 +593,12 @@ pub(crate) mod blocking {
     /// 音声モデルファイル。
     ///
     /// VVMファイルと対応する。
+    #[doc(alias = "VoicevoxVoiceModelFile")]
     pub struct VoiceModelFile(Inner<SingleTasked>);
 
     impl self::VoiceModelFile {
         /// VVMファイルを開く。
+        #[doc(alias = "voicevox_voice_model_file_open")]
         pub fn open(path: impl AsRef<Path>) -> crate::Result<Self> {
             Inner::open(path).block_on().map(Self)
         }
@@ -611,11 +614,13 @@ pub(crate) mod blocking {
         }
 
         /// ID。
+        #[doc(alias = "voicevox_voice_model_file_id")]
         pub fn id(&self) -> VoiceModelId {
             self.0.id()
         }
 
         /// メタ情報。
+        #[doc(alias = "voicevox_voice_model_file_create_metas_json")]
         pub fn metas(&self) -> &VoiceModelMeta {
             self.0.metas()
         }

--- a/crates/voicevox_core_c_api/include/voicevox_core.h
+++ b/crates/voicevox_core_c_api/include/voicevox_core.h
@@ -79,6 +79,8 @@
 
 /**
  * ハードウェアアクセラレーションモードを設定する設定値。
+ *
+ * \orig-impl{VoicevoxAccelerationMode}
  */
 enum VoicevoxAccelerationMode
 #ifdef __cplusplus
@@ -104,6 +106,8 @@ typedef int32_t VoicevoxAccelerationMode;
 
 /**
  * 処理結果を示す結果コード。
+ *
+ * \orig-impl{VoicevoxResultCode,C APIにしか無いものがあることに注意。}
  */
 enum VoicevoxResultCode
 #ifdef __cplusplus
@@ -217,6 +221,8 @@ typedef int32_t VoicevoxResultCode;
 
 /**
  * ユーザー辞書の単語の種類。
+ *
+ * \orig-impl{VoicevoxUserDictWordType}
  */
 enum VoicevoxUserDictWordType
 #ifdef __cplusplus
@@ -264,6 +270,8 @@ typedef int32_t VoicevoxUserDictWordType;
  * voicevox_open_jtalk_rc_delete(open_jtalk);
  * ```
  * }
+ *
+ * \orig-impl{OpenJtalkRc}
  */
 typedef struct OpenJtalkRc OpenJtalkRc;
 
@@ -279,6 +287,8 @@ typedef struct OpenJtalkRc OpenJtalkRc;
  * const VoicevoxOnnxruntime *ort2 = voicevox_onnxruntime_get();
  * assert(ort1 == ort2);
  * ```
+ *
+ * \orig-impl{VoicevoxOnnxruntime}
  */
 typedef struct VoicevoxOnnxruntime VoicevoxOnnxruntime;
 
@@ -286,11 +296,15 @@ typedef struct VoicevoxOnnxruntime VoicevoxOnnxruntime;
  * 音声シンセサイザ。
  *
  * <b>構築</b>(_construction_)は ::voicevox_synthesizer_new で行い、<b>破棄</b>(_destruction_)は ::voicevox_synthesizer_delete で行う。
+ *
+ * \orig-impl{VoicevoxSynthesizer}
  */
 typedef struct VoicevoxSynthesizer VoicevoxSynthesizer;
 
 /**
  * ユーザー辞書。
+ *
+ * \orig-impl{VoicevoxUserDict}
  */
 typedef struct VoicevoxUserDict VoicevoxUserDict;
 
@@ -299,6 +313,8 @@ typedef struct VoicevoxUserDict VoicevoxUserDict;
  *
  * VVMファイルと対応する。
  * <b>構築</b>(_construction_)は ::voicevox_voice_model_file_open で行い、<b>破棄</b>(_destruction_)は ::voicevox_voice_model_file_delete で行う。
+ *
+ * \orig-impl{VoicevoxVoiceModelFile}
  */
 typedef struct VoicevoxVoiceModelFile VoicevoxVoiceModelFile;
 
@@ -309,6 +325,8 @@ typedef struct VoicevoxVoiceModelFile VoicevoxVoiceModelFile;
  * \availability{
  *   [リリース](https://github.com/voicevox/voicevox_core/releases)されているライブラリではiOSを除くプラットフォームで利用可能。詳細は<a href="#voicevox-core-availability">ファイルレベルの"Availability"の節</a>を参照。
  * }
+ *
+ * \no-orig-impl{VoicevoxLoadOnnxruntimeOptions}
  */
 typedef struct VoicevoxLoadOnnxruntimeOptions {
   /**
@@ -322,6 +340,8 @@ typedef struct VoicevoxLoadOnnxruntimeOptions {
 
 /**
  * ::voicevox_synthesizer_new のオプション。
+ *
+ * \no-orig-impl{VoicevoxInitializeOptions}
  */
 typedef struct VoicevoxInitializeOptions {
   /**
@@ -337,6 +357,8 @@ typedef struct VoicevoxInitializeOptions {
 
 /**
  * 音声モデルID。
+ *
+ * \orig-impl{VoicevoxVoiceModelId}
  */
 typedef const uint8_t (*VoicevoxVoiceModelId)[16];
 
@@ -344,11 +366,15 @@ typedef const uint8_t (*VoicevoxVoiceModelId)[16];
  * スタイルID。
  *
  * VOICEVOXにおける、ある<b>キャラクター</b>のある<b>スタイル</b>(_style_)を指す。
+ *
+ * \orig-impl{VoicevoxStyleId}
  */
 typedef uint32_t VoicevoxStyleId;
 
 /**
  * ::voicevox_synthesizer_synthesis のオプション。
+ *
+ * \no-orig-impl{VoicevoxSynthesisOptions}
  */
 typedef struct VoicevoxSynthesisOptions {
   /**
@@ -359,6 +385,8 @@ typedef struct VoicevoxSynthesisOptions {
 
 /**
  * ::voicevox_synthesizer_tts のオプション。
+ *
+ * \no-orig-impl{VoicevoxTtsOptions}
  */
 typedef struct VoicevoxTtsOptions {
   /**
@@ -369,6 +397,8 @@ typedef struct VoicevoxTtsOptions {
 
 /**
  * ユーザー辞書の単語。
+ *
+ * \orig-impl{VoicevoxUserDictWord}
  */
 typedef struct VoicevoxUserDictWord {
   /**
@@ -406,6 +436,8 @@ extern "C" {
  * \availability{
  *   [リリース](https://github.com/voicevox/voicevox_core/releases)されているライブラリではiOSを除くプラットフォームで利用可能。詳細は<a href="#voicevox-core-availability">ファイルレベルの"Availability"の節</a>を参照。
  * }
+ *
+ * \orig-impl{voicevox_get_onnxruntime_lib_versioned_filename}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -420,6 +452,8 @@ const char *voicevox_get_onnxruntime_lib_versioned_filename(void);
  * \availability{
  *   [リリース](https://github.com/voicevox/voicevox_core/releases)されているライブラリではiOSを除くプラットフォームで利用可能。詳細は<a href="#voicevox-core-availability">ファイルレベルの"Availability"の節</a>を参照。
  * }
+ *
+ * \orig-impl{voicevox_get_onnxruntime_lib_unversioned_filename}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -436,6 +470,8 @@ const char *voicevox_get_onnxruntime_lib_unversioned_filename(void);
  * \availability{
  *   [リリース](https://github.com/voicevox/voicevox_core/releases)されているライブラリではiOSを除くプラットフォームで利用可能。詳細は<a href="#voicevox-core-availability">ファイルレベルの"Availability"の節</a>を参照。
  * }
+ *
+ * \no-orig-impl{voicevox_make_default_load_onnxruntime_options}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -449,6 +485,8 @@ struct VoicevoxLoadOnnxruntimeOptions voicevox_make_default_load_onnxruntime_opt
  * 作られていなければ`NULL`を返す。
  *
  * @returns ::VoicevoxOnnxruntime のインスタンス
+ *
+ * \orig-impl{voicevox_onnxruntime_get}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -474,6 +512,8 @@ const struct VoicevoxOnnxruntime *voicevox_onnxruntime_get(void);
  * - `options.filename`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * - `out_onnxruntime`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * }
+ *
+ * \orig-impl{voicevox_onnxruntime_load_once}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -499,6 +539,8 @@ VoicevoxResultCode voicevox_onnxruntime_load_once(struct VoicevoxLoadOnnxruntime
  * \safety{
  * - `out_onnxruntime`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * }
+ *
+ * \orig-impl{voicevox_onnxruntime_init_once}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -527,6 +569,8 @@ VoicevoxResultCode voicevox_onnxruntime_init_once(const struct VoicevoxOnnxrunti
  * - `open_jtalk_dic_dir`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * - `out_open_jtalk`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * }
+ *
+ * \orig-impl{voicevox_open_jtalk_rc_new}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -541,6 +585,8 @@ VoicevoxResultCode voicevox_open_jtalk_rc_new(const char *open_jtalk_dic_dir,
  *
  * @param [in] open_jtalk Open JTalkのオブジェクト
  * @param [in] user_dict ユーザー辞書
+ *
+ * \orig-impl{voicevox_open_jtalk_rc_use_user_dict}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -562,6 +608,8 @@ VoicevoxResultCode voicevox_open_jtalk_rc_use_user_dict(const struct OpenJtalkRc
  * voicevox_open_jtalk_rc_delete(open_jtalk);
  * ```
  * }
+ *
+ * \no-orig-impl{voicevox_open_jtalk_rc_delete}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -571,6 +619,8 @@ void voicevox_open_jtalk_rc_delete(struct OpenJtalkRc *open_jtalk);
 /**
  * デフォルトの初期化オプションを生成する
  * @return デフォルト値が設定された初期化オプション
+ *
+ * \no-orig-impl{voicevox_make_default_initialize_options}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -580,6 +630,8 @@ struct VoicevoxInitializeOptions voicevox_make_default_initialize_options(void);
 /**
  * voicevoxのバージョンを取得する。
  * @return SemVerでフォーマットされたバージョン。
+ *
+ * \orig-impl{voicevox_get_version}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -598,6 +650,8 @@ const char *voicevox_get_version(void);
  * - `path`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * - `out_model`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * }
+ *
+ * \orig-impl{voicevox_voice_model_file_open}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -614,6 +668,8 @@ VoicevoxResultCode voicevox_voice_model_file_open(const char *path,
  * \safety{
  * - `output_voice_model_id`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * }
+ *
+ * \orig-impl{voicevox_voice_model_file_id}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -629,6 +685,8 @@ void voicevox_voice_model_file_id(const struct VoicevoxVoiceModelFile *model,
  * @param [in] model 音声モデル
  *
  * @returns メタ情報のJSON文字列
+ *
+ * \orig-impl{voicevox_voice_model_file_create_metas_json}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -643,6 +701,8 @@ char *voicevox_voice_model_file_create_metas_json(const struct VoicevoxVoiceMode
  * この関数の呼び出し後に破棄し終えた対象にアクセスすると、プロセスを異常終了する。
  *
  * @param [in] model 破棄対象
+ *
+ * \no-orig-impl{voicevox_voice_model_file_delete}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -663,6 +723,8 @@ void voicevox_voice_model_file_delete(struct VoicevoxVoiceModelFile *model);
  * - `onnxruntime`は ::voicevox_onnxruntime_load_once または ::voicevox_onnxruntime_init_once で得たものでなければならない。
  * - `out_synthesizer`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * }
+ *
+ * \orig-impl{voicevox_synthesizer_new}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -680,6 +742,8 @@ VoicevoxResultCode voicevox_synthesizer_new(const struct VoicevoxOnnxruntime *on
  * この関数の呼び出し後に破棄し終えた対象にアクセスすると、プロセスを異常終了する。
  *
  * @param [in] synthesizer 破棄対象
+ *
+ * \no-orig-impl{voicevox_synthesizer_delete}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -693,6 +757,8 @@ void voicevox_synthesizer_delete(struct VoicevoxSynthesizer *synthesizer);
  * @param [in] model 音声モデル
  *
  * @returns 結果コード
+ *
+ * \orig-impl{voicevox_synthesizer_load_voice_model}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -711,6 +777,8 @@ VoicevoxResultCode voicevox_synthesizer_load_voice_model(const struct VoicevoxSy
  * \safety{
  * - `model_id`は<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * }
+ *
+ * \orig-impl{voicevox_synthesizer_unload_voice_model}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -724,6 +792,8 @@ VoicevoxResultCode voicevox_synthesizer_unload_voice_model(const struct Voicevox
  * @param [in] synthesizer 音声シンセサイザ
  *
  * @returns ::VoicevoxOnnxruntime のインスタンス
+ *
+ * \orig-impl{voicevox_synthesizer_get_onnxruntime}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -736,6 +806,8 @@ const struct VoicevoxOnnxruntime *voicevox_synthesizer_get_onnxruntime(const str
  * @param [in] synthesizer 音声シンセサイザ
  *
  * @returns GPUモードかどうか
+ *
+ * \orig-impl{voicevox_synthesizer_is_gpu_mode}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -753,6 +825,8 @@ bool voicevox_synthesizer_is_gpu_mode(const struct VoicevoxSynthesizer *synthesi
  * \safety{
  * - `model_id`は<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * }
+ *
+ * \orig-impl{voicevox_synthesizer_is_loaded_voice_model}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -768,6 +842,8 @@ bool voicevox_synthesizer_is_loaded_voice_model(const struct VoicevoxSynthesizer
  * @param [in] synthesizer 音声シンセサイザ
  *
  * @return メタ情報のJSON文字列
+ *
+ * \orig-impl{voicevox_synthesizer_create_metas_json}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -797,6 +873,8 @@ char *voicevox_synthesizer_create_metas_json(const struct VoicevoxSynthesizer *s
  * - `onnxruntime`は ::voicevox_onnxruntime_load_once または ::voicevox_onnxruntime_init_once で得たものでなければならない。
  * - `output_supported_devices_json`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * }
+ *
+ * \orig-impl{voicevox_onnxruntime_create_supported_devices_json}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -829,6 +907,8 @@ VoicevoxResultCode voicevox_onnxruntime_create_supported_devices_json(const stru
  * - `kana`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * - `output_audio_query_json`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * }
+ *
+ * \orig-impl{voicevox_synthesizer_create_audio_query_from_kana}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -863,6 +943,8 @@ VoicevoxResultCode voicevox_synthesizer_create_audio_query_from_kana(const struc
  * - `text`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * - `output_audio_query_json`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * }
+ *
+ * \orig-impl{voicevox_synthesizer_create_audio_query}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -898,6 +980,8 @@ VoicevoxResultCode voicevox_synthesizer_create_audio_query(const struct Voicevox
  * - `kana`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * - `output_audio_query_json`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * }
+ *
+ * \orig-impl{voicevox_synthesizer_create_accent_phrases_from_kana}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -932,6 +1016,8 @@ VoicevoxResultCode voicevox_synthesizer_create_accent_phrases_from_kana(const st
  * - `text`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * - `output_audio_query_json`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * }
+ *
+ * \orig-impl{voicevox_synthesizer_create_accent_phrases}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -957,6 +1043,8 @@ VoicevoxResultCode voicevox_synthesizer_create_accent_phrases(const struct Voice
  * - `accent_phrases_json`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * - `output_audio_query_json`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * }
+ *
+ * \orig-impl{voicevox_synthesizer_replace_mora_data}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -982,6 +1070,8 @@ VoicevoxResultCode voicevox_synthesizer_replace_mora_data(const struct VoicevoxS
  * - `accent_phrases_json`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * - `output_audio_query_json`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * }
+ *
+ * \orig-impl{voicevox_synthesizer_replace_phoneme_length}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -1007,6 +1097,8 @@ VoicevoxResultCode voicevox_synthesizer_replace_phoneme_length(const struct Voic
  * - `accent_phrases_json`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * - `output_audio_query_json`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * }
+ *
+ * \orig-impl{voicevox_synthesizer_replace_mora_pitch}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -1019,6 +1111,8 @@ VoicevoxResultCode voicevox_synthesizer_replace_mora_pitch(const struct Voicevox
 /**
  * デフォルトの `voicevox_synthesizer_synthesis` のオプションを生成する
  * @return デフォルト値が設定された `voicevox_synthesizer_synthesis` のオプション
+ *
+ * \no-orig-impl{voicevox_make_default_synthesis_options}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -1044,6 +1138,8 @@ struct VoicevoxSynthesisOptions voicevox_make_default_synthesis_options(void);
  * - `output_wav_length`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * - `output_wav`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * }
+ *
+ * \orig-impl{voicevox_synthesizer_synthesis}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -1058,6 +1154,8 @@ VoicevoxResultCode voicevox_synthesizer_synthesis(const struct VoicevoxSynthesiz
 /**
  * デフォルトのテキスト音声合成オプションを生成する
  * @return テキスト音声合成オプション
+ *
+ * \no-orig-impl{voicevox_make_default_tts_options}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -1083,6 +1181,8 @@ struct VoicevoxTtsOptions voicevox_make_default_tts_options(void);
  * - `output_wav_length`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * - `output_wav`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * }
+ *
+ * \orig-impl{voicevox_synthesizer_tts_from_kana}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -1113,6 +1213,8 @@ VoicevoxResultCode voicevox_synthesizer_tts_from_kana(const struct VoicevoxSynth
  * - `output_wav_length`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * - `output_wav`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * }
+ *
+ * \orig-impl{voicevox_synthesizer_tts}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -1144,6 +1246,8 @@ VoicevoxResultCode voicevox_synthesizer_tts(const struct VoicevoxSynthesizer *sy
  * - `json`は<a href="#voicevox-core-safety">読み込みと書き込みについて有効</a>でなければならない。
  * - `json`は以後<b>ダングリングポインタ</b>(_dangling pointer_)として扱われなくてはならない。
  * }
+ *
+ * \no-orig-impl{voicevox_json_free}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -1162,6 +1266,8 @@ void voicevox_json_free(char *json);
  * - `wav`は<a href="#voicevox-core-safety">読み込みと書き込みについて有効</a>でなければならない。
  * - `wav`は以後<b>ダングリングポインタ</b>(_dangling pointer_)として扱われなくてはならない。
  * }
+ *
+ * \no-orig-impl{voicevox_wav_free}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -1189,6 +1295,8 @@ void voicevox_wav_free(uint8_t *wav);
  * assert(strcmp(actual, EXPECTED) == 0);
  * ```
  * }
+ *
+ * \no-orig-impl{voicevox_error_result_to_message}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -1201,6 +1309,8 @@ const char *voicevox_error_result_to_message(VoicevoxResultCode result_code);
  * @param [in] surface 表記
  * @param [in] pronunciation 読み
  * @returns ::VoicevoxUserDictWord
+ *
+ * \orig-impl{voicevox_user_dict_word_make}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -1212,6 +1322,8 @@ struct VoicevoxUserDictWord voicevox_user_dict_word_make(const char *surface,
  * ユーザー辞書をb>構築</b>(_construct_)する。
  *
  * @returns ::VoicevoxUserDict
+ *
+ * \orig-impl{voicevox_user_dict_new}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -1228,6 +1340,8 @@ struct VoicevoxUserDict *voicevox_user_dict_new(void);
  * \safety{
  * - `dict_path`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * }
+ *
+ * \orig-impl{voicevox_user_dict_load}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -1250,6 +1364,8 @@ VoicevoxResultCode voicevox_user_dict_load(const struct VoicevoxUserDict *user_d
  * - `word->surface`と`word->pronunciation`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * - `output_word_uuid`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * }
+ *
+ * \orig-impl{voicevox_user_dict_add_word}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -1270,6 +1386,8 @@ VoicevoxResultCode voicevox_user_dict_add_word(const struct VoicevoxUserDict *us
  * - `word_uuid`は<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * - `word->surface`と`word->pronunciation`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * }
+ *
+ * \orig-impl{voicevox_user_dict_update_word}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -1288,6 +1406,8 @@ VoicevoxResultCode voicevox_user_dict_update_word(const struct VoicevoxUserDict 
  * \safety{
  * - `word_uuid`は<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * }
+ *
+ * \orig-impl{voicevox_user_dict_remove_word}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -1307,6 +1427,8 @@ VoicevoxResultCode voicevox_user_dict_remove_word(const struct VoicevoxUserDict 
  * \safety{
  * - `output_json`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * }
+ *
+ * \orig-impl{voicevox_user_dict_to_json}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -1320,6 +1442,8 @@ VoicevoxResultCode voicevox_user_dict_to_json(const struct VoicevoxUserDict *use
  * @param [in] user_dict ユーザー辞書
  * @param [in] other_dict インポートするユーザー辞書
  * @returns 結果コード
+ *
+ * \orig-impl{voicevox_user_dict_import}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -1336,6 +1460,8 @@ VoicevoxResultCode voicevox_user_dict_import(const struct VoicevoxUserDict *user
  * \safety{
  * - `path`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * }
+ *
+ * \orig-impl{voicevox_user_dict_save}
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -1351,6 +1477,8 @@ VoicevoxResultCode voicevox_user_dict_save(const struct VoicevoxUserDict *user_d
  * この関数の呼び出し後に破棄し終えた対象にアクセスすると、プロセスを異常終了する。
  *
  * @param [in] user_dict 破棄対象
+ *
+ * \no-orig-impl{voicevox_user_dict_delete}
  */
 #ifdef _WIN32
 __declspec(dllimport)

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -99,6 +99,8 @@ fn init_logger_once() {
 /// \availability{
 ///   [リリース](https://github.com/voicevox/voicevox_core/releases)されているライブラリではiOSを除くプラットフォームで利用可能。詳細は<a href="#voicevox-core-availability">ファイルレベルの"Availability"の節</a>を参照。
 /// }
+///
+/// \orig-impl{voicevox_get_onnxruntime_lib_versioned_filename}
 #[cfg(feature = "load-onnxruntime")]
 #[no_mangle]
 pub extern "C" fn voicevox_get_onnxruntime_lib_versioned_filename() -> *const c_char {
@@ -114,6 +116,8 @@ pub extern "C" fn voicevox_get_onnxruntime_lib_versioned_filename() -> *const c_
 /// \availability{
 ///   [リリース](https://github.com/voicevox/voicevox_core/releases)されているライブラリではiOSを除くプラットフォームで利用可能。詳細は<a href="#voicevox-core-availability">ファイルレベルの"Availability"の節</a>を参照。
 /// }
+///
+/// \orig-impl{voicevox_get_onnxruntime_lib_unversioned_filename}
 #[cfg(feature = "load-onnxruntime")]
 #[no_mangle]
 pub extern "C" fn voicevox_get_onnxruntime_lib_unversioned_filename() -> *const c_char {
@@ -127,6 +131,8 @@ pub extern "C" fn voicevox_get_onnxruntime_lib_unversioned_filename() -> *const 
 /// \availability{
 ///   [リリース](https://github.com/voicevox/voicevox_core/releases)されているライブラリではiOSを除くプラットフォームで利用可能。詳細は<a href="#voicevox-core-availability">ファイルレベルの"Availability"の節</a>を参照。
 /// }
+///
+/// \no-orig-impl{VoicevoxLoadOnnxruntimeOptions}
 #[cfg(feature = "load-onnxruntime")]
 #[repr(C)]
 pub struct VoicevoxLoadOnnxruntimeOptions {
@@ -145,6 +151,8 @@ pub struct VoicevoxLoadOnnxruntimeOptions {
 /// \availability{
 ///   [リリース](https://github.com/voicevox/voicevox_core/releases)されているライブラリではiOSを除くプラットフォームで利用可能。詳細は<a href="#voicevox-core-availability">ファイルレベルの"Availability"の節</a>を参照。
 /// }
+///
+/// \no-orig-impl{voicevox_make_default_load_onnxruntime_options}
 #[cfg(feature = "load-onnxruntime")]
 #[no_mangle]
 pub extern "C" fn voicevox_make_default_load_onnxruntime_options() -> VoicevoxLoadOnnxruntimeOptions
@@ -168,6 +176,8 @@ pub extern "C" fn voicevox_make_default_load_onnxruntime_options() -> VoicevoxLo
 /// const VoicevoxOnnxruntime *ort2 = voicevox_onnxruntime_get();
 /// assert(ort1 == ort2);
 /// ```
+///
+/// \orig-impl{VoicevoxOnnxruntime}
 #[cfg(any())]
 pub struct VoicevoxOnnxruntime(!);
 
@@ -183,6 +193,8 @@ pub struct VoicevoxOnnxruntime(voicevox_core::blocking::Onnxruntime);
 /// 作られていなければ`NULL`を返す。
 ///
 /// @returns ::VoicevoxOnnxruntime のインスタンス
+///
+/// \orig-impl{voicevox_onnxruntime_get}
 #[no_mangle]
 pub extern "C" fn voicevox_onnxruntime_get() -> Option<&'static VoicevoxOnnxruntime> {
     VoicevoxOnnxruntime::get()
@@ -207,6 +219,8 @@ pub extern "C" fn voicevox_onnxruntime_get() -> Option<&'static VoicevoxOnnxrunt
 /// - `options.filename`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
 /// - `out_onnxruntime`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
 /// }
+///
+/// \orig-impl{voicevox_onnxruntime_load_once}
 #[cfg(feature = "load-onnxruntime")]
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_onnxruntime_load_once(
@@ -245,6 +259,8 @@ pub unsafe extern "C" fn voicevox_onnxruntime_load_once(
 /// \safety{
 /// - `out_onnxruntime`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
 /// }
+///
+/// \orig-impl{voicevox_onnxruntime_init_once}
 #[cfg(feature = "link-onnxruntime")]
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_onnxruntime_init_once(
@@ -276,6 +292,8 @@ pub unsafe extern "C" fn voicevox_onnxruntime_init_once(
 /// voicevox_open_jtalk_rc_delete(open_jtalk);
 /// ```
 /// }
+///
+/// \orig-impl{OpenJtalkRc}
 #[derive(Debug, Educe)]
 #[educe(Default(expression = "Self { _padding: MaybeUninit::uninit() }"))]
 pub struct OpenJtalkRc {
@@ -304,6 +322,8 @@ pub struct OpenJtalkRc {
 /// - `open_jtalk_dic_dir`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
 /// - `out_open_jtalk`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
 /// }
+///
+/// \orig-impl{voicevox_open_jtalk_rc_new}
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_open_jtalk_rc_new(
     open_jtalk_dic_dir: *const c_char,
@@ -326,6 +346,8 @@ pub unsafe extern "C" fn voicevox_open_jtalk_rc_new(
 ///
 /// @param [in] open_jtalk Open JTalkのオブジェクト
 /// @param [in] user_dict ユーザー辞書
+///
+/// \orig-impl{voicevox_open_jtalk_rc_use_user_dict}
 #[no_mangle]
 pub extern "C" fn voicevox_open_jtalk_rc_use_user_dict(
     open_jtalk: *const OpenJtalkRc,
@@ -353,6 +375,8 @@ pub extern "C" fn voicevox_open_jtalk_rc_use_user_dict(
 /// voicevox_open_jtalk_rc_delete(open_jtalk);
 /// ```
 /// }
+///
+/// \no-orig-impl{voicevox_open_jtalk_rc_delete}
 #[no_mangle]
 pub extern "C" fn voicevox_open_jtalk_rc_delete(open_jtalk: *mut OpenJtalkRc) {
     init_logger_once();
@@ -360,6 +384,8 @@ pub extern "C" fn voicevox_open_jtalk_rc_delete(open_jtalk: *mut OpenJtalkRc) {
 }
 
 /// ハードウェアアクセラレーションモードを設定する設定値。
+///
+/// \orig-impl{VoicevoxAccelerationMode}
 #[repr(i32)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[allow(
@@ -376,6 +402,8 @@ pub enum VoicevoxAccelerationMode {
 }
 
 /// ::voicevox_synthesizer_new のオプション。
+///
+/// \no-orig-impl{VoicevoxInitializeOptions}
 #[repr(C)]
 pub struct VoicevoxInitializeOptions {
     /// ハードウェアアクセラレーションモード
@@ -389,6 +417,8 @@ pub struct VoicevoxInitializeOptions {
 // SAFETY: voicevox_core_c_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
 /// デフォルトの初期化オプションを生成する
 /// @return デフォルト値が設定された初期化オプション
+///
+/// \no-orig-impl{voicevox_make_default_initialize_options}
 #[no_mangle]
 pub extern "C" fn voicevox_make_default_initialize_options() -> VoicevoxInitializeOptions {
     init_logger_once();
@@ -399,6 +429,8 @@ pub extern "C" fn voicevox_make_default_initialize_options() -> VoicevoxInitiali
 // SAFETY: voicevox_core_c_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
 /// voicevoxのバージョンを取得する。
 /// @return SemVerでフォーマットされたバージョン。
+///
+/// \orig-impl{voicevox_get_version}
 #[no_mangle]
 pub extern "C" fn voicevox_get_version() -> *const c_char {
     init_logger_once();
@@ -417,6 +449,8 @@ pub extern "C" fn voicevox_get_version() -> *const c_char {
 ///
 /// VVMファイルと対応する。
 /// <b>構築</b>(_construction_)は ::voicevox_voice_model_file_open で行い、<b>破棄</b>(_destruction_)は ::voicevox_voice_model_file_delete で行う。
+///
+/// \orig-impl{VoicevoxVoiceModelFile}
 #[derive(Debug, Educe)]
 #[educe(Default(expression = "Self { _padding: MaybeUninit::uninit() }"))]
 pub struct VoicevoxVoiceModelFile {
@@ -424,11 +458,15 @@ pub struct VoicevoxVoiceModelFile {
 }
 
 /// 音声モデルID。
+///
+/// \orig-impl{VoicevoxVoiceModelId}
 pub type VoicevoxVoiceModelId<'a> = &'a [u8; 16];
 
 /// スタイルID。
 ///
 /// VOICEVOXにおける、ある<b>キャラクター</b>のある<b>スタイル</b>(_style_)を指す。
+///
+/// \orig-impl{VoicevoxStyleId}
 pub type VoicevoxStyleId = u32;
 
 // TODO: cbindgenが`#[unsafe(no_mangle)]`に対応したら`#[no_mangle]`を置き換える
@@ -444,6 +482,8 @@ pub type VoicevoxStyleId = u32;
 /// - `path`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
 /// - `out_model`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
 /// }
+///
+/// \orig-impl{voicevox_voice_model_file_open}
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_voice_model_file_open(
     path: *const c_char,
@@ -468,6 +508,8 @@ pub unsafe extern "C" fn voicevox_voice_model_file_open(
 /// \safety{
 /// - `output_voice_model_id`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
 /// }
+///
+/// \orig-impl{voicevox_voice_model_file_id}
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_voice_model_file_id(
     model: *const VoicevoxVoiceModelFile,
@@ -487,6 +529,8 @@ pub unsafe extern "C" fn voicevox_voice_model_file_id(
 /// @param [in] model 音声モデル
 ///
 /// @returns メタ情報のJSON文字列
+///
+/// \orig-impl{voicevox_voice_model_file_create_metas_json}
 #[no_mangle]
 pub extern "C" fn voicevox_voice_model_file_create_metas_json(
     model: *const VoicevoxVoiceModelFile,
@@ -504,6 +548,8 @@ pub extern "C" fn voicevox_voice_model_file_create_metas_json(
 /// この関数の呼び出し後に破棄し終えた対象にアクセスすると、プロセスを異常終了する。
 ///
 /// @param [in] model 破棄対象
+///
+/// \no-orig-impl{voicevox_voice_model_file_delete}
 #[no_mangle]
 pub extern "C" fn voicevox_voice_model_file_delete(model: *mut VoicevoxVoiceModelFile) {
     init_logger_once();
@@ -513,6 +559,8 @@ pub extern "C" fn voicevox_voice_model_file_delete(model: *mut VoicevoxVoiceMode
 /// 音声シンセサイザ。
 ///
 /// <b>構築</b>(_construction_)は ::voicevox_synthesizer_new で行い、<b>破棄</b>(_destruction_)は ::voicevox_synthesizer_delete で行う。
+///
+/// \orig-impl{VoicevoxSynthesizer}
 #[derive(Debug, Educe)]
 #[educe(Default(expression = "Self { _padding: MaybeUninit::uninit() }"))]
 pub struct VoicevoxSynthesizer {
@@ -534,6 +582,8 @@ pub struct VoicevoxSynthesizer {
 /// - `onnxruntime`は ::voicevox_onnxruntime_load_once または ::voicevox_onnxruntime_init_once で得たものでなければならない。
 /// - `out_synthesizer`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
 /// }
+///
+/// \orig-impl{voicevox_synthesizer_new}
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_synthesizer_new(
     onnxruntime: &'static VoicevoxOnnxruntime,
@@ -558,6 +608,8 @@ pub unsafe extern "C" fn voicevox_synthesizer_new(
 /// この関数の呼び出し後に破棄し終えた対象にアクセスすると、プロセスを異常終了する。
 ///
 /// @param [in] synthesizer 破棄対象
+///
+/// \no-orig-impl{voicevox_synthesizer_delete}
 #[no_mangle]
 pub extern "C" fn voicevox_synthesizer_delete(synthesizer: *mut VoicevoxSynthesizer) {
     init_logger_once();
@@ -572,6 +624,8 @@ pub extern "C" fn voicevox_synthesizer_delete(synthesizer: *mut VoicevoxSynthesi
 /// @param [in] model 音声モデル
 ///
 /// @returns 結果コード
+///
+/// \orig-impl{voicevox_synthesizer_load_voice_model}
 #[no_mangle]
 pub extern "C" fn voicevox_synthesizer_load_voice_model(
     synthesizer: *const VoicevoxSynthesizer,
@@ -593,6 +647,8 @@ pub extern "C" fn voicevox_synthesizer_load_voice_model(
 /// \safety{
 /// - `model_id`は<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
 /// }
+///
+/// \orig-impl{voicevox_synthesizer_unload_voice_model}
 #[no_mangle]
 pub extern "C" fn voicevox_synthesizer_unload_voice_model(
     synthesizer: *const VoicevoxSynthesizer,
@@ -610,6 +666,8 @@ pub extern "C" fn voicevox_synthesizer_unload_voice_model(
 /// @param [in] synthesizer 音声シンセサイザ
 ///
 /// @returns ::VoicevoxOnnxruntime のインスタンス
+///
+/// \orig-impl{voicevox_synthesizer_get_onnxruntime}
 #[no_mangle]
 pub extern "C" fn voicevox_synthesizer_get_onnxruntime(
     synthesizer: *const VoicevoxSynthesizer,
@@ -624,6 +682,8 @@ pub extern "C" fn voicevox_synthesizer_get_onnxruntime(
 /// @param [in] synthesizer 音声シンセサイザ
 ///
 /// @returns GPUモードかどうか
+///
+/// \orig-impl{voicevox_synthesizer_is_gpu_mode}
 #[no_mangle]
 pub extern "C" fn voicevox_synthesizer_is_gpu_mode(
     synthesizer: *const VoicevoxSynthesizer,
@@ -644,6 +704,8 @@ pub extern "C" fn voicevox_synthesizer_is_gpu_mode(
 /// \safety{
 /// - `model_id`は<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
 /// }
+///
+/// \orig-impl{voicevox_synthesizer_is_loaded_voice_model}
 #[no_mangle]
 pub extern "C" fn voicevox_synthesizer_is_loaded_voice_model(
     synthesizer: *const VoicevoxSynthesizer,
@@ -663,6 +725,8 @@ pub extern "C" fn voicevox_synthesizer_is_loaded_voice_model(
 /// @param [in] synthesizer 音声シンセサイザ
 ///
 /// @return メタ情報のJSON文字列
+///
+/// \orig-impl{voicevox_synthesizer_create_metas_json}
 #[no_mangle]
 pub extern "C" fn voicevox_synthesizer_create_metas_json(
     synthesizer: *const VoicevoxSynthesizer,
@@ -696,6 +760,8 @@ pub extern "C" fn voicevox_synthesizer_create_metas_json(
 /// - `onnxruntime`は ::voicevox_onnxruntime_load_once または ::voicevox_onnxruntime_init_once で得たものでなければならない。
 /// - `output_supported_devices_json`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
 /// }
+///
+/// \orig-impl{voicevox_onnxruntime_create_supported_devices_json}
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_onnxruntime_create_supported_devices_json(
     onnxruntime: &'static VoicevoxOnnxruntime,
@@ -740,6 +806,8 @@ pub unsafe extern "C" fn voicevox_onnxruntime_create_supported_devices_json(
 /// - `kana`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
 /// - `output_audio_query_json`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
 /// }
+///
+/// \orig-impl{voicevox_synthesizer_create_audio_query_from_kana}
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_synthesizer_create_audio_query_from_kana(
     synthesizer: *const VoicevoxSynthesizer,
@@ -789,6 +857,8 @@ pub unsafe extern "C" fn voicevox_synthesizer_create_audio_query_from_kana(
 /// - `text`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
 /// - `output_audio_query_json`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
 /// }
+///
+/// \orig-impl{voicevox_synthesizer_create_audio_query}
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_synthesizer_create_audio_query(
     synthesizer: *const VoicevoxSynthesizer,
@@ -839,6 +909,8 @@ pub unsafe extern "C" fn voicevox_synthesizer_create_audio_query(
 /// - `kana`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
 /// - `output_audio_query_json`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
 /// }
+///
+/// \orig-impl{voicevox_synthesizer_create_accent_phrases_from_kana}
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_synthesizer_create_accent_phrases_from_kana(
     synthesizer: *const VoicevoxSynthesizer,
@@ -886,6 +958,8 @@ pub unsafe extern "C" fn voicevox_synthesizer_create_accent_phrases_from_kana(
 /// - `text`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
 /// - `output_audio_query_json`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
 /// }
+///
+/// \orig-impl{voicevox_synthesizer_create_accent_phrases}
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_synthesizer_create_accent_phrases(
     synthesizer: *const VoicevoxSynthesizer,
@@ -924,6 +998,8 @@ pub unsafe extern "C" fn voicevox_synthesizer_create_accent_phrases(
 /// - `accent_phrases_json`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
 /// - `output_audio_query_json`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
 /// }
+///
+/// \orig-impl{voicevox_synthesizer_replace_mora_data}
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_synthesizer_replace_mora_data(
     synthesizer: *const VoicevoxSynthesizer,
@@ -964,6 +1040,8 @@ pub unsafe extern "C" fn voicevox_synthesizer_replace_mora_data(
 /// - `accent_phrases_json`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
 /// - `output_audio_query_json`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
 /// }
+///
+/// \orig-impl{voicevox_synthesizer_replace_phoneme_length}
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_synthesizer_replace_phoneme_length(
     synthesizer: *const VoicevoxSynthesizer,
@@ -1004,6 +1082,8 @@ pub unsafe extern "C" fn voicevox_synthesizer_replace_phoneme_length(
 /// - `accent_phrases_json`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
 /// - `output_audio_query_json`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
 /// }
+///
+/// \orig-impl{voicevox_synthesizer_replace_mora_pitch}
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_synthesizer_replace_mora_pitch(
     synthesizer: *const VoicevoxSynthesizer,
@@ -1028,6 +1108,8 @@ pub unsafe extern "C" fn voicevox_synthesizer_replace_mora_pitch(
 }
 
 /// ::voicevox_synthesizer_synthesis のオプション。
+///
+/// \no-orig-impl{VoicevoxSynthesisOptions}
 #[repr(C)]
 pub struct VoicevoxSynthesisOptions {
     /// 疑問文の調整を有効にする
@@ -1038,6 +1120,8 @@ pub struct VoicevoxSynthesisOptions {
 // SAFETY: voicevox_core_c_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
 /// デフォルトの `voicevox_synthesizer_synthesis` のオプションを生成する
 /// @return デフォルト値が設定された `voicevox_synthesizer_synthesis` のオプション
+///
+/// \no-orig-impl{voicevox_make_default_synthesis_options}
 #[no_mangle]
 pub extern "C" fn voicevox_make_default_synthesis_options() -> VoicevoxSynthesisOptions {
     init_logger_once();
@@ -1064,6 +1148,8 @@ pub extern "C" fn voicevox_make_default_synthesis_options() -> VoicevoxSynthesis
 /// - `output_wav_length`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
 /// - `output_wav`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
 /// }
+///
+/// \orig-impl{voicevox_synthesizer_synthesis}
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_synthesizer_synthesis(
     synthesizer: *const VoicevoxSynthesizer,
@@ -1094,6 +1180,8 @@ pub unsafe extern "C" fn voicevox_synthesizer_synthesis(
 }
 
 /// ::voicevox_synthesizer_tts のオプション。
+///
+/// \no-orig-impl{VoicevoxTtsOptions}
 #[repr(C)]
 pub struct VoicevoxTtsOptions {
     /// 疑問文の調整を有効にする
@@ -1104,6 +1192,8 @@ pub struct VoicevoxTtsOptions {
 // SAFETY: voicevox_core_c_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
 /// デフォルトのテキスト音声合成オプションを生成する
 /// @return テキスト音声合成オプション
+///
+/// \no-orig-impl{voicevox_make_default_tts_options}
 #[no_mangle]
 pub extern "C" fn voicevox_make_default_tts_options() -> VoicevoxTtsOptions {
     init_logger_once();
@@ -1130,6 +1220,8 @@ pub extern "C" fn voicevox_make_default_tts_options() -> VoicevoxTtsOptions {
 /// - `output_wav_length`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
 /// - `output_wav`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
 /// }
+///
+/// \orig-impl{voicevox_synthesizer_tts_from_kana}
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_synthesizer_tts_from_kana(
     synthesizer: *const VoicevoxSynthesizer,
@@ -1175,6 +1267,8 @@ pub unsafe extern "C" fn voicevox_synthesizer_tts_from_kana(
 /// - `output_wav_length`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
 /// - `output_wav`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
 /// }
+///
+/// \orig-impl{voicevox_synthesizer_tts}
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_synthesizer_tts(
     synthesizer: *const VoicevoxSynthesizer,
@@ -1221,6 +1315,8 @@ pub unsafe extern "C" fn voicevox_synthesizer_tts(
 /// - `json`は<a href="#voicevox-core-safety">読み込みと書き込みについて有効</a>でなければならない。
 /// - `json`は以後<b>ダングリングポインタ</b>(_dangling pointer_)として扱われなくてはならない。
 /// }
+///
+/// \no-orig-impl{voicevox_json_free}
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_json_free(json: *mut c_char) {
     init_logger_once();
@@ -1240,6 +1336,8 @@ pub unsafe extern "C" fn voicevox_json_free(json: *mut c_char) {
 /// - `wav`は<a href="#voicevox-core-safety">読み込みと書き込みについて有効</a>でなければならない。
 /// - `wav`は以後<b>ダングリングポインタ</b>(_dangling pointer_)として扱われなくてはならない。
 /// }
+///
+/// \no-orig-impl{voicevox_wav_free}
 #[no_mangle]
 pub extern "C" fn voicevox_wav_free(wav: *mut u8) {
     init_logger_once();
@@ -1268,6 +1366,8 @@ pub extern "C" fn voicevox_wav_free(wav: *mut u8) {
 /// assert(strcmp(actual, EXPECTED) == 0);
 /// ```
 /// }
+///
+/// \no-orig-impl{voicevox_error_result_to_message}
 #[no_mangle]
 pub extern "C" fn voicevox_error_result_to_message(
     result_code: VoicevoxResultCode,
@@ -1278,6 +1378,8 @@ pub extern "C" fn voicevox_error_result_to_message(
 }
 
 /// ユーザー辞書。
+///
+/// \orig-impl{VoicevoxUserDict}
 #[derive(Debug, Educe)]
 #[educe(Default(expression = "Self { _padding: MaybeUninit::uninit() }"))]
 pub struct VoicevoxUserDict {
@@ -1285,6 +1387,8 @@ pub struct VoicevoxUserDict {
 }
 
 /// ユーザー辞書の単語。
+///
+/// \orig-impl{VoicevoxUserDictWord}
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub struct VoicevoxUserDictWord {
@@ -1301,6 +1405,8 @@ pub struct VoicevoxUserDictWord {
 }
 
 /// ユーザー辞書の単語の種類。
+///
+/// \orig-impl{VoicevoxUserDictWordType}
 #[repr(i32)]
 #[allow(
     non_camel_case_types,
@@ -1327,6 +1433,8 @@ pub enum VoicevoxUserDictWordType {
 /// @param [in] surface 表記
 /// @param [in] pronunciation 読み
 /// @returns ::VoicevoxUserDictWord
+///
+/// \orig-impl{voicevox_user_dict_word_make}
 #[no_mangle]
 pub extern "C" fn voicevox_user_dict_word_make(
     surface: *const c_char,
@@ -1347,6 +1455,8 @@ pub extern "C" fn voicevox_user_dict_word_make(
 /// ユーザー辞書をb>構築</b>(_construct_)する。
 ///
 /// @returns ::VoicevoxUserDict
+///
+/// \orig-impl{voicevox_user_dict_new}
 #[no_mangle]
 pub extern "C" fn voicevox_user_dict_new() -> NonNull<VoicevoxUserDict> {
     init_logger_once();
@@ -1364,6 +1474,8 @@ pub extern "C" fn voicevox_user_dict_new() -> NonNull<VoicevoxUserDict> {
 /// \safety{
 /// - `dict_path`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
 /// }
+///
+/// \orig-impl{voicevox_user_dict_load}
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_user_dict_load(
     user_dict: *const VoicevoxUserDict,
@@ -1394,6 +1506,8 @@ pub unsafe extern "C" fn voicevox_user_dict_load(
 /// - `word->surface`と`word->pronunciation`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
 /// - `output_word_uuid`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
 /// }
+///
+/// \orig-impl{voicevox_user_dict_add_word}
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_user_dict_add_word(
     user_dict: *const VoicevoxUserDict,
@@ -1423,6 +1537,8 @@ pub unsafe extern "C" fn voicevox_user_dict_add_word(
 /// - `word_uuid`は<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
 /// - `word->surface`と`word->pronunciation`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
 /// }
+///
+/// \orig-impl{voicevox_user_dict_update_word}
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_user_dict_update_word(
     user_dict: *const VoicevoxUserDict,
@@ -1450,6 +1566,8 @@ pub unsafe extern "C" fn voicevox_user_dict_update_word(
 /// \safety{
 /// - `word_uuid`は<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
 /// }
+///
+/// \orig-impl{voicevox_user_dict_remove_word}
 #[no_mangle]
 pub extern "C" fn voicevox_user_dict_remove_word(
     user_dict: *const VoicevoxUserDict,
@@ -1477,6 +1595,8 @@ pub extern "C" fn voicevox_user_dict_remove_word(
 /// \safety{
 /// - `output_json`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
 /// }
+///
+/// \orig-impl{voicevox_user_dict_to_json}
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_user_dict_to_json(
     user_dict: *const VoicevoxUserDict,
@@ -1496,6 +1616,8 @@ pub unsafe extern "C" fn voicevox_user_dict_to_json(
 /// @param [in] user_dict ユーザー辞書
 /// @param [in] other_dict インポートするユーザー辞書
 /// @returns 結果コード
+///
+/// \orig-impl{voicevox_user_dict_import}
 #[no_mangle]
 pub extern "C" fn voicevox_user_dict_import(
     user_dict: *const VoicevoxUserDict,
@@ -1518,6 +1640,8 @@ pub extern "C" fn voicevox_user_dict_import(
 /// \safety{
 /// - `path`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
 /// }
+///
+/// \orig-impl{voicevox_user_dict_save}
 #[no_mangle]
 pub unsafe extern "C" fn voicevox_user_dict_save(
     user_dict: *const VoicevoxUserDict,
@@ -1540,6 +1664,8 @@ pub unsafe extern "C" fn voicevox_user_dict_save(
 /// この関数の呼び出し後に破棄し終えた対象にアクセスすると、プロセスを異常終了する。
 ///
 /// @param [in] user_dict 破棄対象
+///
+/// \no-orig-impl{voicevox_user_dict_delete}
 #[no_mangle]
 pub extern "C" fn voicevox_user_dict_delete(user_dict: *mut VoicevoxUserDict) {
     init_logger_once();

--- a/crates/voicevox_core_c_api/src/result_code.rs
+++ b/crates/voicevox_core_c_api/src/result_code.rs
@@ -1,6 +1,8 @@
 use std::ffi::CStr;
 
 /// 処理結果を示す結果コード。
+///
+/// \orig-impl{VoicevoxResultCode,C APIにしか無いものがあることに注意。}
 #[repr(i32)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[allow(

--- a/docs/ghpages/apis/c_api/doxygen/Doxyfile
+++ b/docs/ghpages/apis/c_api/doxygen/Doxyfile
@@ -2666,3 +2666,7 @@ ALIASES += examples{1}="<dl><dt>Examples</dt><dd>\1</dd></dl>"
 
 # 中身は箇条書きで、素の文章からは始まらない想定
 ALIASES += safety{1}="<dl><dt> Safety</dt><dd><details><summary>⚠️安全性要件</summary><a href=\"#voicevox-core-safety\">安全性要件</a>は以下の通りである。\1</details></dd></dl>"
+
+ALIASES += orig-impl{1}="<dl><dt>Original Implementation</dt><dd>[\"\1\" Search - Rust](../rust_api/voicevox_core/index.html?search=\1)</dd></dl>"
+ALIASES += orig-impl{2}="<dl><dt>Original Implementation</dt><dd><p>\2</p>[\"\1\" Search - Rust](../rust_api/voicevox_core/index.html?search=\1)</dd></dl>"
+ALIASES += no-orig-impl{1}="\orig-impl{\1,Rust APIには存在しない。}"


### PR DESCRIPTION
## 内容

Rust API側において`#[doc(alias(…))]`機能でC APIの名前に紐付かせ、C API側からはそのエイリアスに対してリンクを張る (`?search=…`)。
(補足として、エイリアスは完全一致でしか引っ掛からないためRust APIでの検索を阻害することは基本無い)

ユーザーにRust APIのことを意識させることによって、 #975 のようなことに対する緩和をねらう。

![image](https://github.com/user-attachments/assets/8bec7bfc-4176-4574-a144-234182bb643c)

![image](https://github.com/user-attachments/assets/ebb8b738-bb6f-4a8e-afa7-301ce0a69b14)

![image](https://github.com/user-attachments/assets/d5f87a4a-a9bd-4305-a980-cdd99cfc8c5f)

![image](https://github.com/user-attachments/assets/eff14fb0-343e-4b3a-82e9-0ebd9364a84b)

![image](https://github.com/user-attachments/assets/b25225bc-ed32-4a9a-bb7d-05787b1d3baf)

See-also: https://doc.rust-lang.org/rustdoc/advanced-features.html#add-aliases-for-an-item-in-documentation-search

## 関連 Issue

## その他
