### PR TITLE
docs: テストの方法を案内する

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,25 @@ Issue 側で取り組み始めたことを伝えるか、最初に Draft プル�
 
 [cbindgen](https://crates.io/crates/cbindgen) が手元にインストールされているなら、それを使いヘッダファイルを生成することもできます。
 
+## テスト
+
+テストの方法は各言語ごとに異なります。各言語のreadmeを参照してください。
+
+Rustのコードに対しては一般的なRustライブラリと同様、`cargo test`でテストできます。
+
+```bash
+cargo test # Rust APIのテストを実行
+```
+
+[`--include-ignored`]を付けることで[C API]のテストも一緒に実行できます。
+
+```bash
+cargo test -- --include-ignored # Rust APIとC APIをまとめてテスト
+```
+
+[`--include-ignored`]: https://doc.rust-lang.org/reference/attributes/testing.html#the-ignore-attribute
+[C API]: ./crates/voicevox_core_c_api/
+
 ## ダウンローダーの実行
 
 ```bash

--- a/crates/voicevox_core_python_api/README.md
+++ b/crates/voicevox_core_python_api/README.md
@@ -60,6 +60,16 @@ VOICEVOX CORE の Python バインディングです。
 ❯ maturin build --release --locked
 ```
 
+## テスト
+
+`maturin develop` で editable な状態でインストールした後に[pytestのテスト]を実行します。
+
+```console
+❯ pytest
+```
+
+[pytestのテスト]: ./python/test/
+
 ## サンプル実行
 
 `maturin develop` で editable な状態でインストールした後、[example/python](../../example/python) にてサンプルを実行できます。


### PR DESCRIPTION
## 内容

C APIとJava APIにはテスト方法を書いてあるが、Rust APIとPython APIに書かれてなかったので書く。また、CONTRIBUTING.mdにも案内を書く。

## 関連 Issue

Resolves: #1051

## その他
