### PR TITLE
feat: いくつかのAPIを露出し、「テキスト音声合成の流れ」を明確に

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4716,6 +4716,7 @@ dependencies = [
 name = "voicevox_core_python_api"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "async-lock",
  "blocking",
  "camino",

--- a/crates/voicevox_core/src/__internal/interop.rs
+++ b/crates/voicevox_core/src/__internal/interop.rs
@@ -4,7 +4,8 @@ pub use crate::{
     convert::ToJsonValue,
     metas::merge as merge_metas,
     synthesizer::{
-        blocking::PerformInference, DEFAULT_CPU_NUM_THREADS, DEFAULT_ENABLE_INTERROGATIVE_UPSPEAK,
+        blocking::PerformInference, BlockingTextAnalyzerExt, NonblockingTextAnalyzerExt,
+        DEFAULT_CPU_NUM_THREADS, DEFAULT_ENABLE_INTERROGATIVE_UPSPEAK,
         DEFAULT_HEAVY_INFERENCE_CANCELLABLE, MARGIN,
     },
     user_dict::{DEFAULT_PRIORITY, DEFAULT_WORD_TYPE},

--- a/crates/voicevox_core/src/lib.rs
+++ b/crates/voicevox_core/src/lib.rs
@@ -52,13 +52,19 @@
 //!     };
 //!
 //!     let wav3 = {
+//!         let phrases = synth.create_accent_phrases(TEXT, STYLE_ID)?;
+//!         let query = AudioQuery::from(phrases);
+//!         synth.synthesis(&query, STYLE_ID).perform()?
+//!     };
+//!
+//!     let wav4 = {
 //!         let phrases = synth.text_analyzer().analyze(TEXT)?;
 //!         let phrases = synth.replace_mora_data(&phrases, STYLE_ID)?;
 //!         let query = AudioQuery::from(phrases);
 //!         synth.synthesis(&query, STYLE_ID).perform()?
 //!     };
 //!
-//!     let wav4 = {
+//!     let wav5 = {
 //!         let phrases = synth.text_analyzer().analyze(TEXT)?;
 //!         let phrases = synth.replace_phoneme_length(&phrases, STYLE_ID)?;
 //!         let phrases = synth.replace_mora_pitch(&phrases, STYLE_ID)?;
@@ -66,7 +72,7 @@
 //!         synth.synthesis(&query, STYLE_ID).perform()?
 //!     };
 //!
-//!     assert_eq!(1, HashSet::from([wav1, wav2, wav3, wav4]).len());
+//!     assert_eq!(1, HashSet::from([wav1, wav2, wav3, wav4, wav5]).len());
 //!     Ok(())
 //! }
 //! #

--- a/crates/voicevox_core/src/lib.rs
+++ b/crates/voicevox_core/src/lib.rs
@@ -15,6 +15,72 @@
 //! https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-link-lib
 //! [`Onnxruntime`]: blocking::Onnxruntime
 //! [ONNX RuntimeのGPU機能]: https://onnxruntime.ai/docs/execution-providers/
+//!
+//! # 音声の調整
+//!
+//! ユーザーガイドの[テキスト音声合成の流れ]を参照。
+//!
+//! 以下の`wav1`から`wav4`はすべて同一となる。
+//!
+//! [テキスト音声合成の流れ]: https://github.com/VOICEVOX/voicevox_core/blob/main/docs/guide/user/tts-process.md
+//!
+//! ```
+//! use std::collections::HashSet;
+//!
+//! use voicevox_core::{
+//!     blocking::{Synthesizer, TextAnalyzer},
+//!     AudioQuery, StyleId,
+//! };
+//! #
+//! # use test_util::{ONNXRUNTIME_DYLIB_PATH, OPEN_JTALK_DIC_DIR, SAMPLE_VOICE_MODEL_FILE_PATH};
+//! # use voicevox_core::blocking::{Onnxruntime, OpenJtalk, VoiceModelFile};
+//!
+//! fn f(synth: &Synthesizer<impl TextAnalyzer>) -> anyhow::Result<()> {
+//! #    const TEXT: &str = "";
+//! #   #[cfg(any())]
+//!     const TEXT: &str = _;
+//! #
+//! #   const STYLE_ID: StyleId = StyleId(0);
+//! #   #[cfg(any())]
+//!     const STYLE_ID: StyleId = _;
+//!
+//!     let wav1 = synth.tts(TEXT, STYLE_ID).perform()?;
+//!
+//!     let wav2 = {
+//!         let query = synth.create_audio_query(TEXT, STYLE_ID)?;
+//!         synth.synthesis(&query, STYLE_ID).perform()?
+//!     };
+//!
+//!     let wav3 = {
+//!         let phrases = synth.text_analyzer().analyze(TEXT)?;
+//!         let phrases = synth.replace_mora_data(&phrases, STYLE_ID)?;
+//!         let query = AudioQuery::from(phrases);
+//!         synth.synthesis(&query, STYLE_ID).perform()?
+//!     };
+//!
+//!     let wav4 = {
+//!         let phrases = synth.text_analyzer().analyze(TEXT)?;
+//!         let phrases = synth.replace_phoneme_length(&phrases, STYLE_ID)?;
+//!         let phrases = synth.replace_mora_pitch(&phrases, STYLE_ID)?;
+//!         let query = AudioQuery::from(phrases);
+//!         synth.synthesis(&query, STYLE_ID).perform()?
+//!     };
+//!
+//!     assert_eq!(1, HashSet::from([wav1, wav2, wav3, wav4]).len());
+//!     Ok(())
+//! }
+//! #
+//! # let synth = &{
+//! #     let ort = Onnxruntime::load_once()
+//! #         .filename(ONNXRUNTIME_DYLIB_PATH)
+//! #         .perform()?;
+//! #     let ojt = OpenJtalk::new(OPEN_JTALK_DIC_DIR)?;
+//! #     Synthesizer::builder(ort).text_analyzer(ojt).build()?
+//! # };
+//! # synth.load_voice_model(&VoiceModelFile::open(SAMPLE_VOICE_MODEL_FILE_PATH)?)?;
+//! # f(synth)?;
+//! # anyhow::Ok(())
+//! ```
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 

--- a/crates/voicevox_core/src/metas.rs
+++ b/crates/voicevox_core/src/metas.rs
@@ -82,7 +82,7 @@ impl Display for CharacterVersion {
 pub type VoiceModelMeta = Vec<CharacterMeta>;
 
 /// <i>キャラクター</i>のメタ情報。
-#[derive(Deserialize, Serialize, Clone)]
+#[derive(Deserialize, Serialize, Clone, Debug)]
 #[non_exhaustive]
 pub struct CharacterMeta {
     /// キャラクター名。
@@ -142,7 +142,7 @@ impl CharacterMeta {
 }
 
 /// <i>スタイル</i>のメタ情報。
-#[derive(Deserialize, Serialize, Clone)]
+#[derive(Deserialize, Serialize, Clone, Debug)]
 #[non_exhaustive]
 pub struct StyleMeta {
     /// スタイルID。

--- a/crates/voicevox_core/src/text_analyzer.rs
+++ b/crates/voicevox_core/src/text_analyzer.rs
@@ -1,7 +1,9 @@
 pub(crate) mod blocking {
     use crate::AccentPhrase;
 
+    /// テキスト解析器。
     pub trait TextAnalyzer: Sync {
+        /// テキストを解析する。
         fn analyze(&self, text: &str) -> anyhow::Result<Vec<AccentPhrase>>;
     }
 }
@@ -11,7 +13,9 @@ pub(crate) mod nonblocking {
 
     use crate::AccentPhrase;
 
+    /// テキスト解析器。
     pub trait TextAnalyzer: Sync {
+        /// テキストを解析する。
         fn analyze(
             &self,
             text: &str,

--- a/crates/voicevox_core_c_api/include/voicevox_core.h
+++ b/crates/voicevox_core_c_api/include/voicevox_core.h
@@ -595,6 +595,24 @@ VoicevoxResultCode voicevox_open_jtalk_rc_use_user_dict(const struct OpenJtalkRc
                                                         const struct VoicevoxUserDict *user_dict);
 
 /**
+ * 日本語のテキストを解析する。
+ *
+ * 生成したJSON文字列を解放するには ::voicevox_json_free を使う。
+ *
+ * @param [in] open_jtalk Open JTalkのオブジェクト
+ * @param [in] text UTF-8の日本語テキスト
+ * @param [out] output_accent_phrases_json 生成先
+ *
+ * \orig-impl{voicevox_open_jtalk_rc_use_user_dict}
+ */
+#ifdef _WIN32
+__declspec(dllimport)
+#endif
+VoicevoxResultCode voicevox_open_jtalk_rc_analyze(const struct OpenJtalkRc *open_jtalk,
+                                                  const char *text,
+                                                  char **output_accent_phrases_json);
+
+/**
  * ::OpenJtalkRc を<b>破棄</b>(_destruct_)する。
  *
  * 破棄対象への他スレッドでのアクセスが存在する場合、それらがすべて終わるのを待ってから破棄する。
@@ -637,6 +655,27 @@ struct VoicevoxInitializeOptions voicevox_make_default_initialize_options(void);
 __declspec(dllimport)
 #endif
 const char *voicevox_get_version(void);
+
+/**
+ * AccentPhraseの配列からAudioQueryを作る。
+ *
+ * 生成したJSON文字列を解放するには ::voicevox_json_free を使う。
+ *
+ * @param [in] accent_phrases_json AccentPhraseの配列のJSON文字列
+ * @param [out] output_accent_phrases_json 生成先
+ *
+ * \safety{
+ * - `accent_phrases_json`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
+ * - `output_audio_query_json`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
+ * }
+ *
+ * \orig-impl{voicevox_audio_query_create_from_accent_phrases}
+ */
+#ifdef _WIN32
+__declspec(dllimport)
+#endif
+VoicevoxResultCode voicevox_audio_query_create_from_accent_phrases(const char *accent_phrases_json,
+                                                                   char **output_audio_query_json);
 
 /**
  * VVMファイルを開く。
@@ -923,6 +962,9 @@ VoicevoxResultCode voicevox_synthesizer_create_audio_query_from_kana(const struc
  *
  * 生成したJSON文字列を解放するには ::voicevox_json_free を使う。
  *
+ * ::voicevox_synthesizer_create_accent_phrases と ::voicevox_audio_query_create_from_accent_phrases
+ * が一体になったショートハンド。詳細は[テキスト音声合成の流れ]を参照。
+ *
  * @param [in] synthesizer 音声シンセサイザ
  * @param [in] text UTF-8の日本語テキスト
  * @param [in] style_id スタイルID
@@ -945,6 +987,8 @@ VoicevoxResultCode voicevox_synthesizer_create_audio_query_from_kana(const struc
  * }
  *
  * \orig-impl{voicevox_synthesizer_create_audio_query}
+ *
+ * [テキスト音声合成の流れ]: https://github.com/VOICEVOX/voicevox_core/blob/main/docs/guide/user/tts-process.md
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -996,6 +1040,9 @@ VoicevoxResultCode voicevox_synthesizer_create_accent_phrases_from_kana(const st
  *
  * 生成したJSON文字列を解放するには ::voicevox_json_free を使う。
  *
+ * ::voicevox_open_jtalk_rc_analyze と ::voicevox_synthesizer_replace_mora_data
+ * が一体になったショートハンド。詳細は[テキスト音声合成の流れ]を参照。
+ *
  * @param [in] synthesizer 音声シンセサイザ
  * @param [in] text UTF-8の日本語テキスト
  * @param [in] style_id スタイルID
@@ -1018,6 +1065,8 @@ VoicevoxResultCode voicevox_synthesizer_create_accent_phrases_from_kana(const st
  * }
  *
  * \orig-impl{voicevox_synthesizer_create_accent_phrases}
+ *
+ * [テキスト音声合成の流れ]: https://github.com/VOICEVOX/voicevox_core/blob/main/docs/guide/user/tts-process.md
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -1032,6 +1081,9 @@ VoicevoxResultCode voicevox_synthesizer_create_accent_phrases(const struct Voice
  *
  * 生成したJSON文字列を解放するには ::voicevox_json_free を使う。
  *
+ * ::voicevox_synthesizer_replace_phoneme_length と ::voicevox_synthesizer_replace_mora_pitch
+ * が一体になったショートハンド。詳細は[テキスト音声合成の流れ]を参照。
+ *
  * @param [in] synthesizer 音声シンセサイザ
  * @param [in] accent_phrases_json AccentPhraseの配列のJSON文字列
  * @param [in] style_id スタイルID
@@ -1045,6 +1097,8 @@ VoicevoxResultCode voicevox_synthesizer_create_accent_phrases(const struct Voice
  * }
  *
  * \orig-impl{voicevox_synthesizer_replace_mora_data}
+ *
+ * [テキスト音声合成の流れ]: https://github.com/VOICEVOX/voicevox_core/blob/main/docs/guide/user/tts-process.md
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -1199,6 +1253,9 @@ VoicevoxResultCode voicevox_synthesizer_tts_from_kana(const struct VoicevoxSynth
  *
  * 生成したWAVデータを解放するには ::voicevox_wav_free を使う。
  *
+ * ::voicevox_synthesizer_create_audio_query と ::voicevox_synthesizer_synthesis
+ * が一体になったショートハンド。詳細は[テキスト音声合成の流れ]を参照。
+ *
  * @param [in] synthesizer
  * @param [in] text UTF-8の日本語テキスト
  * @param [in] style_id スタイルID
@@ -1215,6 +1272,8 @@ VoicevoxResultCode voicevox_synthesizer_tts_from_kana(const struct VoicevoxSynth
  * }
  *
  * \orig-impl{voicevox_synthesizer_tts}
+ *
+ * [テキスト音声合成の流れ]: https://github.com/VOICEVOX/voicevox_core/blob/main/docs/guide/user/tts-process.md
  */
 #ifdef _WIN32
 __declspec(dllimport)
@@ -1233,8 +1292,10 @@ VoicevoxResultCode voicevox_synthesizer_tts(const struct VoicevoxSynthesizer *sy
  *
  * \safety{
  * - `json`は以下のAPIで得られたポインタでなくてはいけない。
+ *     - ::voicevox_audio_query_create_from_accent_phrases
  *     - ::voicevox_onnxruntime_create_supported_devices_json
  *     - ::voicevox_voice_model_file_create_metas_json
+ *     - ::voicevox_open_jtalk_rc_analyze
  *     - ::voicevox_synthesizer_create_metas_json
  *     - ::voicevox_synthesizer_create_audio_query
  *     - ::voicevox_synthesizer_create_accent_phrases

--- a/crates/voicevox_core_c_api/tests/e2e/snapshots.toml
+++ b/crates/voicevox_core_c_api/tests/e2e/snapshots.toml
@@ -228,7 +228,7 @@ stderr.unix = '''
 {timestamp}  INFO voicevox_core::synthesizer: CPUを利用します
 '''
 
-[tts_via_audio_query]
+[tts]
 output."こんにちは、音声合成の世界へようこそ".wav_length = 176172
 stderr.windows = '''
 {windows-video-cards}

--- a/crates/voicevox_core_c_api/tests/e2e/testcases.rs
+++ b/crates/voicevox_core_c_api/tests/e2e/testcases.rs
@@ -7,6 +7,6 @@ mod double_delete_voice_model_file;
 mod global_info;
 mod simple_tts;
 mod synthesizer_new_output_json;
-mod tts_via_audio_query;
+mod tts;
 mod user_dict_load;
 mod user_dict_manipulate;

--- a/crates/voicevox_core_c_api/tests/e2e/testcases/tts.rs
+++ b/crates/voicevox_core_c_api/tests/e2e/testcases/tts.rs
@@ -32,7 +32,7 @@ struct TestCase {
     text: String,
 }
 
-#[typetag::serde(name = "tts_via_audio_query")]
+#[typetag::serde(name = "tts")]
 impl assert_cdylib::TestCase for TestCase {
     unsafe fn exec(&self, lib: Library) -> anyhow::Result<()> {
         let lib = CApi::from_library(lib)?;
@@ -332,7 +332,7 @@ impl assert_cdylib::TestCase for TestCase {
     }
 }
 
-static SNAPSHOTS: LazyLock<Snapshots> = snapshots::section!(tts_via_audio_query);
+static SNAPSHOTS: LazyLock<Snapshots> = snapshots::section!(tts);
 
 #[derive(Deserialize)]
 struct Snapshots {

--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/AudioQuery.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/AudioQuery.java
@@ -1,11 +1,13 @@
 package jp.hiroshiba.voicevoxcore;
 
+import com.google.gson.Gson;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
+import jp.hiroshiba.voicevoxcore.internal.Dll;
 
 /**
  * AudioQuery（音声合成用のクエリ）。
@@ -14,6 +16,10 @@ import java.util.List;
  * target="_blank">Jacksonに切り替わる予定</a> 。
  */
 public class AudioQuery {
+  static {
+    Dll.loadLibrary();
+  }
+
   /** アクセント句の配列。 */
   @SerializedName("accent_phrases")
   @Expose
@@ -63,4 +69,17 @@ public class AudioQuery {
     this.outputSamplingRate = 24000;
     this.kana = null;
   }
+
+  public static AudioQuery fromAccentPhrases(List<AccentPhrase> accentPhrases) {
+    Gson gson = new Gson();
+    String queryJson = rsFromAccentPhrases(gson.toJson(accentPhrases));
+    AudioQuery query = gson.fromJson(queryJson, AudioQuery.class);
+    if (query == null) {
+      throw new NullPointerException();
+    }
+    return query;
+  }
+
+  @Nonnull
+  private static native String rsFromAccentPhrases(String accentPhrases);
 }

--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/blocking/OpenJtalk.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/blocking/OpenJtalk.java
@@ -1,5 +1,10 @@
 package jp.hiroshiba.voicevoxcore.blocking;
 
+import com.google.gson.Gson;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import jp.hiroshiba.voicevoxcore.AccentPhrase;
 import jp.hiroshiba.voicevoxcore.internal.Dll;
 
 /** テキスト解析機としてのOpen JTalk。 */
@@ -42,9 +47,21 @@ public class OpenJtalk {
     rsUseUserDict(userDict);
   }
 
+  public List<AccentPhrase> analyze(String text) {
+    Gson gson = new Gson();
+    String accentPhrasesJson = rsAnalyze(text);
+    AccentPhrase[] rawAccentPhrases = gson.fromJson(accentPhrasesJson, AccentPhrase[].class);
+    if (rawAccentPhrases == null) {
+      throw new NullPointerException("accent_phrases");
+    }
+    return new ArrayList<AccentPhrase>(Arrays.asList(rawAccentPhrases));
+  }
+
   private native void rsNew(String openJtalkDictDir);
 
   private native void rsUseUserDict(UserDict userDict);
+
+  private native String rsAnalyze(String text);
 
   private native void rsDrop();
 }

--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/blocking/Synthesizer.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/blocking/Synthesizer.java
@@ -6,7 +6,6 @@ import jakarta.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import jp.hiroshiba.voicevoxcore.AccelerationMode;
 import jp.hiroshiba.voicevoxcore.AccentPhrase;
@@ -28,9 +27,13 @@ public class Synthesizer {
   }
 
   private long handle;
+  @Nonnull private final Onnxruntime onnxruntime;
+  @Nonnull private final OpenJtalk openJtalk;
 
   private Synthesizer(Onnxruntime onnxruntime, OpenJtalk openJtalk, Builder builder) {
     rsNew(onnxruntime, openJtalk, builder);
+    this.onnxruntime = onnxruntime;
+    this.openJtalk = openJtalk;
   }
 
   protected void finalize() throws Throwable {
@@ -45,9 +48,17 @@ public class Synthesizer {
    */
   @Nonnull
   public Onnxruntime getOnnxruntime() {
-    Optional<Onnxruntime> onnxruntime = Onnxruntime.get();
-    assert onnxruntime.isPresent() : "`Synthesizer`のコンストラクタで要求しているはず";
-    return onnxruntime.get();
+    return onnxruntime;
+  }
+
+  /**
+   * Open JTalk。
+   *
+   * @return {@link OpenJtalk}。
+   */
+  @Nonnull
+  public OpenJtalk getOpenJtalk() {
+    return openJtalk;
   }
 
   /**
@@ -132,6 +143,9 @@ public class Synthesizer {
   /**
    * 日本語のテキストから {@link AudioQuery} を生成する。
    *
+   * <p>{@link #createAccentPhrases}と{@link AudioQuery#fromAccentPhrases}を合わせたショートハンド。詳細は<a
+   * href="https://github.com/VOICEVOX/voicevox_core/blob/main/docs/guide/user/tts-process.md">テキスト音声合成の流れ</a>を参照。
+   *
    * @param text 日本語のテキスト。
    * @param styleId スタイルID。
    * @return {@link AudioQuery}。
@@ -175,6 +189,9 @@ public class Synthesizer {
   /**
    * 日本語のテキストから {@link AccentPhrase} のリストを生成する。
    *
+   * <p>{@link OpenJtalk#analyze}と{@link #replaceMoraData}を合わせたショートハンド。詳細は<a
+   * href="https://github.com/VOICEVOX/voicevox_core/blob/main/docs/guide/user/tts-process.md">テキスト音声合成の流れ</a>を参照。
+   *
    * @param text 日本語のテキスト。
    * @param styleId スタイルID。
    * @return {@link AccentPhrase} のリスト。
@@ -193,6 +210,9 @@ public class Synthesizer {
 
   /**
    * アクセント句の音高・音素長を変更する。
+   *
+   * <p>{@link #replacePhonemeLength}と{@link #replaceMoraPitch}を合わせたショートハンド。詳細は<a
+   * href="https://github.com/VOICEVOX/voicevox_core/blob/main/docs/guide/user/tts-process.md">テキスト音声合成の流れ</a>を参照。
    *
    * @param accentPhrases 変更元のアクセント句の配列。
    * @param styleId スタイルID。
@@ -279,6 +299,9 @@ public class Synthesizer {
 
   /**
    * 日本語のテキストをもとに音声合成を実行するためのオブジェクトを生成する。
+   *
+   * <p>{@link #createAudioQuery}と{@link #synthesis}を合わせたショートハンド。詳細は<a
+   * href="https://github.com/VOICEVOX/voicevox_core/blob/main/docs/guide/user/tts-process.md">テキスト音声合成の流れ</a>を参照。
    *
    * @param text 日本語のテキスト。
    * @param styleId スタイルID。

--- a/crates/voicevox_core_java_api/lib/src/test/java/jp/hiroshiba/voicevoxcore/blocking/SynthesizerTest.java
+++ b/crates/voicevox_core_java_api/lib/src/test/java/jp/hiroshiba/voicevoxcore/blocking/SynthesizerTest.java
@@ -4,9 +4,11 @@
  */
 package jp.hiroshiba.voicevoxcore.blocking;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
 import java.util.List;
 import jp.hiroshiba.voicevoxcore.AccelerationMode;
 import jp.hiroshiba.voicevoxcore.AccentPhrase;
@@ -124,6 +126,50 @@ class SynthesizerTest extends TestUtils {
     try (VoiceModelFile model = openModel()) {
       synthesizer.loadVoiceModel(model);
     }
-    synthesizer.tts("こんにちは", synthesizer.metas()[0].styles[0].id).perform();
+
+    final String TEXT = "こんにちは？";
+    int styleId = synthesizer.metas()[0].styles[0].id;
+
+    // FIXME: `interrogativeUpspeak`のデフォルトがJava APIだけ`false`になっている
+
+    byte[] wav1 = synthesizer.tts(TEXT, styleId).perform();
+
+    AudioQuery query = synthesizer.createAudioQuery(TEXT, styleId);
+    byte[] wav2 = synthesizer.synthesis(query, styleId).perform();
+
+    List<AccentPhrase> phrases = synthesizer.getOpenJtalk().analyze(TEXT);
+    phrases = synthesizer.replaceMoraData(phrases, styleId);
+    query = AudioQuery.fromAccentPhrases(phrases);
+    byte[] wav3 = synthesizer.synthesis(query, styleId).perform();
+
+    phrases = synthesizer.getOpenJtalk().analyze(TEXT);
+    phrases = synthesizer.replacePhonemeLength(phrases, styleId);
+    phrases = synthesizer.replaceMoraPitch(phrases, styleId);
+    query = AudioQuery.fromAccentPhrases(phrases);
+    byte[] wav4 = synthesizer.synthesis(query, styleId).perform();
+
+    byte[] wav5 = synthesizer.tts(TEXT, styleId).interrogativeUpspeak(true).perform();
+
+    query = synthesizer.createAudioQuery(TEXT, styleId);
+    byte[] wav6 = synthesizer.synthesis(query, styleId).interrogativeUpspeak(true).perform();
+
+    phrases = synthesizer.getOpenJtalk().analyze(TEXT);
+    phrases = synthesizer.replaceMoraData(phrases, styleId);
+    query = AudioQuery.fromAccentPhrases(phrases);
+    byte[] wav7 = synthesizer.synthesis(query, styleId).interrogativeUpspeak(true).perform();
+
+    phrases = synthesizer.getOpenJtalk().analyze(TEXT);
+    phrases = synthesizer.replacePhonemeLength(phrases, styleId);
+    phrases = synthesizer.replaceMoraPitch(phrases, styleId);
+    query = AudioQuery.fromAccentPhrases(phrases);
+    byte[] wav8 = synthesizer.synthesis(query, styleId).interrogativeUpspeak(true).perform();
+
+    assertFalse(Arrays.equals(wav1, wav5));
+    assertArrayEquals(wav1, wav2);
+    assertArrayEquals(wav1, wav3);
+    assertArrayEquals(wav1, wav4);
+    assertArrayEquals(wav5, wav6);
+    assertArrayEquals(wav5, wav7);
+    assertArrayEquals(wav5, wav8);
   }
 }

--- a/crates/voicevox_core_java_api/lib/src/test/java/jp/hiroshiba/voicevoxcore/blocking/SynthesizerTest.java
+++ b/crates/voicevox_core_java_api/lib/src/test/java/jp/hiroshiba/voicevoxcore/blocking/SynthesizerTest.java
@@ -137,39 +137,49 @@ class SynthesizerTest extends TestUtils {
     AudioQuery query = synthesizer.createAudioQuery(TEXT, styleId);
     byte[] wav2 = synthesizer.synthesis(query, styleId).perform();
 
-    List<AccentPhrase> phrases = synthesizer.getOpenJtalk().analyze(TEXT);
-    phrases = synthesizer.replaceMoraData(phrases, styleId);
+    List<AccentPhrase> phrases = synthesizer.createAccentPhrases(TEXT, styleId);
     query = AudioQuery.fromAccentPhrases(phrases);
     byte[] wav3 = synthesizer.synthesis(query, styleId).perform();
 
     phrases = synthesizer.getOpenJtalk().analyze(TEXT);
-    phrases = synthesizer.replacePhonemeLength(phrases, styleId);
-    phrases = synthesizer.replaceMoraPitch(phrases, styleId);
+    phrases = synthesizer.replaceMoraData(phrases, styleId);
     query = AudioQuery.fromAccentPhrases(phrases);
     byte[] wav4 = synthesizer.synthesis(query, styleId).perform();
 
-    byte[] wav5 = synthesizer.tts(TEXT, styleId).interrogativeUpspeak(true).perform();
+    phrases = synthesizer.getOpenJtalk().analyze(TEXT);
+    phrases = synthesizer.replacePhonemeLength(phrases, styleId);
+    phrases = synthesizer.replaceMoraPitch(phrases, styleId);
+    query = AudioQuery.fromAccentPhrases(phrases);
+    byte[] wav5 = synthesizer.synthesis(query, styleId).perform();
+
+    byte[] wav6 = synthesizer.tts(TEXT, styleId).interrogativeUpspeak(true).perform();
 
     query = synthesizer.createAudioQuery(TEXT, styleId);
-    byte[] wav6 = synthesizer.synthesis(query, styleId).interrogativeUpspeak(true).perform();
+    byte[] wav7 = synthesizer.synthesis(query, styleId).interrogativeUpspeak(true).perform();
+
+    phrases = synthesizer.createAccentPhrases(TEXT, styleId);
+    query = AudioQuery.fromAccentPhrases(phrases);
+    byte[] wav8 = synthesizer.synthesis(query, styleId).interrogativeUpspeak(true).perform();
 
     phrases = synthesizer.getOpenJtalk().analyze(TEXT);
     phrases = synthesizer.replaceMoraData(phrases, styleId);
     query = AudioQuery.fromAccentPhrases(phrases);
-    byte[] wav7 = synthesizer.synthesis(query, styleId).interrogativeUpspeak(true).perform();
+    byte[] wav9 = synthesizer.synthesis(query, styleId).interrogativeUpspeak(true).perform();
 
     phrases = synthesizer.getOpenJtalk().analyze(TEXT);
     phrases = synthesizer.replacePhonemeLength(phrases, styleId);
     phrases = synthesizer.replaceMoraPitch(phrases, styleId);
     query = AudioQuery.fromAccentPhrases(phrases);
-    byte[] wav8 = synthesizer.synthesis(query, styleId).interrogativeUpspeak(true).perform();
+    byte[] wav10 = synthesizer.synthesis(query, styleId).interrogativeUpspeak(true).perform();
 
-    assertFalse(Arrays.equals(wav1, wav5));
+    assertFalse(Arrays.equals(wav1, wav6));
     assertArrayEquals(wav1, wav2);
     assertArrayEquals(wav1, wav3);
     assertArrayEquals(wav1, wav4);
-    assertArrayEquals(wav5, wav6);
-    assertArrayEquals(wav5, wav7);
-    assertArrayEquals(wav5, wav8);
+    assertArrayEquals(wav1, wav5);
+    assertArrayEquals(wav6, wav7);
+    assertArrayEquals(wav6, wav8);
+    assertArrayEquals(wav6, wav9);
+    assertArrayEquals(wav6, wav10);
   }
 }

--- a/crates/voicevox_core_java_api/src/audio_query.rs
+++ b/crates/voicevox_core_java_api/src/audio_query.rs
@@ -1,0 +1,26 @@
+use std::ptr;
+
+use crate::common::{throw_if_err, JavaApiError};
+use jni::{
+    objects::{JClass, JString},
+    sys::jstring,
+    JNIEnv,
+};
+use voicevox_core::AudioQuery;
+
+// SAFETY: voicevox_core_java_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
+#[unsafe(no_mangle)]
+extern "system" fn Java_jp_hiroshiba_voicevoxcore_AudioQuery_rsFromAccentPhrases(
+    env: JNIEnv<'_>,
+    _class: JClass<'_>,
+    accent_phrases: JString<'_>,
+) -> jstring {
+    throw_if_err(env, ptr::null_mut(), |env| {
+        let accent_phrases = &String::from(env.get_string(&accent_phrases)?);
+        let accent_phrases = serde_json::from_str(accent_phrases).map_err(JavaApiError::DeJson)?;
+        let query = &AudioQuery::from_accent_phrases(accent_phrases);
+        let query = serde_json::to_string(query).expect("should not fail");
+        let query = env.new_string(query)?;
+        Ok(query.into_raw())
+    })
+}

--- a/crates/voicevox_core_java_api/src/lib.rs
+++ b/crates/voicevox_core_java_api/src/lib.rs
@@ -1,3 +1,4 @@
+mod audio_query;
 mod common;
 mod info;
 mod logger;

--- a/crates/voicevox_core_python_api/Cargo.toml
+++ b/crates/voicevox_core_python_api/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
+anyhow.workspace = true
 async-lock.workspace = true
 blocking.workspace = true
 camino.workspace = true

--- a/crates/voicevox_core_python_api/python/test/test_asyncio_object_identities.py
+++ b/crates/voicevox_core_python_api/python/test/test_asyncio_object_identities.py
@@ -1,0 +1,39 @@
+"""
+同一であるべきオブジェクトと同一であるべきではないオブジェクトについて、同一性
+(*identity*)を確認する。
+
+``test_blocking_object_identities`` と対になる。
+"""
+
+import conftest
+import pytest
+from voicevox_core.asyncio import (
+    Onnxruntime,
+    OpenJtalk,
+    Synthesizer,
+    UserDict,
+    VoiceModelFile,
+)
+
+
+@pytest.mark.asyncio
+async def test() -> None:
+    onnxruntime = await Onnxruntime.load_once(filename=conftest.onnxruntime_filename)
+
+    assert Onnxruntime.get() is onnxruntime
+    assert await Onnxruntime.load_once() is onnxruntime
+    assert onnxruntime.supported_devices() is not onnxruntime.supported_devices()
+
+    open_jtalk = await OpenJtalk.new(conftest.open_jtalk_dic_dir)
+
+    synthesizer = Synthesizer(onnxruntime, open_jtalk)
+    assert synthesizer.onnxruntime is onnxruntime
+    assert synthesizer.open_jtalk is open_jtalk
+    assert synthesizer.metas() is not synthesizer.metas()
+
+    async with await VoiceModelFile.open(conftest.model_dir) as model:
+        assert model.id is model.id
+        assert model.metas is model.metas
+
+    userdict = UserDict()
+    assert userdict.to_dict() is not userdict.to_dict()

--- a/crates/voicevox_core_python_api/python/test/test_asyncio_tts.py
+++ b/crates/voicevox_core_python_api/python/test/test_asyncio_tts.py
@@ -1,0 +1,81 @@
+"""
+音声合成を行う。
+
+``test_blocking_tts`` と対になる。
+"""
+
+import multiprocessing
+import platform
+
+import conftest
+import pytest
+import pytest_asyncio
+from voicevox_core import AudioQuery
+from voicevox_core.asyncio import Onnxruntime, OpenJtalk, Synthesizer, VoiceModelFile
+
+
+@pytest.mark.asyncio
+async def test(synthesizer: Synthesizer) -> None:
+    TEXT = "こんにちは？"
+    STYLE_ID = 0
+
+    wav1 = await synthesizer.tts(TEXT, STYLE_ID)
+
+    query = await synthesizer.create_audio_query(TEXT, STYLE_ID)
+    wav2 = await synthesizer.synthesis(query, STYLE_ID)
+
+    phrases = await synthesizer.open_jtalk.analyze(TEXT)
+    phrases = await synthesizer.replace_mora_data(phrases, STYLE_ID)
+    query = AudioQuery.from_accent_phrases(phrases)
+    wav3 = await synthesizer.synthesis(query, STYLE_ID)
+
+    phrases = await synthesizer.open_jtalk.analyze(TEXT)
+    phrases = await synthesizer.replace_phoneme_length(phrases, STYLE_ID)
+    phrases = await synthesizer.replace_mora_pitch(phrases, STYLE_ID)
+    query = AudioQuery.from_accent_phrases(phrases)
+    wav4 = await synthesizer.synthesis(query, STYLE_ID)
+
+    wav5 = await synthesizer.tts(TEXT, STYLE_ID, enable_interrogative_upspeak=False)
+
+    query = await synthesizer.create_audio_query(TEXT, STYLE_ID)
+    wav6 = await synthesizer.synthesis(
+        query, STYLE_ID, enable_interrogative_upspeak=False
+    )
+
+    phrases = await synthesizer.open_jtalk.analyze(TEXT)
+    phrases = await synthesizer.replace_mora_data(phrases, STYLE_ID)
+    query = AudioQuery.from_accent_phrases(phrases)
+    wav7 = await synthesizer.synthesis(
+        query, STYLE_ID, enable_interrogative_upspeak=False
+    )
+
+    phrases = await synthesizer.open_jtalk.analyze(TEXT)
+    phrases = await synthesizer.replace_phoneme_length(phrases, STYLE_ID)
+    phrases = await synthesizer.replace_mora_pitch(phrases, STYLE_ID)
+    query = AudioQuery.from_accent_phrases(phrases)
+    wav8 = await synthesizer.synthesis(
+        query, STYLE_ID, enable_interrogative_upspeak=False
+    )
+
+    assert wav1 != wav5
+    assert len({wav1, wav2, wav3, wav4}) == 1
+    assert len({wav5, wav6, wav7, wav8}) == 1
+
+
+@pytest_asyncio.fixture
+async def synthesizer() -> Synthesizer:
+    onnxruntime = await Onnxruntime.load_once(filename=conftest.onnxruntime_filename)
+    open_jtalk = await OpenJtalk.new(conftest.open_jtalk_dic_dir)
+    synthesizer = Synthesizer(
+        onnxruntime,
+        open_jtalk,
+        acceleration_mode="CPU",
+        cpu_num_threads=max(
+            multiprocessing.cpu_count(), 2
+        )  # https://github.com/VOICEVOX/voicevox_core/issues/888
+        if platform.system() == "Darwin"
+        else 0,  # default
+    )
+    async with await VoiceModelFile.open(conftest.model_dir) as model:
+        await synthesizer.load_voice_model(model)
+    return synthesizer

--- a/crates/voicevox_core_python_api/python/test/test_asyncio_tts.py
+++ b/crates/voicevox_core_python_api/python/test/test_asyncio_tts.py
@@ -24,42 +24,54 @@ async def test(synthesizer: Synthesizer) -> None:
     query = await synthesizer.create_audio_query(TEXT, STYLE_ID)
     wav2 = await synthesizer.synthesis(query, STYLE_ID)
 
-    phrases = await synthesizer.open_jtalk.analyze(TEXT)
-    phrases = await synthesizer.replace_mora_data(phrases, STYLE_ID)
+    phrases = await synthesizer.create_accent_phrases(TEXT, STYLE_ID)
+    print(f"{phrases=}")
+    print(f"{type(phrases)=}")
     query = AudioQuery.from_accent_phrases(phrases)
     wav3 = await synthesizer.synthesis(query, STYLE_ID)
 
     phrases = await synthesizer.open_jtalk.analyze(TEXT)
-    phrases = await synthesizer.replace_phoneme_length(phrases, STYLE_ID)
-    phrases = await synthesizer.replace_mora_pitch(phrases, STYLE_ID)
+    phrases = await synthesizer.replace_mora_data(phrases, STYLE_ID)
     query = AudioQuery.from_accent_phrases(phrases)
     wav4 = await synthesizer.synthesis(query, STYLE_ID)
 
-    wav5 = await synthesizer.tts(TEXT, STYLE_ID, enable_interrogative_upspeak=False)
+    phrases = await synthesizer.open_jtalk.analyze(TEXT)
+    phrases = await synthesizer.replace_phoneme_length(phrases, STYLE_ID)
+    phrases = await synthesizer.replace_mora_pitch(phrases, STYLE_ID)
+    query = AudioQuery.from_accent_phrases(phrases)
+    wav5 = await synthesizer.synthesis(query, STYLE_ID)
+
+    wav6 = await synthesizer.tts(TEXT, STYLE_ID, enable_interrogative_upspeak=False)
 
     query = await synthesizer.create_audio_query(TEXT, STYLE_ID)
-    wav6 = await synthesizer.synthesis(
-        query, STYLE_ID, enable_interrogative_upspeak=False
-    )
-
-    phrases = await synthesizer.open_jtalk.analyze(TEXT)
-    phrases = await synthesizer.replace_mora_data(phrases, STYLE_ID)
-    query = AudioQuery.from_accent_phrases(phrases)
     wav7 = await synthesizer.synthesis(
         query, STYLE_ID, enable_interrogative_upspeak=False
     )
 
-    phrases = await synthesizer.open_jtalk.analyze(TEXT)
-    phrases = await synthesizer.replace_phoneme_length(phrases, STYLE_ID)
-    phrases = await synthesizer.replace_mora_pitch(phrases, STYLE_ID)
+    phrases = await synthesizer.create_accent_phrases(TEXT, STYLE_ID)
     query = AudioQuery.from_accent_phrases(phrases)
     wav8 = await synthesizer.synthesis(
         query, STYLE_ID, enable_interrogative_upspeak=False
     )
 
-    assert wav1 != wav5
-    assert len({wav1, wav2, wav3, wav4}) == 1
-    assert len({wav5, wav6, wav7, wav8}) == 1
+    phrases = await synthesizer.open_jtalk.analyze(TEXT)
+    phrases = await synthesizer.replace_mora_data(phrases, STYLE_ID)
+    query = AudioQuery.from_accent_phrases(phrases)
+    wav9 = await synthesizer.synthesis(
+        query, STYLE_ID, enable_interrogative_upspeak=False
+    )
+
+    phrases = await synthesizer.open_jtalk.analyze(TEXT)
+    phrases = await synthesizer.replace_phoneme_length(phrases, STYLE_ID)
+    phrases = await synthesizer.replace_mora_pitch(phrases, STYLE_ID)
+    query = AudioQuery.from_accent_phrases(phrases)
+    wav10 = await synthesizer.synthesis(
+        query, STYLE_ID, enable_interrogative_upspeak=False
+    )
+
+    assert wav1 != wav6
+    assert len({wav1, wav2, wav3, wav4, wav5}) == 1
+    assert len({wav6, wav7, wav8, wav9, wav10}) == 1
 
 
 @pytest_asyncio.fixture

--- a/crates/voicevox_core_python_api/python/test/test_blocking_object_identities.py
+++ b/crates/voicevox_core_python_api/python/test/test_blocking_object_identities.py
@@ -1,0 +1,37 @@
+"""
+同一であるべきオブジェクトと同一であるべきではないオブジェクトについて、同一性
+(*identity*)を確認する。
+
+``test_asyncio_object_identities`` と対になる。
+"""
+
+import conftest
+from voicevox_core.blocking import (
+    Onnxruntime,
+    OpenJtalk,
+    Synthesizer,
+    UserDict,
+    VoiceModelFile,
+)
+
+
+def test() -> None:
+    onnxruntime = Onnxruntime.load_once(filename=conftest.onnxruntime_filename)
+
+    assert Onnxruntime.get() is onnxruntime
+    assert Onnxruntime.load_once() is onnxruntime
+    assert onnxruntime.supported_devices() is not onnxruntime.supported_devices()
+
+    open_jtalk = OpenJtalk(conftest.open_jtalk_dic_dir)
+
+    synthesizer = Synthesizer(onnxruntime, open_jtalk)
+    assert synthesizer.onnxruntime is onnxruntime
+    assert synthesizer.open_jtalk is open_jtalk
+    assert synthesizer.metas() is not synthesizer.metas()
+
+    with VoiceModelFile.open(conftest.model_dir) as model:
+        assert model.id is model.id
+        assert model.metas is model.metas
+
+    userdict = UserDict()
+    assert userdict.to_dict() is not userdict.to_dict()

--- a/crates/voicevox_core_python_api/python/test/test_blocking_tts.py
+++ b/crates/voicevox_core_python_api/python/test/test_blocking_tts.py
@@ -19,36 +19,44 @@ def test(synthesizer: Synthesizer) -> None:
     query = synthesizer.create_audio_query(TEXT, STYLE_ID)
     wav2 = synthesizer.synthesis(query, STYLE_ID)
 
-    phrases = synthesizer.open_jtalk.analyze(TEXT)
-    phrases = synthesizer.replace_mora_data(phrases, STYLE_ID)
+    phrases = synthesizer.create_accent_phrases(TEXT, STYLE_ID)
     query = AudioQuery.from_accent_phrases(phrases)
     wav3 = synthesizer.synthesis(query, STYLE_ID)
 
     phrases = synthesizer.open_jtalk.analyze(TEXT)
-    phrases = synthesizer.replace_phoneme_length(phrases, STYLE_ID)
-    phrases = synthesizer.replace_mora_pitch(phrases, STYLE_ID)
+    phrases = synthesizer.replace_mora_data(phrases, STYLE_ID)
     query = AudioQuery.from_accent_phrases(phrases)
     wav4 = synthesizer.synthesis(query, STYLE_ID)
 
-    wav5 = synthesizer.tts(TEXT, STYLE_ID, enable_interrogative_upspeak=False)
+    phrases = synthesizer.open_jtalk.analyze(TEXT)
+    phrases = synthesizer.replace_phoneme_length(phrases, STYLE_ID)
+    phrases = synthesizer.replace_mora_pitch(phrases, STYLE_ID)
+    query = AudioQuery.from_accent_phrases(phrases)
+    wav5 = synthesizer.synthesis(query, STYLE_ID)
+
+    wav6 = synthesizer.tts(TEXT, STYLE_ID, enable_interrogative_upspeak=False)
 
     query = synthesizer.create_audio_query(TEXT, STYLE_ID)
-    wav6 = synthesizer.synthesis(query, STYLE_ID, enable_interrogative_upspeak=False)
+    wav7 = synthesizer.synthesis(query, STYLE_ID, enable_interrogative_upspeak=False)
+
+    phrases = synthesizer.create_accent_phrases(TEXT, STYLE_ID)
+    query = AudioQuery.from_accent_phrases(phrases)
+    wav8 = synthesizer.synthesis(query, STYLE_ID, enable_interrogative_upspeak=False)
 
     phrases = synthesizer.open_jtalk.analyze(TEXT)
     phrases = synthesizer.replace_mora_data(phrases, STYLE_ID)
     query = AudioQuery.from_accent_phrases(phrases)
-    wav7 = synthesizer.synthesis(query, STYLE_ID, enable_interrogative_upspeak=False)
+    wav9 = synthesizer.synthesis(query, STYLE_ID, enable_interrogative_upspeak=False)
 
     phrases = synthesizer.open_jtalk.analyze(TEXT)
     phrases = synthesizer.replace_phoneme_length(phrases, STYLE_ID)
     phrases = synthesizer.replace_mora_pitch(phrases, STYLE_ID)
     query = AudioQuery.from_accent_phrases(phrases)
-    wav8 = synthesizer.synthesis(query, STYLE_ID, enable_interrogative_upspeak=False)
+    wav10 = synthesizer.synthesis(query, STYLE_ID, enable_interrogative_upspeak=False)
 
-    assert wav1 != wav5
-    assert len({wav1, wav2, wav3, wav4}) == 1
-    assert len({wav5, wav6, wav7, wav8}) == 1
+    assert wav1 != wav6
+    assert len({wav1, wav2, wav3, wav4, wav5}) == 1
+    assert len({wav6, wav7, wav8, wav9, wav10}) == 1
 
 
 @pytest.fixture

--- a/crates/voicevox_core_python_api/python/test/test_blocking_tts.py
+++ b/crates/voicevox_core_python_api/python/test/test_blocking_tts.py
@@ -1,0 +1,61 @@
+"""
+音声合成を行う。
+
+``test_asyncio_tts`` と対になる。
+"""
+
+import conftest
+import pytest
+from voicevox_core import AudioQuery
+from voicevox_core.blocking import Onnxruntime, OpenJtalk, Synthesizer, VoiceModelFile
+
+
+def test(synthesizer: Synthesizer) -> None:
+    TEXT = "こんにちは？"
+    STYLE_ID = 0
+
+    wav1 = synthesizer.tts(TEXT, STYLE_ID)
+
+    query = synthesizer.create_audio_query(TEXT, STYLE_ID)
+    wav2 = synthesizer.synthesis(query, STYLE_ID)
+
+    phrases = synthesizer.open_jtalk.analyze(TEXT)
+    phrases = synthesizer.replace_mora_data(phrases, STYLE_ID)
+    query = AudioQuery.from_accent_phrases(phrases)
+    wav3 = synthesizer.synthesis(query, STYLE_ID)
+
+    phrases = synthesizer.open_jtalk.analyze(TEXT)
+    phrases = synthesizer.replace_phoneme_length(phrases, STYLE_ID)
+    phrases = synthesizer.replace_mora_pitch(phrases, STYLE_ID)
+    query = AudioQuery.from_accent_phrases(phrases)
+    wav4 = synthesizer.synthesis(query, STYLE_ID)
+
+    wav5 = synthesizer.tts(TEXT, STYLE_ID, enable_interrogative_upspeak=False)
+
+    query = synthesizer.create_audio_query(TEXT, STYLE_ID)
+    wav6 = synthesizer.synthesis(query, STYLE_ID, enable_interrogative_upspeak=False)
+
+    phrases = synthesizer.open_jtalk.analyze(TEXT)
+    phrases = synthesizer.replace_mora_data(phrases, STYLE_ID)
+    query = AudioQuery.from_accent_phrases(phrases)
+    wav7 = synthesizer.synthesis(query, STYLE_ID, enable_interrogative_upspeak=False)
+
+    phrases = synthesizer.open_jtalk.analyze(TEXT)
+    phrases = synthesizer.replace_phoneme_length(phrases, STYLE_ID)
+    phrases = synthesizer.replace_mora_pitch(phrases, STYLE_ID)
+    query = AudioQuery.from_accent_phrases(phrases)
+    wav8 = synthesizer.synthesis(query, STYLE_ID, enable_interrogative_upspeak=False)
+
+    assert wav1 != wav5
+    assert len({wav1, wav2, wav3, wav4}) == 1
+    assert len({wav5, wav6, wav7, wav8}) == 1
+
+
+@pytest.fixture
+def synthesizer() -> Synthesizer:
+    onnxruntime = Onnxruntime.load_once(filename=conftest.onnxruntime_filename)
+    open_jtalk = OpenJtalk(conftest.open_jtalk_dic_dir)
+    synthesizer = Synthesizer(onnxruntime, open_jtalk, acceleration_mode="CPU")
+    with VoiceModelFile.open(conftest.model_dir) as model:
+        synthesizer.load_voice_model(model)
+    return synthesizer

--- a/crates/voicevox_core_python_api/python/voicevox_core/_models/__init__.py
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_models/__init__.py
@@ -6,7 +6,11 @@ import pydantic.alias_generators
 from pydantic import ConfigDict
 from pydantic_core import ArgsKwargs
 
-from .._rust import _to_zenkaku, _validate_user_dict_word
+from .._rust import (
+    _audio_query_from_accent_phrases,
+    _to_zenkaku,
+    _validate_user_dict_word,
+)
 from ._please_do_not_use import _Reserved
 
 StyleId = NewType("StyleId", int)
@@ -397,6 +401,10 @@ class AudioQuery:
     :func:`Synthesizer.create_audio_query` が返すもののみ ``str`` となる。入力として
     のAudioQueryでは無視される。
     """
+
+    @staticmethod
+    def from_accent_phrases(accent_phrases: list["AccentPhrase"]) -> "AudioQuery":
+        return _audio_query_from_accent_phrases(accent_phrases)
 
 
 UserDictWordType: TypeAlias = (

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/__init__.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/__init__.pyi
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from voicevox_core import UserDictWord
+    from voicevox_core import AccentPhrase, AudioQuery, UserDictWord
 
 __version__: str
 
@@ -105,6 +105,9 @@ class InvalidWordError(ValueError):
 
     ...
 
+def _audio_query_from_accent_phrases(
+    accent_phrases: list[AccentPhrase],
+) -> AudioQuery: ...
 def _validate_user_dict_word(word: UserDictWord) -> None: ...
 def _to_zenkaku(text: str) -> str: ...
 def wav_from_s16le(pcm: bytes, sampling_rate: int, is_stereo: bool) -> bytes:

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/asyncio.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/asyncio.pyi
@@ -162,6 +162,16 @@ class OpenJtalk:
             ユーザー辞書。
         """
         ...
+    async def analyze(self, text: str) -> list[AccentPhrase]:
+        """
+        日本語のテキストを解析する。
+
+        Parameters
+        ----------
+        text
+            日本語のテキスト。
+        """
+        ...
 
 class Synthesizer:
     """
@@ -194,6 +204,10 @@ class Synthesizer:
     @property
     def onnxruntime(self) -> Onnxruntime:
         """ONNX Runtime。"""
+        ...
+    @property
+    def open_jtalk(self) -> OpenJtalk:
+        """Open JTalk。"""
         ...
     @property
     def is_gpu_mode(self) -> bool:
@@ -264,6 +278,14 @@ class Synthesizer:
         """
         日本語のテキストから :class:`AudioQuery` を生成する。
 
+        :func:`create_accent_phrases` と |from-accent-phrases|_
+        が一体になったショートハンド。詳細は `テキスト音声合成の流れ
+        <https://github.com/VOICEVOX/voicevox_core/blob/main/docs/guide/user/tts-process.md>`_
+        を参照。
+
+        .. |from-accent-phrases| replace:: ``AudioQuery.from_accent_phrases()``
+        .. _from-accent-phrases: ../index.html#voicevox_core.AudioQuery.from_accent_phrases
+
         Parameters
         ----------
         text
@@ -304,6 +326,11 @@ class Synthesizer:
         """
         日本語のテキストからAccentPhrase（アクセント句）の配列を生成する。
 
+        :func:`OpenJtalk.analyze` と :func:`replace_mora_data`
+        が一体になったショートハンド。詳細は `テキスト音声合成の流れ
+        <https://github.com/VOICEVOX/voicevox_core/blob/main/docs/guide/user/tts-process.md>`_
+        を参照。
+
         Parameters
         ----------
         text
@@ -325,6 +352,11 @@ class Synthesizer:
         アクセント句の音高・音素長を変更した新しいアクセント句の配列を生成する。
 
         元のアクセント句の音高・音素長は変更されない。
+
+        :func:`replace_phoneme_length` と :func:`replace_mora_pitch`
+        が一体になったショートハンド。詳細は `テキスト音声合成の流れ
+        <https://github.com/VOICEVOX/voicevox_core/blob/main/docs/guide/user/tts-process.md>`_
+        を参照。
 
         Parameters
         ----------
@@ -442,6 +474,11 @@ class Synthesizer:
     ) -> bytes:
         """
         日本語のテキストから音声合成を行う。
+
+        :func:`create_audio_query` と :func:`synthesis`
+        が一体になったショートハンド。詳細は `テキスト音声合成の流れ
+        <https://github.com/VOICEVOX/voicevox_core/blob/main/docs/guide/user/tts-process.md>`_
+        を参照。
 
         ``cancellable``
         を有効化しない限り、非同期タスクとしてキャンセルしても終わるまで停止しない。

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
@@ -154,6 +154,16 @@ class OpenJtalk:
             ユーザー辞書。
         """
         ...
+    def analyze(self, text: str) -> list[AccentPhrase]:
+        """
+        日本語のテキストを解析する。
+
+        Parameters
+        ----------
+        text
+            日本語のテキスト。
+        """
+        ...
 
 class AudioFeature:
     @property
@@ -191,6 +201,10 @@ class Synthesizer:
     @property
     def onnxruntime(self) -> Onnxruntime:
         """ONNX Runtime。"""
+        ...
+    @property
+    def open_jtalk(self) -> OpenJtalk:
+        """Open JTalk。"""
         ...
     @property
     def is_gpu_mode(self) -> bool:
@@ -261,6 +275,14 @@ class Synthesizer:
         """
         日本語のテキストから :class:`AudioQuery` を生成する。
 
+        :func:`create_accent_phrases` と |from-accent-phrases|_
+        が一体になったショートハンド。詳細は `テキスト音声合成の流れ
+        <https://github.com/VOICEVOX/voicevox_core/blob/main/docs/guide/user/tts-process.md>`_
+        を参照。
+
+        .. |from-accent-phrases| replace:: ``AudioQuery.from_accent_phrases()``
+        .. _from-accent-phrases: ../index.html#voicevox_core.AudioQuery.from_accent_phrases
+
         Parameters
         ----------
         text
@@ -301,6 +323,11 @@ class Synthesizer:
         """
         日本語のテキストからAccentPhrase（アクセント句）の配列を生成する。
 
+        :func:`OpenJtalk.analyze` と :func:`replace_mora_data`
+        が一体になったショートハンド。詳細は `テキスト音声合成の流れ
+        <https://github.com/VOICEVOX/voicevox_core/blob/main/docs/guide/user/tts-process.md>`_
+        を参照。
+
         Parameters
         ----------
         text
@@ -322,6 +349,11 @@ class Synthesizer:
         アクセント句の音高・音素長を変更した新しいアクセント句の配列を生成する。
 
         元のアクセント句の音高・音素長は変更されない。
+
+        :func:`replace_phoneme_length` と :func:`replace_mora_pitch`
+        が一体になったショートハンド。詳細は `テキスト音声合成の流れ
+        <https://github.com/VOICEVOX/voicevox_core/blob/main/docs/guide/user/tts-process.md>`_
+        を参照。
 
         Parameters
         ----------
@@ -437,6 +469,11 @@ class Synthesizer:
     ) -> bytes:
         """
         日本語のテキストから音声合成を行う。
+
+        :func:`create_audio_query` と :func:`synthesis`
+        が一体になったショートハンド。詳細は `テキスト音声合成の流れ
+        <https://github.com/VOICEVOX/voicevox_core/blob/main/docs/guide/user/tts-process.md>`_
+        を参照。
 
         Parameters
         ----------

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -1331,7 +1331,7 @@ mod asyncio {
                     .into_py_result(py)?
                     .iter()
                     .map(|ap| crate::convert::to_pydantic_dataclass(ap, class))
-                    .collect::<PyResult<Vec<_>>>();
+                    .collect::<PyResult<Vec<_>>>()?;
                 PyList::new(py, accent_phrases).map(Into::into)
             })
         }

--- a/docs/guide/user/tts-process.md
+++ b/docs/guide/user/tts-process.md
@@ -1,0 +1,47 @@
+# テキスト音声合成の流れ
+
+テキスト音声合成の流れを図にするとこのようになります。
+
+```mermaid
+flowchart TD;
+    ja-txt[日本語のテキスト]
+    ap-without-mora-data[音高・音素長<b>抜きの</b><br><a href="https://voicevox.github.io/voicevox_core/apis/python_api/autoapi/voicevox_core/index.html#voicevox_core.AccentPhrase">アクセント句</a>の列]
+    ap-with-mora-data[音高・音素長<b>入りの</b><br><a href="https://voicevox.github.io/voicevox_core/apis/python_api/autoapi/voicevox_core/index.html#voicevox_core.AccentPhrase">アクセント句</a>の列]
+    aq[<a href="https://voicevox.github.io/voicevox_core/apis/python_api/autoapi/voicevox_core/index.html#voicevox_core.AudioQuery">AudioQuery</a>]
+    wav[WAV形式の音声]
+
+    ja-txt -->|<a href="https://voicevox.github.io/voicevox_core/apis/python_api/autoapi/voicevox_core/blocking/index.html#voicevox_core.blocking.OpenJtalk.analyze">OpenJtalk.analyze</a>| ap-without-mora-data
+           -->|<ul><li><a href="https://voicevox.github.io/voicevox_core/apis/python_api/autoapi/voicevox_core/blocking/index.html#voicevox_core.blocking.Synthesizer.replace_phoneme_length">Synthesizer.replace_phoneme_length</a></li><li><a href="https://voicevox.github.io/voicevox_core/apis/python_api/autoapi/voicevox_core/blocking/index.html#voicevox_core.blocking.Synthesizer.replace_mora_pitch">Synthesizer.replace_mora_pitch</a></li><ul>| ap-with-mora-data
+           -->|<a href="https://voicevox.github.io/voicevox_core/apis/python_api/autoapi/voicevox_core/index.html#voicevox_core.AudioQuery.from_accent_phrases">AudioQuery.from_accent_phrases</a>| aq
+           -->|<a href="https://voicevox.github.io/voicevox_core/apis/python_api/autoapi/voicevox_core/blocking/index.html#voicevox_core.blocking.Synthesizer.synthesis">Synthesizer.synthesis</a>| wav
+
+    linkStyle 0,1,2,3 font-family:monospace;
+```
+
+毎回これらの関数を経るのは大変なので、ショートハンドとなるAPIもあります。例えば[`Synthesizer.tts`]は日本語のテキストから直接音声を生成します。
+
+[`Synthesizer.tts`]: https://voicevox.github.io/voicevox_core/apis/python_api/autoapi/voicevox_core/blocking/index.html#voicevox_core.blocking.Synthesizer.tts
+
+```mermaid
+flowchart TD;
+    ja-txt[日本語のテキスト]
+    ap-without-mora-data[音高・音素長<b>抜きの</b><br><a href="https://voicevox.github.io/voicevox_core/apis/python_api/autoapi/voicevox_core/index.html#voicevox_core.AccentPhrase">アクセント句</a>の列]
+    ap-with-mora-data[音高・音素長<b>入りの</b><br><a href="https://voicevox.github.io/voicevox_core/apis/python_api/autoapi/voicevox_core/index.html#voicevox_core.AccentPhrase">アクセント句</a>の列]
+    aq[<a href="https://voicevox.github.io/voicevox_core/apis/python_api/autoapi/voicevox_core/index.html#voicevox_core.AudioQuery">AudioQuery</a>]
+    wav[WAV形式の音声]
+
+    ja-txt ==>|<a href="https://voicevox.github.io/voicevox_core/apis/python_api/autoapi/voicevox_core/blocking/index.html#voicevox_core.blocking.Synthesizer.tts">Synthesizer.tts</a>| wav
+    ja-txt ==>|<a href="https://voicevox.github.io/voicevox_core/apis/python_api/autoapi/voicevox_core/blocking/index.html#voicevox_core.blocking.Synthesizer.create_audio_query">Synthesizer.create_audio_query</a>| aq
+    ja-txt ==>|<a href="https://voicevox.github.io/voicevox_core/apis/python_api/autoapi/voicevox_core/blocking/index.html#voicevox_core.blocking.Synthesizer.create_accent_phrases">Synthesizer.create_accent_phrases</a>| ap-with-mora-data
+    ja-txt -->|<a href="https://voicevox.github.io/voicevox_core/apis/python_api/autoapi/voicevox_core/blocking/index.html#voicevox_core.blocking.OpenJtalk.analyze">OpenJtalk.analyze</a>| ap-without-mora-data
+    ap-without-mora-data ==>|<a href="https://voicevox.github.io/voicevox_core/apis/python_api/autoapi/voicevox_core/blocking/index.html#voicevox_core.blocking.Synthesizer.replace_mora_data">Synthesizer.replace_mora_data</a>| ap-with-mora-data
+    ap-without-mora-data -->|<ul><li><a href="https://voicevox.github.io/voicevox_core/apis/python_api/autoapi/voicevox_core/blocking/index.html#voicevox_core.blocking.Synthesizer.replace_phoneme_length">Synthesizer.replace_phoneme_length</a></li><li><a href="https://voicevox.github.io/voicevox_core/apis/python_api/autoapi/voicevox_core/blocking/index.html#voicevox_core.blocking.Synthesizer.replace_mora_pitch">Synthesizer.replace_mora_pitch</a></li><ul>| ap-with-mora-data
+                         -->|<a href="https://voicevox.github.io/voicevox_core/apis/python_api/autoapi/voicevox_core/index.html#voicevox_core.AudioQuery.from_accent_phrases">AudioQuery.from_accent_phrases</a>| aq
+                         -->|<a href="https://voicevox.github.io/voicevox_core/apis/python_api/autoapi/voicevox_core/blocking/index.html#voicevox_core.blocking.Synthesizer.synthesis">Synthesizer.synthesis</a>| wav
+
+    %% 不可視の矢印を用いてできるだけ右側に「引っ張」る。
+    ja-txt ~~~ aq
+    ja-txt ~~~ wav
+
+    linkStyle 0,1,2,3,4,5,6,7 font-family:monospace;
+```

--- a/docs/guide/user/usage.md
+++ b/docs/guide/user/usage.md
@@ -133,6 +133,8 @@ with VoiceModelFile.open("models/vvms/0.vvm") as model:
 
 `Synthesizer`はイントネーションの生成と音声合成の処理を分けることもできます。
 
+詳しくは: [テキスト音声合成の流れ](./tts-process.md)
+
 ### AudioQuery の生成
 
 まずテキストから`AudioQuery`を生成します。`AudioQuery`には各音の高さや長さが含まれています。


### PR DESCRIPTION
## 内容

次のAPIをパブリックAPIとして露出させ、それに関連するテストとドキュメントを用意する。このテストとドキュメントが主目的。テストでは各ショートハンドがショートハンドとして機能するか確かめ、ドキュメントにおいては[テキスト音声合成の流れ]というものを用意してMermaidのflowchart図を載せる。また各ショートハンドメソッドについて、何のショートハンドなのかを明記するようにする。

[テキスト音声合成の流れ]: https://github.com/qryxip/voicevox_core/blob/pr/feat-expose-some-apis-and-explain-tts-process/docs/guide/user/tts-process.md

- `OpenJtalk::analyze`/`TextAnalyzer::analyze`
    (Rust APIでは既に露出済み)
- `Synthesizer::open_jtalk`/`Synthesizer::text_analyzer`
- `AudioQuery::from_accent_phrases`

`kana`系のAPIについては今回はノータッチ。

## 関連 Issue

## その他
