### PR TITLE
docs: APIドキュメントの`{Character,Style}Meta`周りの記述を統一

### DIFF
--- a/crates/voicevox_core/src/metas.rs
+++ b/crates/voicevox_core/src/metas.rs
@@ -39,10 +39,10 @@ pub fn merge<'a>(metas: impl IntoIterator<Item = &'a CharacterMeta>) -> Vec<Char
 
 /// スタイルID。
 ///
-/// VOICEVOXにおける、ある[**キャラクター**]のある[**スタイル**(_style_)]を指す。
+/// VOICEVOXにおける、ある[<i>キャラクター</i>]のある[<i>スタイル</i>]を指す。
 ///
-/// [**キャラクター**]: CharacterMeta
-/// [**スタイル**(_style_)]: StyleMeta
+/// [<i>キャラクター</i>]: CharacterMeta
+/// [<i>スタイル</i>]: StyleMeta
 #[derive(
     PartialEq,
     Eq,
@@ -66,9 +66,9 @@ impl Display for StyleId {
     }
 }
 
-/// [**キャラクター**]のバージョン。
+/// [<i>キャラクター</i>]のバージョン。
 ///
-/// [**キャラクター**]: CharacterMeta
+/// [<i>キャラクター</i>]: CharacterMeta
 #[derive(PartialEq, Eq, Clone, Ord, PartialOrd, Deserialize, Serialize, new, Debug)]
 pub struct CharacterVersion(pub String);
 
@@ -81,7 +81,7 @@ impl Display for CharacterVersion {
 /// 音声モデルのメタ情報。
 pub type VoiceModelMeta = Vec<CharacterMeta>;
 
-/// キャラクターのメタ情報。
+/// <i>キャラクター</i>のメタ情報。
 #[derive(Deserialize, Serialize, Clone)]
 #[non_exhaustive]
 pub struct CharacterMeta {
@@ -141,7 +141,7 @@ impl CharacterMeta {
     }
 }
 
-/// **スタイル**(_style_)のメタ情報。
+/// <i>スタイル</i>のメタ情報。
 #[derive(Deserialize, Serialize, Clone)]
 #[non_exhaustive]
 pub struct StyleMeta {
@@ -158,7 +158,9 @@ pub struct StyleMeta {
     pub order: Option<u32>,
 }
 
-/// **スタイル**(_style_)に対応するモデルの種類。
+/// [<i>スタイル</i>]に対応するモデルの種類。
+///
+/// [<i>スタイル</i>]: StyleMeta
 #[derive(
     Default,
     Clone,

--- a/crates/voicevox_core_c_api/include/voicevox_core.h
+++ b/crates/voicevox_core_c_api/include/voicevox_core.h
@@ -365,7 +365,7 @@ typedef const uint8_t (*VoicevoxVoiceModelId)[16];
 /**
  * スタイルID。
  *
- * VOICEVOXにおける、ある<b>キャラクター</b>のある<b>スタイル</b>(_style_)を指す。
+ * VOICEVOXにおける、ある<i>キャラクター</i>のある<i>スタイル</i>を指す。
  *
  * \orig-impl{VoicevoxStyleId}
  */

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -464,7 +464,7 @@ pub type VoicevoxVoiceModelId<'a> = &'a [u8; 16];
 
 /// スタイルID。
 ///
-/// VOICEVOXにおける、ある<b>キャラクター</b>のある<b>スタイル</b>(_style_)を指す。
+/// VOICEVOXにおける、ある<i>キャラクター</i>のある<i>スタイル</i>を指す。
 ///
 /// \orig-impl{VoicevoxStyleId}
 pub type VoicevoxStyleId = u32;

--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/CharacterMeta.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/CharacterMeta.java
@@ -6,7 +6,7 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 
 /**
- * キャラクターのメタ情報。
+ * <i>キャラクター</i>のメタ情報。
  *
  * <p>現在この型はGSONに対応しているが、将来的には <a href="https://github.com/VOICEVOX/voicevox_core/issues/984"
  * target="_blank">Jacksonに切り替わる予定</a> 。

--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/StyleMeta.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/StyleMeta.java
@@ -6,7 +6,7 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 
 /**
- * スタイル（style）のメタ情報。
+ * <i>スタイル</i>のメタ情報。
  *
  * <p>現在この型はGSONに対応しているが、将来的には <a href="https://github.com/VOICEVOX/voicevox_core/issues/984"
  * target="_blank">Jacksonに切り替わる予定</a> 。

--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/StyleType.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/StyleType.java
@@ -9,7 +9,7 @@ import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import java.lang.reflect.Type;
 
-/** スタイル（style）に対応するモデルの種類。 */
+/** {@link StyleMeta <i>スタイル</i>}に対応するモデルの種類。 */
 public class StyleType {
   /** 音声合成クエリの作成と音声合成が可能。 */
   public static final StyleType TALK = new StyleType("talk");

--- a/crates/voicevox_core_python_api/python/voicevox_core/_models/__init__.py
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_models/__init__.py
@@ -13,6 +13,13 @@ StyleId = NewType("StyleId", int)
 """
 スタイルID。
 
+VOICEVOXにおける、ある |styleid-character|_ のある |styleid-style|_ を指す。
+
+.. |styleid-character| replace:: *キャラクター*
+.. _styleid-character: #voicevox_core.CharacterMeta
+.. |styleid-style| replace:: *スタイル*
+.. _styleid-style: #voicevox_core.StyleMeta
+
 Parameters
 ----------
 x : int
@@ -20,7 +27,10 @@ x : int
 
 CharacterVersion = NewType("CharacterVersion", str)
 """
-**キャラクター**のバージョン。
+|characterversion-character|_ のバージョン。
+
+.. |characterversion-character| replace:: *キャラクター*
+.. _characterversion-character: #voicevox_core.CharacterMeta
 
 Parameters
 ----------
@@ -41,7 +51,10 @@ StyleType: TypeAlias = (
 )
 """
 
-**スタイル** (_style_)に対応するモデルの種類。
+|styletype-style|_ に対応するモデルの種類。
+
+.. |styletype-style| replace:: *スタイル*
+.. _styletype-style: #voicevox_core.StyleMeta
 
 ===================== ==================================================
 値                    説明
@@ -90,7 +103,7 @@ def _(style_type: StyleType):
 @pydantic.dataclasses.dataclass
 class StyleMeta:
     """
-    **スタイル** (_style_)のメタ情報。
+    *スタイル* のメタ情報。
 
     現在は |pydantic-dataclasses-dataclass-stylemeta|_ ではあるが、将来的には
     |de-pydantic-stylemeta|_ 。
@@ -121,7 +134,7 @@ class StyleMeta:
 @pydantic.dataclasses.dataclass
 class CharacterMeta:
     """
-    **キャラクター**のメタ情報。
+    *キャラクター* のメタ情報。
 
     現在は |pydantic-dataclasses-dataclass-charactermeta|_ ではあるが、将来的には
     |de-pydantic-charactermeta|_ 。


### PR DESCRIPTION
## 内容

Sphinxの表示が壊れており警告も出ている状態だったため、それを直すとともに、以下のような記述で統一する。

> <i>キャラクター</i>のメタ情報。

> <i>スタイル</i>のメタ情報。

> VOICEVOXにおける、ある[<i>キャラクター</i>]のある[<i>スタイル</i>]を指す。

[<i>キャラクター</i>]: https://voicevox.github.io/voicevox_core/apis/rust_api/voicevox_core/struct.CharacterMeta.html
[<i>スタイル</i>]: https://voicevox.github.io/voicevox_core/apis/rust_api/voicevox_core/struct.StyleMeta.html

## 関連 Issue

## その他
