### PR TITLE
build!: Ubuntu 20.04のサポートを切る

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   audit:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Install cargo-deny

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   audit:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install cargo-deny

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -66,7 +66,7 @@ jobs:
               "can_skip_in_simple_test": true
             },
             {
-              "os": "ubuntu-20.04",
+              "os": "ubuntu-22.04",
               "target": "x86_64-unknown-linux-gnu",
               "artifact_name": "linux-x64",
               "c_release_format": "plain-cdylib",
@@ -74,7 +74,7 @@ jobs:
               "can_skip_in_simple_test": false
             },
             {
-              "os": "ubuntu-20.04",
+              "os": "ubuntu-22.04",
               "target": "aarch64-unknown-linux-gnu",
               "artifact_name": "linux-arm64",
               "c_release_format": "plain-cdylib",
@@ -82,7 +82,7 @@ jobs:
               "can_skip_in_simple_test": true
             },
             {
-              "os": "ubuntu-20.04",
+              "os": "ubuntu-22.04",
               "target": "aarch64-linux-android",
               "artifact_name": "android-arm64",
               "c_release_format": "plain-cdylib",
@@ -90,7 +90,7 @@ jobs:
               "can_skip_in_simple_test": true
             },
             {
-              "os": "ubuntu-20.04",
+              "os": "ubuntu-22.04",
               "target": "x86_64-linux-android",
               "artifact_name": "android-x86_64",
               "c_release_format": "plain-cdylib",

--- a/.github/workflows/build_and_deploy_downloader.yml
+++ b/.github/workflows/build_and_deploy_downloader.yml
@@ -47,11 +47,11 @@ jobs:
 
           - name: download-linux-x64
             target: x86_64-unknown-linux-gnu
-            os: ubuntu-20.04
+            os: ubuntu-22.04
 
           - name: download-linux-arm64
             target: aarch64-unknown-linux-gnu
-            os: ubuntu-20.04
+            os: ubuntu-22.04
 
           - name: download-osx-x64
             target: x86_64-apple-darwin

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   licenses:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install cargo-deny

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   licenses:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Install cargo-deny

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,8 +109,8 @@ jobs:
             { "os": "windows-2022", "can_skip_in_simple_test": true },
             { "os": "macos-13", "can_skip_in_simple_test": false },
             { "os": "macos-14", "can_skip_in_simple_test": true },
-            { "os": "ubuntu-20.04", "can_skip_in_simple_test": false },
-            { "os": "ubuntu-22.04", "can_skip_in_simple_test": true }
+            { "os": "ubuntu-22.04", "can_skip_in_simple_test": false },
+            { "os": "ubuntu-24.04", "can_skip_in_simple_test": true }
           ]'
 
           # FIXME: composite action に切り出す


### PR DESCRIPTION
## 内容

`ubuntu-20.04`のbrownoutが開始したため。

See-also: https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/

## 関連 Issue

## その他
