### PR TITLE
feat!: デフォルトで`RunAsync`ではなく`Run`を使う

### DIFF
--- a/crates/voicevox_core/src/__internal/interop.rs
+++ b/crates/voicevox_core/src/__internal/interop.rs
@@ -4,8 +4,8 @@ pub use crate::{
     convert::ToJsonValue,
     metas::merge as merge_metas,
     synthesizer::{
-        blocking::PerformInference, DEFAULT_ASYNC_CANCELLABLE, DEFAULT_CPU_NUM_THREADS,
-        DEFAULT_ENABLE_INTERROGATIVE_UPSPEAK, MARGIN,
+        blocking::PerformInference, DEFAULT_CPU_NUM_THREADS, DEFAULT_ENABLE_INTERROGATIVE_UPSPEAK,
+        DEFAULT_HEAVY_INFERENCE_CANCELLABLE, MARGIN,
     },
     user_dict::{DEFAULT_PRIORITY, DEFAULT_WORD_TYPE},
 };

--- a/crates/voicevox_core/src/__internal/interop.rs
+++ b/crates/voicevox_core/src/__internal/interop.rs
@@ -4,8 +4,8 @@ pub use crate::{
     convert::ToJsonValue,
     metas::merge as merge_metas,
     synthesizer::{
-        blocking::PerformInference, DEFAULT_CPU_NUM_THREADS, DEFAULT_ENABLE_INTERROGATIVE_UPSPEAK,
-        MARGIN,
+        blocking::PerformInference, DEFAULT_ASYNC_CANCELLABLE, DEFAULT_CPU_NUM_THREADS,
+        DEFAULT_ENABLE_INTERROGATIVE_UPSPEAK, MARGIN,
     },
     user_dict::{DEFAULT_PRIORITY, DEFAULT_WORD_TYPE},
 };

--- a/crates/voicevox_core/src/infer/session_set.rs
+++ b/crates/voicevox_core/src/infer/session_set.rs
@@ -92,13 +92,11 @@ impl<R: InferenceRuntime, I: InferenceInputSignature> InferenceSessionCell<R, I>
     pub(crate) async fn run<A: super::AsyncExt>(
         self,
         input: I,
-        async_cancellable: bool,
+        cancellable: A::Cancellable,
     ) -> crate::Result<<I::Signature as InferenceSignature>::Output> {
         async {
             let ctx = input.make_run_context::<R>(self.inner.clone())?;
-            A::run_session::<R>(ctx, async_cancellable)
-                .await?
-                .try_into()
+            A::run_session::<R>(ctx, cancellable).await?.try_into()
         }
         .await
         .map_err(ErrorRepr::RunModel)

--- a/crates/voicevox_core/src/infer/session_set.rs
+++ b/crates/voicevox_core/src/infer/session_set.rs
@@ -92,10 +92,13 @@ impl<R: InferenceRuntime, I: InferenceInputSignature> InferenceSessionCell<R, I>
     pub(crate) async fn run<A: super::AsyncExt>(
         self,
         input: I,
+        async_cancellable: bool,
     ) -> crate::Result<<I::Signature as InferenceSignature>::Output> {
         async {
             let ctx = input.make_run_context::<R>(self.inner.clone())?;
-            A::run_session::<R>(ctx).await?.try_into()
+            A::run_session::<R>(ctx, async_cancellable)
+                .await?
+                .try_into()
         }
         .await
         .map_err(ErrorRepr::RunModel)

--- a/crates/voicevox_core/src/status.rs
+++ b/crates/voicevox_core/src/status.rs
@@ -119,7 +119,7 @@ impl<R: InferenceRuntime> Status<R> {
         &self,
         model_id: VoiceModelId,
         input: I,
-        async_cancellable: bool,
+        cancellable: A::Cancellable,
     ) -> Result<<I::Signature as InferenceSignature>::Output>
     where
         A: infer::AsyncExt,
@@ -127,7 +127,7 @@ impl<R: InferenceRuntime> Status<R> {
         <I::Signature as InferenceSignature>::Domain: InferenceDomainExt,
     {
         let sess = self.loaded_models.lock().unwrap().get(model_id);
-        sess.run::<A>(input, async_cancellable).await
+        sess.run::<A>(input, cancellable).await
     }
 }
 

--- a/crates/voicevox_core/src/status.rs
+++ b/crates/voicevox_core/src/status.rs
@@ -119,6 +119,7 @@ impl<R: InferenceRuntime> Status<R> {
         &self,
         model_id: VoiceModelId,
         input: I,
+        async_cancellable: bool,
     ) -> Result<<I::Signature as InferenceSignature>::Output>
     where
         A: infer::AsyncExt,
@@ -126,7 +127,7 @@ impl<R: InferenceRuntime> Status<R> {
         <I::Signature as InferenceSignature>::Domain: InferenceDomainExt,
     {
         let sess = self.loaded_models.lock().unwrap().get(model_id);
-        sess.run::<A>(input).await
+        sess.run::<A>(input, async_cancellable).await
     }
 }
 

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/asyncio.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/asyncio.pyi
@@ -380,9 +380,13 @@ class Synthesizer:
         style_id: StyleId | int,
         *,
         enable_interrogative_upspeak: bool = True,
+        cancellable: bool = False,
     ) -> bytes:
         """
         :class:`AudioQuery` から音声合成する。
+
+        ``cancellable``
+        を有効化しない限り、非同期タスクとしてキャンセルしても終わるまで停止しない。
 
         Parameters
         ----------
@@ -392,6 +396,9 @@ class Synthesizer:
             スタイルID。
         enable_interrogative_upspeak
             疑問文の調整を有効にするかどうか。
+        cancellable
+            音声モデルの実行をキャンセル可能にするかどうか。このオプションを有効にすると、負荷がかかっている状況下でハングする可能性がある。そのためデフォルトでは無効化されている。
+            `VOICEVOX/voicevox_core#968 <https://github.com/VOICEVOX/voicevox_core/issues/968>`_ を参照。
 
         Returns
         -------
@@ -404,9 +411,13 @@ class Synthesizer:
         style_id: StyleId | int,
         *,
         enable_interrogative_upspeak: bool = True,
+        cancellable: bool = False,
     ) -> bytes:
         """
         AquesTalk風記法から音声合成を行う。
+
+        ``cancellable``
+        を有効化しない限り、非同期タスクとしてキャンセルしても終わるまで停止しない。
 
         Parameters
         ----------
@@ -416,6 +427,9 @@ class Synthesizer:
             スタイルID。
         enable_interrogative_upspeak
             疑問文の調整を有効にするかどうか。
+        cancellable
+            音声モデルの実行をキャンセル可能にするかどうか。このオプションを有効にすると、負荷がかかっている状況下でハングする可能性がある。そのためデフォルトでは無効化されている。
+            `VOICEVOX/voicevox_core#968 <https://github.com/VOICEVOX/voicevox_core/issues/968>`_ を参照。
         """
         ...
     async def tts(
@@ -424,9 +438,13 @@ class Synthesizer:
         style_id: StyleId | int,
         *,
         enable_interrogative_upspeak: bool = True,
+        cancellable: bool = False,
     ) -> bytes:
         """
         日本語のテキストから音声合成を行う。
+
+        ``cancellable``
+        を有効化しない限り、非同期タスクとしてキャンセルしても終わるまで停止しない。
 
         Parameters
         ----------
@@ -436,6 +454,9 @@ class Synthesizer:
             スタイルID。
         enable_interrogative_upspeak
             疑問文の調整を有効にするかどうか。
+        cancellable
+            音声モデルの実行をキャンセル可能にするかどうか。このオプションを有効にすると、負荷がかかっている状況下でハングする可能性がある。そのためデフォルトでは無効化されている。
+            `VOICEVOX/voicevox_core#968 <https://github.com/VOICEVOX/voicevox_core/issues/968>`_ を参照。
 
         Returns
         -------

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -1332,7 +1332,7 @@ mod asyncio {
             *,
             enable_interrogative_upspeak =
                 voicevox_core::__internal::interop::DEFAULT_ENABLE_INTERROGATIVE_UPSPEAK,
-            cancellable = voicevox_core::__internal::interop::DEFAULT_ASYNC_CANCELLABLE,
+            cancellable = voicevox_core::__internal::interop::DEFAULT_HEAVY_INFERENCE_CANCELLABLE,
         ))]
         async fn synthesis(
             &self,
@@ -1358,7 +1358,7 @@ mod asyncio {
             *,
             enable_interrogative_upspeak =
                 voicevox_core::__internal::interop::DEFAULT_ENABLE_INTERROGATIVE_UPSPEAK,
-            cancellable = voicevox_core::__internal::interop::DEFAULT_ASYNC_CANCELLABLE,
+            cancellable = voicevox_core::__internal::interop::DEFAULT_HEAVY_INFERENCE_CANCELLABLE,
         ))]
         async fn tts_from_kana(
             &self,
@@ -1385,7 +1385,7 @@ mod asyncio {
             *,
             enable_interrogative_upspeak =
                 voicevox_core::__internal::interop::DEFAULT_ENABLE_INTERROGATIVE_UPSPEAK,
-            cancellable = voicevox_core::__internal::interop::DEFAULT_ASYNC_CANCELLABLE,
+            cancellable = voicevox_core::__internal::interop::DEFAULT_HEAVY_INFERENCE_CANCELLABLE,
         ))]
         async fn tts(
             &self,

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -1332,18 +1332,21 @@ mod asyncio {
             *,
             enable_interrogative_upspeak =
                 voicevox_core::__internal::interop::DEFAULT_ENABLE_INTERROGATIVE_UPSPEAK,
+            cancellable = voicevox_core::__internal::interop::DEFAULT_ASYNC_CANCELLABLE,
         ))]
         async fn synthesis(
             &self,
             #[pyo3(from_py_with = "crate::convert::from_dataclass")] audio_query: AudioQuery,
             style_id: u32,
             enable_interrogative_upspeak: bool,
+            cancellable: bool,
         ) -> PyResult<Vec<u8>> {
             let synthesizer = self.synthesizer.clone();
             let wav = synthesizer
                 .read()?
                 .synthesis(&audio_query, StyleId::new(style_id))
                 .enable_interrogative_upspeak(enable_interrogative_upspeak)
+                .cancellable(cancellable)
                 .perform()
                 .await;
             Python::with_gil(|py| wav.into_py_result(py))
@@ -1355,12 +1358,14 @@ mod asyncio {
             *,
             enable_interrogative_upspeak =
                 voicevox_core::__internal::interop::DEFAULT_ENABLE_INTERROGATIVE_UPSPEAK,
+            cancellable = voicevox_core::__internal::interop::DEFAULT_ASYNC_CANCELLABLE,
         ))]
         async fn tts_from_kana(
             &self,
             kana: String,
             style_id: u32,
             enable_interrogative_upspeak: bool,
+            cancellable: bool,
         ) -> PyResult<Vec<u8>> {
             let style_id = StyleId::new(style_id);
             let synthesizer = self.synthesizer.clone();
@@ -1368,6 +1373,7 @@ mod asyncio {
                 .read()?
                 .tts_from_kana(&kana, style_id)
                 .enable_interrogative_upspeak(enable_interrogative_upspeak)
+                .cancellable(cancellable)
                 .perform()
                 .await;
             Python::with_gil(|py| wav.into_py_result(py))
@@ -1379,12 +1385,14 @@ mod asyncio {
             *,
             enable_interrogative_upspeak =
                 voicevox_core::__internal::interop::DEFAULT_ENABLE_INTERROGATIVE_UPSPEAK,
+            cancellable = voicevox_core::__internal::interop::DEFAULT_ASYNC_CANCELLABLE,
         ))]
         async fn tts(
             &self,
             text: String,
             style_id: u32,
             enable_interrogative_upspeak: bool,
+            cancellable: bool,
         ) -> PyResult<Vec<u8>> {
             let style_id = StyleId::new(style_id);
             let synthesizer = self.synthesizer.clone();
@@ -1392,6 +1400,7 @@ mod asyncio {
                 .read()?
                 .tts(&text, style_id)
                 .enable_interrogative_upspeak(enable_interrogative_upspeak)
+                .cancellable(cancellable)
                 .perform()
                 .await;
             Python::with_gil(|py| wav.into_py_result(py))


### PR DESCRIPTION
## 内容

デフォルトで`OrtApi::RunAsync`ではなく`OrtApi::Run`を使うようにする。その代わり非同期APIにおけるdecode系の推論のみ、`cancellable`というオプションで`RunAsync`を使うようにする。predict系の推論は完全にキャンセル不可となる。

BREAKING-CHANGE: 推論の挙動の変更。

## 関連 Issue

Refs: https://github.com/VOICEVOX/voicevox_core/issues/968#issuecomment-2683857839

## その他
