### PR TITLE
feat: [Python, Java] fix up #832: `Drop`のメッセージをやめる

### DIFF
--- a/crates/voicevox_core_java_api/src/common.rs
+++ b/crates/voicevox_core_java_api/src/common.rs
@@ -6,7 +6,7 @@ use jni::{
     objects::{JObject, JThrowable},
     JNIEnv,
 };
-use tracing::{debug, warn};
+use tracing::debug;
 use uuid::Uuid;
 use voicevox_core::__internal::interop::raii::MaybeClosed;
 
@@ -222,23 +222,6 @@ impl<T: HasJavaClassIdent> Closable<T> {
             debug!("Closing a `{}`", T::JAVA_CLASS_IDENT);
         }
         drop(mem::replace(lock, MaybeClosed::Closed));
-    }
-}
-
-impl<T: HasJavaClassIdent> Drop for Closable<T> {
-    fn drop(&mut self) {
-        let content = mem::replace(
-            self.0.get_mut().unwrap_or_else(|e| panic!("{e}")),
-            MaybeClosed::Closed,
-        );
-        if let MaybeClosed::Open(content) = content {
-            warn!(
-                "デストラクタにより`{}`のクローズを行います。通常は、可能な限り`close`でクローズす\
-                 るようにして下さい",
-                T::JAVA_CLASS_IDENT,
-            );
-            drop(content);
-        }
     }
 }
 

--- a/example/python/README.md
+++ b/example/python/README.md
@@ -81,7 +81,6 @@ optional arguments:
 [INFO] __main__: Creating an AudioQuery from 'この音声は、ボイスボックスを使用して、出力されています。'
 [INFO] __main__: Synthesizing with {"accent_phrases":[…],"speedScale":1.0,"pitchScale":0.0,"intonationScale":1.0,"volumeScale":1.0,"prePhonemeLength":0.1,"postPhonemeLength":0.1,"outputSamplingRate":24000,"outputStereo":false,"pauseLength":null,"pauseLengthScale":1.0,"kana":"コノ'/オ'ンセエワ、ボイスボ'ッ_クスオ/シヨオ'/_シテ'、_ シュツ'リョ_ク/サレテ'/イマ'_ス"}
 [INFO] __main__: Wrote `output.wav`
-[WARNING] voicevox_core_python_api: デストラクタにより`Synthesizer`のクローズを行います。通常は、可能な限り`__exit__`でクローズするようにして下さい
 ```
 
 正常に実行されれば音声合成の結果である wav ファイルが生成されます。


### PR DESCRIPTION
## 内容

次のようなメッセージをやめる。

```console
[WARNING] voicevox_core_python_api: デストラクタにより`Synthesizer`のクローズを行います。通常は、可能な限り`__exit__`でクローズするようにして下さい
```

カジュアルな用途だと相当にうっとおしいはずなので。

## 関連 Issue

## その他
