### PR TITLE
fix(python): ダミー`__new__`の型付けを直す

### DIFF
--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/asyncio.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/asyncio.pyi
@@ -18,9 +18,7 @@ class VoiceModelFile:
     """
     音声モデルファイル。"""
 
-    def __new__(
-        cls, *args: tuple[object], **kwargs: dict[object, object]
-    ) -> NoReturn: ...
+    def __new__(cls, *args: object, **kwargs: object) -> NoReturn: ...
     @staticmethod
     async def open(path: str | PathLike[str]) -> VoiceModelFile:
         """
@@ -98,9 +96,7 @@ class Onnxruntime:
     LIB_UNVERSIONED_FILENAME: str
     """:attr:`LIB_NAME` からなる動的ライブラリのファイル名。"""
 
-    def __new__(
-        cls, *args: tuple[object], **kwargs: dict[object, object]
-    ) -> NoReturn: ...
+    def __new__(cls, *args: object, **kwargs: object) -> NoReturn: ...
     @staticmethod
     def get() -> Union["Onnxruntime", None]:
         """
@@ -136,9 +132,7 @@ class OpenJtalk:
     テキスト解析器としてのOpen JTalk。
     """
 
-    def __new__(
-        cls, *args: tuple[object], **kwargs: dict[object, object]
-    ) -> NoReturn: ...
+    def __new__(cls, *args: object, **kwargs: object) -> NoReturn: ...
     @staticmethod
     async def new(open_jtalk_dict_dir: str | PathLike[str]) -> "OpenJtalk":
         """

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
@@ -18,9 +18,7 @@ class VoiceModelFile:
     """
     音声モデルファイル。"""
 
-    def __new__(
-        cls, *args: tuple[object], **kwargs: dict[object, object]
-    ) -> NoReturn: ...
+    def __new__(cls, *args: object, **kwargs: object) -> NoReturn: ...
     @staticmethod
     def open(path: str | PathLike[str]) -> VoiceModelFile:
         """
@@ -98,9 +96,7 @@ class Onnxruntime:
     LIB_UNVERSIONED_FILENAME: str
     """:attr:`LIB_NAME` からなる動的ライブラリのファイル名。"""
 
-    def __new__(
-        cls, *args: tuple[object], **kwargs: dict[object, object]
-    ) -> NoReturn: ...
+    def __new__(cls, *args: object, **kwargs: object) -> NoReturn: ...
     @staticmethod
     def get() -> Union["Onnxruntime", None]:
         """


### PR DESCRIPTION
## 内容

誤: `*args: tuple[object], **kwargs: dict[object, object]`
生: `*args: object, **kwargs: object`

普通にユーザーが目にする範囲ではあるので、直す。

## 関連 Issue

## その他
