### PR TITLE
feat!: ユーザー辞書単語のJSON表現をENGINEと同じにする

### DIFF
--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/UserDictWord.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/UserDictWord.java
@@ -1,14 +1,5 @@
 package jp.hiroshiba.voicevoxcore;
 
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonPrimitive;
-import com.google.gson.JsonSerializationContext;
-import com.google.gson.JsonSerializer;
-import com.google.gson.annotations.Expose;
-import com.google.gson.annotations.SerializedName;
 import jakarta.annotation.Nonnull;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -21,35 +12,22 @@ import jakarta.validation.constraints.Min;
  */
 public class UserDictWord {
   /** 単語の表層形。 */
-  @SerializedName("surface")
-  @Expose
-  @Nonnull
-  public String surface;
+  @Nonnull public String surface;
 
   /** 単語の発音。 発音として有効なカタカナである必要がある。 */
-  @SerializedName("pronunciation")
-  @Expose
-  @Nonnull
-  public String pronunciation;
+  @Nonnull public String pronunciation;
 
   /**
    * 単語の種類。
    *
    * @see Type
    */
-  @SerializedName("word_type")
-  @Expose
-  @Nonnull
-  public Type wordType;
+  @Nonnull public Type wordType;
 
   /** アクセント型。 音が下がる場所を指す。 */
-  @SerializedName("accent_type")
-  @Expose
   public int accentType;
 
   /** 単語の優先度。 0から10までの整数。 数字が大きいほど優先度が高くなる。 1から9までの値を指定することを推奨。 */
-  @SerializedName("priority")
-  @Expose
   @Min(0)
   @Max(10)
   public int priority;
@@ -131,41 +109,6 @@ public class UserDictWord {
 
     /** 語尾。 */
     public static final Type SUFFIX = new Type("SUFFIX");
-
-    public static final class Serializer implements JsonSerializer<Type> {
-      @Override
-      public JsonElement serialize(
-          Type src, java.lang.reflect.Type typeOfSrc, JsonSerializationContext context) {
-        return new JsonPrimitive(src.toString());
-      }
-    }
-
-    public static final class Deserializer implements JsonDeserializer<Type> {
-      @Override
-      public Type deserialize(
-          JsonElement json, java.lang.reflect.Type typeOfT, JsonDeserializationContext context)
-          throws JsonParseException {
-        String value = json.getAsString();
-        switch (value) {
-          case "PROPER_NOUN":
-            return PROPER_NOUN;
-          case "COMMON_NOUN":
-            return COMMON_NOUN;
-          case "VERB":
-            return VERB;
-          case "ADJECTIVE":
-            return ADJECTIVE;
-          case "SUFFIX":
-            return SUFFIX;
-          default:
-            throw new JsonParseException(
-                String.format(
-                    "Invalid variant `%s`, expected one of "
-                        + "`PROPER_NOUN`, `COMMON_NOUN`, `VERB`, `ADJECTIVE`, `SUFFIX`",
-                    value));
-        }
-      }
-    }
 
     private final String identifier;
 

--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/blocking/UserDict.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/blocking/UserDict.java
@@ -1,8 +1,5 @@
 package jp.hiroshiba.voicevoxcore.blocking;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.internal.LinkedTreeMap;
 import jakarta.annotation.Nonnull;
 import java.io.File;
 import java.nio.file.Path;
@@ -38,12 +35,7 @@ public class UserDict {
    */
   @Nonnull
   public String addWord(UserDictWord word) {
-    GsonBuilder gsonBuilder = new GsonBuilder();
-    gsonBuilder.registerTypeAdapter(UserDictWord.Type.class, new UserDictWord.Type.Serializer());
-    Gson gson = gsonBuilder.create();
-    String wordJson = gson.toJson(word);
-
-    return rsAddWord(wordJson);
+    return rsAddWord(word);
   }
 
   /**
@@ -53,12 +45,7 @@ public class UserDict {
    * @param word 新しい単語のデータ。
    */
   public void updateWord(String uuid, UserDictWord word) {
-    GsonBuilder gsonBuilder = new GsonBuilder();
-    gsonBuilder.registerTypeAdapter(UserDictWord.Type.class, new UserDictWord.Type.Serializer());
-    Gson gson = gsonBuilder.create();
-    String wordJson = gson.toJson(word);
-
-    rsUpdateWord(uuid, wordJson);
+    rsUpdateWord(uuid, word);
   }
 
   /**
@@ -146,34 +133,15 @@ public class UserDict {
    */
   @Nonnull
   public HashMap<String, UserDictWord> toHashMap() {
-    String json = rsGetWords();
-    GsonBuilder gsonBuilder = new GsonBuilder();
-    gsonBuilder.registerTypeAdapter(UserDictWord.Type.class, new UserDictWord.Type.Deserializer());
-    Gson gson = gsonBuilder.create();
-    @SuppressWarnings("unchecked")
-    HashMap<String, LinkedTreeMap<String, ?>> rawWords = gson.fromJson(json, HashMap.class);
-    if (rawWords == null) {
-      throw new NullPointerException("words");
-    }
-    HashMap<String, UserDictWord> words = new HashMap<>();
-    rawWords.forEach(
-        (uuid, rawWord) -> {
-          UserDictWord word = gson.fromJson(gson.toJson(rawWord), UserDictWord.class);
-          if (word == null) {
-            throw new NullPointerException("word");
-          }
-          words.put(uuid, word);
-        });
-
-    return words;
+    return rsToHashMap();
   }
 
   private native void rsNew();
 
   @Nonnull
-  private native String rsAddWord(String word);
+  private native String rsAddWord(UserDictWord word);
 
-  private native void rsUpdateWord(String uuid, String word);
+  private native void rsUpdateWord(String uuid, UserDictWord word);
 
   private native void rsRemoveWord(String uuid);
 
@@ -184,7 +152,7 @@ public class UserDict {
   private native void rsSave(String path) throws SaveUserDictException;
 
   @Nonnull
-  private native String rsGetWords();
+  private native HashMap<String, UserDictWord> rsToHashMap();
 
   private native void rsDrop();
 }

--- a/crates/voicevox_core_java_api/src/common.rs
+++ b/crates/voicevox_core_java_api/src/common.rs
@@ -36,9 +36,9 @@ macro_rules! static_field {
     };
 }
 
-pub(crate) fn throw_if_err<T, F>(mut env: JNIEnv<'_>, fallback: T, inner: F) -> T
+pub(crate) fn throw_if_err<'local, T, F>(mut env: JNIEnv<'local>, fallback: T, inner: F) -> T
 where
-    F: FnOnce(&mut JNIEnv<'_>) -> Result<T, JavaApiError>,
+    F: FnOnce(&mut JNIEnv<'local>) -> Result<T, JavaApiError>,
 {
     match inner(&mut env) {
         Ok(value) => value as _,
@@ -167,7 +167,7 @@ where
     }
 }
 
-type JavaApiResult<T> = Result<T, JavaApiError>;
+pub(crate) type JavaApiResult<T> = Result<T, JavaApiError>;
 
 #[derive(From, Debug)]
 pub(crate) enum JavaApiError {

--- a/crates/voicevox_core_python_api/python/test/test_asyncio_user_dict_manipulate.py
+++ b/crates/voicevox_core_python_api/python/test/test_asyncio_user_dict_manipulate.py
@@ -79,7 +79,7 @@ async def test_user_dict_load() -> None:
     assert uuid_c in dict_a.to_dict()
 
     # 単語のバリデーション
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(voicevox_core.InvalidWordError):
         dict_a.add_word(
             voicevox_core.UserDictWord(
                 surface="",

--- a/crates/voicevox_core_python_api/python/test/test_blocking_user_dict_manipulate.py
+++ b/crates/voicevox_core_python_api/python/test/test_blocking_user_dict_manipulate.py
@@ -10,7 +10,6 @@ import os
 import tempfile
 from uuid import UUID
 
-import pydantic
 import pytest
 import voicevox_core
 
@@ -78,7 +77,7 @@ def test_user_dict_load() -> None:
     assert uuid_c in dict_a.to_dict()
 
     # 単語のバリデーション
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(voicevox_core.InvalidWordError):
         dict_a.add_word(
             voicevox_core.UserDictWord(
                 surface="",

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/__init__.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/__init__.pyi
@@ -1,3 +1,8 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from voicevox_core import UserDictWord
+
 __version__: str
 
 class NotLoadedOpenjtalkDictError(Exception):
@@ -100,7 +105,7 @@ class InvalidWordError(ValueError):
 
     ...
 
-def _validate_pronunciation(pronunciation: str) -> None: ...
+def _validate_user_dict_word(word: UserDictWord) -> None: ...
 def _to_zenkaku(text: str) -> str: ...
 def wav_from_s16le(pcm: bytes, sampling_rate: int, is_stereo: bool) -> bytes:
     """

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 mod convert;
-use self::convert::{from_utf8_path, VoicevoxCoreResultExt as _};
+use self::convert::from_utf8_path;
 use easy_ext::ext;
 use log::{debug, warn};
 use macros::pyproject_project_version;
@@ -19,7 +19,7 @@ use pyo3::{
     exceptions::{PyException, PyKeyError, PyValueError},
     pyfunction, pymodule,
     types::{PyBytes, PyList, PyModule},
-    wrap_pyfunction, Py, PyObject, PyResult, PyTypeInfo, Python,
+    wrap_pyfunction, Py, PyAny, PyObject, PyResult, PyTypeInfo, Python,
 };
 use voicevox_core::__internal::interop::raii::MaybeClosed;
 
@@ -29,7 +29,7 @@ fn rust(py: Python<'_>, module: &PyModule) -> PyResult<()> {
     pyo3_log::init();
 
     module.add("__version__", pyproject_project_version!())?;
-    module.add_wrapped(wrap_pyfunction!(_validate_pronunciation))?;
+    module.add_wrapped(wrap_pyfunction!(_validate_user_dict_word))?;
     module.add_wrapped(wrap_pyfunction!(_to_zenkaku))?;
     module.add_wrapped(wrap_pyfunction!(wav_from_s16le))?;
 
@@ -243,8 +243,8 @@ struct VoiceModelFilePyFields {
 }
 
 #[pyfunction]
-fn _validate_pronunciation(pronunciation: &str, py: Python<'_>) -> PyResult<()> {
-    voicevox_core::__internal::validate_pronunciation(pronunciation).into_py_result(py)
+fn _validate_user_dict_word(ob: &PyAny) -> PyResult<()> {
+    convert::to_rust_user_dict_word(ob).map(|_| ())
 }
 
 #[pyfunction]


### PR DESCRIPTION
## 内容

`UserDictWord`の**シリアライズ形式だけを**ENGINEと同じにする。

COREで`UserDict.save`したユーザー辞書をENGINEで`/import_user_dict`、およびENGINEで`/user_dict`でダンプしたものをCOREで`UserDict.load`できることを確認。

`UserDictWord`として編集できる部分以外、例えば`inflectional_type`などをJSON上で編集するとエラーになるようにする。また`word_type`のデシリアライズについては、`PartOfSpeechDetail`を線形探索することで判別する。

BREAKING-CHANGE: シリアライズ形式がENGINEと同じになる。
BREAKING-CHANGE: Pythonにおいて、Pydanticが外される (#960 の部分達成)。
BREAKING-CHANGE: Pythonにおいて、dataclassとして`frozen`となる。
BREAKING-CHANGE: Pythonにおいて、コンストラクト時点で各種バリデートがされるように。
BREAKING-CHANGE: Javaにおいて、GSONが外される。

## 関連 Issue

See-also: #946

## その他