### PR TITLE
fix: [Python] fix up #962: async版`create_accent_phrases`を直す

### DIFF
--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -1270,7 +1270,7 @@ mod asyncio {
                     .into_py_result(py)?
                     .iter()
                     .map(|ap| crate::convert::to_pydantic_dataclass(ap, class))
-                    .collect::<PyResult<Vec<_>>>();
+                    .collect::<PyResult<Vec<_>>>()?;
                 PyList::new(py, accent_phrases).map(Into::into)
             })
         }


### PR DESCRIPTION
## 内容

#1025 のテストを書こうとして発覚。

Rustの`Result<T, _>`は`IntoIterator<Item = T>`であり、`Vec<_>`とするところを誤って`Result<Vec<_>, _>`としてしまったために`voicevox_core.asyncio.Synthesizer.create_accent_phrases`が`list[list[AccentPhrase]]`を返していた。

通常[`for x in result`のようなことをすれば怒られる](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/for_loops_over_fallibles/static.FOR_LOOPS_OVER_FALLIBLES.html)が、関数の引数として入れる分には警告が出なかった。

## 関連 Issue

## その他
