### PR TITLE
build(fix): [Java] `javadoc.options.encoding = 'UTF-8'`

### DIFF
--- a/crates/voicevox_core_java_api/lib/build.gradle
+++ b/crates/voicevox_core_java_api/lib/build.gradle
@@ -51,6 +51,7 @@ tasks.named('test') {
 
 compileJava.options.encoding = 'UTF-8'
 compileTestJava.options.encoding = 'UTF-8'
+javadoc.options.encoding = 'UTF-8'
 
 spotless {
     java {


### PR DESCRIPTION
## 内容

Windowsで`gradle javadoc`を試みるとこうなるので、UTF-8を指定することで直す。

![image](https://github.com/user-attachments/assets/3ab5af9a-4a1e-4d9a-99cc-afd6d6bdc696)

## 関連 Issue

## その他
