### PR TITLE
docs: APIドキュメントのポータルのTODOを外し、Java APIを一旦隠す

### DIFF
--- a/docs/ghpages/apis/index.html
+++ b/docs/ghpages/apis/index.html
@@ -9,7 +9,10 @@
       <li><a href="./rust_api/voicevox_core">Rust API</a></li>
       <li><a href="./c_api/voicevox__core_8h.html">C API</a></li>
       <li><a href="./python_api/autoapi/voicevox_core/index.html">Python API</a></li>
-      <!-- <li><a href="./java_api">Java API</a></li> -->
+      <!--
+        TODO: Java APIが正式版になったらコメントアウトをやめる
+        <li><a href="./java_api">Java API</a></li>
+      -->
     </ul>
   </body>
 </html>

--- a/docs/ghpages/apis/index.html
+++ b/docs/ghpages/apis/index.html
@@ -4,13 +4,12 @@
     <meta charset="utf-8" />
   </head>
   <body>
-    <p>TODO: まともなページを用意する</p>
     <p><a href="https://github.com/VOICEVOX/voicevox_core/pull/496">VOICEVOX/voicevox_core#496</a></p>
     <ul>
       <li><a href="./rust_api/voicevox_core">Rust API</a></li>
       <li><a href="./c_api/voicevox__core_8h.html">C API</a></li>
       <li><a href="./python_api/autoapi/voicevox_core/index.html">Python API</a></li>
-      <li><a href="./java_api">Java API</a></li>
+      <!-- <li><a href="./java_api">Java API</a></li> -->
     </ul>
   </body>
 </html>


### PR DESCRIPTION
## 内容

APIドキュメントのポータルのTODOを外し、Java APIを一旦隠すようにしました。
これで↓をcloseできるはず･･･？

- https://github.com/VOICEVOX/voicevox_core/issues/1017

## 関連 Issue

close #1017

## スクリーンショット・動画など

## その他
