### PR TITLE
docs: vvm周りのリンクを更新

### DIFF
--- a/docs/guide/dev/vvm.md
+++ b/docs/guide/dev/vvm.md
@@ -15,7 +15,7 @@
 model は `.onnx` や `.bin` など様々ある。例えば `sample.vvm` は `predict_duration.onnx` / `predict_intonation.onnx` / `decode.onnx` を含む。  
 
 VOICEVOX OSS が提供する VVM には `sample.vvm` がある（ビルドを行うと `crates/test_util/data/model/sample.vvm` が生成される）。  
-製品版 VOICEVOX で利用される VVM は [こちらのレポジトリ](https://github.com/VOICEVOX/voicevox_fat_resource/tree/main/core/model) で確認できる。  
+製品版 VOICEVOX で利用される VVM は [こちらのレポジトリ](https://github.com/VOICEVOX/voicevox_vvm/tree/main/vvms) で確認できる。  
 
 ## マニフェストファイル
 

--- a/docs/guide/user/usage.md
+++ b/docs/guide/user/usage.md
@@ -86,7 +86,7 @@ AIエンジンの`Onnxruntime`のインスタンスと、辞書などを取り�
 
 ### 2. 音声モデルの読み込み
 
-VVM ファイルから`VoiceModelFile`インスタンスを作成し、`Synthesizer`に読み込ませます。その VVM ファイルにどの声が含まれているかは`VoiceModelFile`の`.metas`や[音声モデルと声の対応表](https://github.com/VOICEVOX/voicevox_fat_resource/blob/main/core/model/README.md#%E9%9F%B3%E5%A3%B0%E3%83%A2%E3%83%87%E3%83%ABvvm%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E3%81%A8%E5%A3%B0%E3%82%AD%E3%83%A3%E3%83%A9%E3%82%AF%E3%82%BF%E3%83%BC%E3%82%B9%E3%82%BF%E3%82%A4%E3%83%AB%E5%90%8D%E3%81%A8%E3%82%B9%E3%82%BF%E3%82%A4%E3%83%AB-id-%E3%81%AE%E5%AF%BE%E5%BF%9C%E8%A1%A8)で確認できます。
+VVM ファイルから`VoiceModelFile`インスタンスを作成し、`Synthesizer`に読み込ませます。その VVM ファイルにどの声が含まれているかは`VoiceModelFile`の`.metas`や[音声モデルと声の対応表](https://github.com/VOICEVOX/voicevox_vvm/blob/main/README.md#%E9%9F%B3%E5%A3%B0%E3%83%A2%E3%83%87%E3%83%ABvvm%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E3%81%A8%E5%A3%B0%E3%82%AD%E3%83%A3%E3%83%A9%E3%82%AF%E3%82%BF%E3%83%BC%E3%82%B9%E3%82%BF%E3%82%A4%E3%83%AB%E5%90%8D%E3%81%A8%E3%82%B9%E3%82%BF%E3%82%A4%E3%83%AB-id-%E3%81%AE%E5%AF%BE%E5%BF%9C%E8%A1%A8)で確認できます。
 
 ```python
 with VoiceModelFile.open("models/vvms/0.vvm") as model:


### PR DESCRIPTION
## 内容
voicevox_fat_resourceを参照していた部分をvoicevox_vvmのリンクに置き換えました。

https://github.com/VOICEVOX/voicevox_core/issues/922
こちらのissueの議論の流れを一通り読ませていただいて、現在VVMはvoicevox_fat_resourceリポジトリではなく、voicevox_vvmリポジトリで管理されることになったという認識です。
よってドキュメントのリンクなども更新しておいたほうがよいのではないかと思いPR作成いたしました。

## 関連 Issue
https://github.com/VOICEVOX/voicevox_core/issues/922

## その他
