### PR TITLE
ci: fix up #1006: deny.tomlの対応

### DIFF
--- a/.github/workflows/check-release-target-tuples.yml
+++ b/.github/workflows/check-release-target-tuples.yml
@@ -1,0 +1,45 @@
+# 以下のファイルにおいて、リリース対象のtarget tupleが一致しているかを検査する。
+# - build and deploy workflow
+# - deny.toml
+# - about.toml
+name: Check release target tuples
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - .github/workflows/check-release-target-tuples.yml
+      - .github/workflows/build_and_deploy.yml
+      - 'crates/*/about.toml'
+      - deny.toml
+
+jobs:
+  check:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Install go-yq v4
+        run: |
+          mkdir -p ~/.local/bin
+          echo ~/.local/bin >> "$GITHUB_PATH"
+          tag=$(gh release ls -R mikefarah/yq --json tagName -q 'map(.tagName | select(test("^v4\\.")))[0]')
+          gh release download -R mikefarah/yq "$tag" -p yq_linux_amd64 -O ~/.local/bin/yq
+          chmod u+x ~/.local/bin/yq
+          ~/.local/bin/yq -V
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check release target tuples
+        run: |
+          targets=$(yq -ro json '.jobs.config.steps[] | select(.id == "strategy_matrix").run' ./.github/workflows/build_and_deploy.yml)
+          targets=$(sed -n 's/^ \+"target": \(.*\),$/\1/p' <<< "$targets")
+          targets=$(jq -sr sort[] <<< "$targets")
+
+          diff -u <(cat <<< "$targets") <(yq -ro json '.graph.targets | map(.triple) | sort[]' ./deny.toml)
+          for about_toml in ./crates/*/about.toml; do
+            diff -u <(cat <<< "$targets") <(yq -ro json '.targets | sort[]' "$about_toml")
+          done

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -1,6 +1,7 @@
 # 依存ライブラリのライセンスを確認する。
 #
-# `advisories`以外についてcargo-denyを実行する。
+# `advisories`以外についてのcargo-denyと、cargo-aboutを実行する。
+# cargo-aboutは`accepted`のチェックのため。
 
 name: licenses
 
@@ -20,3 +21,8 @@ jobs:
         uses: ./.github/actions/install-cargo-deny
       - name: cargo-deny
         run: cargo deny --all-features check -s bans licenses sources
+      - name: cargo-about
+        run: |
+          for about_toml in ./crates/*/about.toml; do
+            cargo about generate /dev/null --manifest-path "${about_toml/about.toml/Cargo.toml}" > /dev/null
+          done

--- a/crates/downloader/about.toml
+++ b/crates/downloader/about.toml
@@ -1,0 +1,34 @@
+# `accepted`のチェックのためだけにcargo-aboutを使っている。
+
+accepted = [
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC0-1.0",
+    "ISC",
+    "LGPL-3.0", # https://github.com/sharkdp/bat/issues/792#issuecomment-570074671
+    "MIT",
+    "MPL-2.0",
+    "OpenSSL",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+]
+targets = [
+    "x86_64-pc-windows-msvc",
+    "i686-pc-windows-msvc",
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "aarch64-linux-android",
+    "x86_64-linux-android",
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-apple-ios-sim",
+    "x86_64-apple-ios",
+]
+ignore-build-dependencies = true
+ignore-dev-dependencies = true
+no-clearly-defined = true # https://github.com/EmbarkStudios/cargo-about/issues/218
+workarounds = [
+    "ring",
+]

--- a/crates/voicevox_core/about.toml
+++ b/crates/voicevox_core/about.toml
@@ -1,0 +1,25 @@
+# `accepted`のチェックのためだけにcargo-aboutを使っている。
+
+accepted = [
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "MIT",
+    "Unicode-DFS-2016",
+    "Zlib",
+]
+targets = [
+    "x86_64-pc-windows-msvc",
+    "i686-pc-windows-msvc",
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "aarch64-linux-android",
+    "x86_64-linux-android",
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-apple-ios-sim",
+    "x86_64-apple-ios",
+]
+ignore-build-dependencies = true
+ignore-dev-dependencies = true
+no-clearly-defined = true # https://github.com/EmbarkStudios/cargo-about/issues/218

--- a/crates/voicevox_core_c_api/about.toml
+++ b/crates/voicevox_core_c_api/about.toml
@@ -1,0 +1,25 @@
+# `accepted`のチェックのためだけにcargo-aboutを使っている。
+
+accepted = [
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "MIT",
+    "Unicode-DFS-2016",
+    "Zlib",
+]
+targets = [
+    "x86_64-pc-windows-msvc",
+    "i686-pc-windows-msvc",
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "aarch64-linux-android",
+    "x86_64-linux-android",
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-apple-ios-sim",
+    "x86_64-apple-ios",
+]
+ignore-build-dependencies = true
+ignore-dev-dependencies = true
+no-clearly-defined = true # https://github.com/EmbarkStudios/cargo-about/issues/218

--- a/crates/voicevox_core_java_api/about.toml
+++ b/crates/voicevox_core_java_api/about.toml
@@ -1,0 +1,25 @@
+# `accepted`のチェックのためだけにcargo-aboutを使っている。
+
+accepted = [
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "MIT",
+    "Unicode-DFS-2016",
+    "Zlib",
+]
+targets = [
+    "x86_64-pc-windows-msvc",
+    "i686-pc-windows-msvc",
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "aarch64-linux-android",
+    "x86_64-linux-android",
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-apple-ios-sim",
+    "x86_64-apple-ios",
+]
+ignore-build-dependencies = true
+ignore-dev-dependencies = true
+no-clearly-defined = true # https://github.com/EmbarkStudios/cargo-about/issues/218

--- a/crates/voicevox_core_python_api/about.toml
+++ b/crates/voicevox_core_python_api/about.toml
@@ -1,0 +1,26 @@
+# `accepted`のチェックのためだけにcargo-aboutを使っている。
+
+accepted = [
+    "Apache-2.0 WITH LLVM-exception",
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "MIT",
+    "Unicode-DFS-2016",
+    "Zlib",
+]
+targets = [
+    "x86_64-pc-windows-msvc",
+    "i686-pc-windows-msvc",
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "aarch64-linux-android",
+    "x86_64-linux-android",
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-apple-ios-sim",
+    "x86_64-apple-ios",
+]
+ignore-build-dependencies = true
+ignore-dev-dependencies = true
+no-clearly-defined = true # https://github.com/EmbarkStudios/cargo-about/issues/218

--- a/deny.toml
+++ b/deny.toml
@@ -20,6 +20,8 @@ multiple-versions = "allow"
  # deny build scripts that are not listed in `bypass` (except `typenum`. see the fixme)
 allow-build-scripts = [
     # FIXME: build/main.rsのような場所に置かれていると駄目なのか、`bypass`からは認識してくれない
+    # SHA256: 050585225b92ce395bb32634fd8d3e7b6111ab66308f86940aea800b1ea86230
+    { name = "bat", version = "0.25" }, # https://docs.rs/crate/bat/0.25.0/source/build/main.rs
     # SHA256: b4dd86261a70df757efa53f06ce7543a4dc9c51178b9b023c92069fddee97a29
     { name = "typenum", version = "1" }, # https://docs.rs/crate/typenum/1.15.0/source/build/main.rs
 ]
@@ -36,9 +38,8 @@ bypass = [
     { name = "cbindgen", version = "0.27", build-script = "f0fa57ad2c0dca5855cc2636a2e95acbadb52fa887609216022bdf71ed996dec" }, # https://docs.rs/crate/cbindgen/0.27.0/source/build.rs
     { name = "crc32fast", version = "1", build-script = "4ccc50c3da67eb27f0b622440d2b7aee2f73fa9c71884571f3c041122231d105" }, # https://docs.rs/crate/crc32fast/1.3.2/source/build.rs
     { name = "crossbeam-epoch", version = "0.9", build-script = "901be3c21843440be5c456ff049f57f72ee5ec365918a772ad2a4751e52f69c5" }, # https://docs.rs/crate/crossbeam-epoch/0.9.13/source/build.rs
-    { name = "crossbeam-utils", version = "0.8", build-script = "4859f9c926c230023e861bf01c4b225b460035faf8cf6240108530efedbb747f" }, # https://docs.rs/crate/crossbeam-utils/0.8.2/source/build.rs
+    { name = "crossbeam-utils", version = "0.8", build-script = "7a7f9e56ea7fb4f78c4e532b84b9d27be719d600e85eaeb3a2f4b79a4f0b419c" }, # https://docs.rs/crate/crossbeam-utils/0.8.21/source/build.rs
     { name = "doc-comment", version = "0.3", build-script = "a342cd0a760b7e04b13406c5de82a9b6b39d9b8495a274c2f78d56d676aeca3a" }, # https://docs.rs/crate/doc-comment/0.3.3/source/build.rs
-    { name = "encoding_rs", version = "0.8", build-script = "9276ee24ef71433d46323c15296b3fbbb29c0b37c4b1ca45416587f14ba8e777" }, # https://docs.rs/crate/encoding_rs/0.8.31/source/build.rs
     { name = "eyre", version = "0.6", build-script = "fbd0d04cc64884da6b65ad460084ad49e56f8a14fba24a256e161cb18b15441c" }, # https://docs.rs/crate/eyre/0.6.12/source/build.rs
     { name = "fs-err", version = "2", build-script = "f1d5a299d68f91e26fbe9dd642dfcd00e122ec9cb999d4a4b38c6d7200fb9763" }, # https://docs.rs/crate/fs-err/2.11.0/source/build.rs
     { name = "generic-array", version = "0.14", build-script = "08fa30c4a2c1ad24fe5f987e721dfb20131f45ea5b5dc3e836dcf88a8e33248c" }, # https://docs.rs/crate/generic-array/0.14.6/source/build.rs
@@ -72,6 +73,7 @@ bypass = [
     { name = "semver", version = "1", build-script = "eedfc19afa205955347175916974cdad121b55cb940e40c61931e5e7629f0e65" }, # https://docs.rs/crate/semver/1.0.14/source/build.rs
     { name = "serde", version = "1", build-script = "a98eaa82c783fdb4169d1646c06028ec5cb82937d39ee127ec8ed33651d2f238" }, # https://docs.rs/crate/serde/1.0.210/source/build.rs
     { name = "serde_json", version = "1", build-script = "1630d0bbfc936b0975d840cec5cfb5910d861b6afeeeeabe11000a2c202d571d" }, # https://docs.rs/crate/serde_json/1.0.128/source/build.rs
+    { name = "signal-hook", version = "0.3", build-script = "3a95a69d2921f1c28922a141a671e23a061f358b6d831350043003e13ef96463" }, # https://docs.rs/crate/signal-hook/0.3.17/source/build.rs
     { name = "slab", version = "0.4", build-script = "2c008232a3ae7c83c166f61c2942314717976776a4dba38e9063cd8e57a1b9bd" }, # https://docs.rs/crate/slab/0.4.7/source/build.rs
     { name = "syn", version = "1", build-script = "b815649fd2929d3debd93a58f5da2fb8eba506047a6a5ba538347305828a87b0" }, # https://docs.rs/crate/syn/1.0.102/source/build.rs
     { name = "target-lexicon", version = "0.12", build-script = "4716b4f955c7a4cb39cb3b7521c1745d5110c1cbd1e054bca906e37f5e974675" }, # https://docs.rs/crate/target-lexicon/0.12.4/source/build.rs
@@ -159,6 +161,7 @@ allow = [
     "BSD-3-Clause",
     "CC0-1.0",
     "ISC",
+    "LGPL-3.0", # ライブラリ層に混入しないことをcargo-aboutで担保
     "MIT",
     "MPL-2.0",
     "OpenSSL",


### PR DESCRIPTION
## 内容

#1006 で対応し忘れたdeny.tomlを直す。

#1009 については**deny.tomlとしては`LGPL-3.0`を許容してしまい、ライブラリにLGPLが入っていないかどうかはcargo-aboutで担保する**という方向にする。

See-also: https://embarkstudios.github.io/cargo-about/cli/generate/config.html#the-accepted-field

## 関連 Issue

Fixes: #1009

## その他
