### PR TITLE
feat: [Python] 「存在しないコンストラクタ」についてケア

### DIFF
--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/asyncio.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/asyncio.pyi
@@ -1,5 +1,5 @@
 from os import PathLike
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, NoReturn, Union
 from uuid import UUID
 
 if TYPE_CHECKING:
@@ -18,6 +18,9 @@ class VoiceModelFile:
     """
     音声モデルファイル。"""
 
+    def __new__(
+        cls, *args: tuple[object], **kwargs: dict[object, object]
+    ) -> NoReturn: ...
     @staticmethod
     async def open(path: str | PathLike[str]) -> VoiceModelFile:
         """
@@ -95,6 +98,9 @@ class Onnxruntime:
     LIB_UNVERSIONED_FILENAME: str
     """:attr:`LIB_NAME` からなる動的ライブラリのファイル名。"""
 
+    def __new__(
+        cls, *args: tuple[object], **kwargs: dict[object, object]
+    ) -> NoReturn: ...
     @staticmethod
     def get() -> Union["Onnxruntime", None]:
         """

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
@@ -1,5 +1,5 @@
 from os import PathLike
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, NoReturn, Union
 from uuid import UUID
 
 if TYPE_CHECKING:
@@ -18,6 +18,9 @@ class VoiceModelFile:
     """
     音声モデルファイル。"""
 
+    def __new__(
+        cls, *args: tuple[object], **kwargs: dict[object, object]
+    ) -> NoReturn: ...
     @staticmethod
     def open(path: str | PathLike[str]) -> VoiceModelFile:
         """
@@ -95,6 +98,9 @@ class Onnxruntime:
     LIB_UNVERSIONED_FILENAME: str
     """:attr:`LIB_NAME` からなる動的ライブラリのファイル名。"""
 
+    def __new__(
+        cls, *args: tuple[object], **kwargs: dict[object, object]
+    ) -> NoReturn: ...
     @staticmethod
     def get() -> Union["Onnxruntime", None]:
         """

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -294,9 +294,9 @@ mod blocking {
 
     use camino::Utf8PathBuf;
     use pyo3::{
-        exceptions::{PyIndexError, PyValueError},
+        exceptions::{PyIndexError, PyTypeError, PyValueError},
         pyclass, pymethods,
-        types::{IntoPyDict as _, PyBytes, PyDict, PyList},
+        types::{IntoPyDict as _, PyBytes, PyDict, PyList, PyTuple, PyType},
         Py, PyAny, PyObject, PyRef, PyResult, Python,
     };
     use uuid::Uuid;
@@ -316,6 +316,16 @@ mod blocking {
 
     #[pymethods]
     impl VoiceModelFile {
+        #[new]
+        #[classmethod]
+        #[pyo3(signature = (*_args, **_kwargs))]
+        fn new(_cls: &PyType, _args: &PyTuple, _kwargs: Option<&PyDict>) -> PyResult<Self> {
+            Err(PyTypeError::new_err((
+                "`VoiceModelFile` does not have a normal constructor. Use \
+                 `VoiceModelFile.load_once` to construct",
+            )))
+        }
+
         #[staticmethod]
         fn open(py: Python<'_>, path: PathBuf) -> PyResult<Self> {
             let model = voicevox_core::blocking::VoiceModelFile::open(path).into_py_result(py)?;
@@ -383,6 +393,16 @@ mod blocking {
         #[classattr]
         const LIB_UNVERSIONED_FILENAME: &'static str =
             voicevox_core::blocking::Onnxruntime::LIB_UNVERSIONED_FILENAME;
+
+        #[new]
+        #[classmethod]
+        #[pyo3(signature = (*_args, **_kwargs))]
+        fn new(_cls: &PyType, _args: &PyTuple, _kwargs: Option<&PyDict>) -> PyResult<Self> {
+            Err(PyTypeError::new_err((
+                "`Onnxruntime` does not have a normal constructor. Use `Onnxruntime.load_once` or \
+                 `Onnxruntime.get` to construct",
+            )))
+        }
 
         #[staticmethod]
         fn get(py: Python<'_>) -> PyResult<Option<Py<Self>>> {
@@ -883,8 +903,9 @@ mod asyncio {
 
     use camino::Utf8PathBuf;
     use pyo3::{
+        exceptions::PyTypeError,
         pyclass, pymethods,
-        types::{IntoPyDict as _, PyBytes, PyDict, PyList},
+        types::{IntoPyDict as _, PyBytes, PyDict, PyList, PyTuple, PyType},
         Py, PyAny, PyErr, PyObject, PyRef, PyResult, Python, ToPyObject as _,
     };
     use uuid::Uuid;
@@ -904,6 +925,16 @@ mod asyncio {
 
     #[pymethods]
     impl VoiceModelFile {
+        #[new]
+        #[classmethod]
+        #[pyo3(signature = (*_args, **_kwargs))]
+        fn new(_cls: &PyType, _args: &PyTuple, _kwargs: Option<&PyDict>) -> PyResult<Self> {
+            Err(PyTypeError::new_err((
+                "`VoiceModelFile` does not have a normal constructor. Use \
+                 `VoiceModelFile.load_once` to construct",
+            )))
+        }
+
         #[staticmethod]
         fn open(py: Python<'_>, path: PathBuf) -> PyResult<&PyAny> {
             pyo3_asyncio::tokio::future_into_py(py, async move {
@@ -985,6 +1016,16 @@ mod asyncio {
         #[classattr]
         const LIB_UNVERSIONED_FILENAME: &'static str =
             voicevox_core::nonblocking::Onnxruntime::LIB_UNVERSIONED_FILENAME;
+
+        #[new]
+        #[classmethod]
+        #[pyo3(signature = (*_args, **_kwargs))]
+        fn new(_cls: &PyType, _args: &PyTuple, _kwargs: Option<&PyDict>) -> PyResult<Self> {
+            Err(PyTypeError::new_err((
+                "`Onnxruntime` does not have a normal constructor. Use `Onnxruntime.load_once` or \
+                 `Onnxruntime.get` to construct",
+            )))
+        }
 
         #[staticmethod]
         fn get(py: Python<'_>) -> PyResult<Option<Py<Self>>> {


### PR DESCRIPTION
## 内容

現在`VoiceModelFile`と`Onnxruntime`には通常のコンストラクタが存在しない。正確に言えば`__new__`は存在してはいるが、それを呼ぶと`TypeError`になる。その「存在しないコンストラクタ」について次の2つを行う。

1. エラーメッセージの改善。

    Before (PyO3(?)が出しているやつ):

    ```console
    TypeError: No constructor defined
    ```

    After:

    ```console
    TypeError: `Onnxruntime` does not have a normal constructor. Use `Onnxruntime.load_once` or `Onnxruntime.get` to construct
    ```

2. pyiに`__new__`について記述。

    シグネチャは`(cls, *args, **kwargs) -> NoReturn`。

    **これをやらないとデフォルトコンストラクタ (`() -> Self`)が存在することになってしまう**。

    ちなみにPyright/Pylanceとmypy（多分）にのみ影響。Sphinxには`__new__`の記述は無視されてしまった。

## 関連 Issue

## その他
