### PR TITLE
docs: readmeから"ダウンローダーの実行"の節を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,15 +169,6 @@ sed 's:^//\(#define VOICEVOX_LOAD_ONNXRUNTIME\)$:\1:' \
 cargo test -p voicevox_core_c_api --features load-onnxruntime -- --include-ignored
 ```
 
-## ダウンローダーの実行
-
-```bash
-cargo run -p downloader
-
-# ヘルプを表示
-cargo run -p downloader -- -h
-```
-
 ## ヘッダファイルの更新
 
 ```bash


### PR DESCRIPTION
## 内容

今となっては意図の把握も難しい箇所になっているため。

#1021 をやる前に。

## 関連 Issue

## その他
