### PR TITLE
feat: [downloader] "y/N"の意味についてプロンプトに追記

### DIFF
--- a/crates/downloader/src/main.rs
+++ b/crates/downloader/src/main.rs
@@ -693,7 +693,8 @@ fn ensure_confirmation(terms: &str, terms_name: &'static str) -> anyhow::Result<
     return Ok(());
 
     const PROMPT: &str =
-        "上記の利用規約に同意しますか？ (Do you agree with the above terms of use?) (y/N): ";
+        "上記の利用規約に同意しますか？ (Do you agree with the above terms of use?) (y/N)\n\
+         同意するならyを、同意しないならnを入力し、エンターキーを押してください: ";
 
     fn ask_yn() -> anyhow::Result<bool> {
         loop {


### PR DESCRIPTION
## 内容

"y/N"の意味がわからない可能性を考え、プロンプト内で説明する。

> 3. 「同意するならyを、同意しないならnを入力してください」（エンターを押してください？）という一文が必要そう（y/Nの意味がわからない可能性があるので）

## 関連 Issue

Refs: #1000

## その他
