### PR TITLE
fix(ci): downloaderビルドのenvironment指定を直す

### DIFF
--- a/.github/workflows/build_and_deploy_downloader.yml
+++ b/.github/workflows/build_and_deploy_downloader.yml
@@ -37,7 +37,7 @@ defaults:
 
 jobs:
   deploy_and_deploy_downloader:
-    environment: ${{ inputs.code_signing && 'production' || '' }} # コード署名用のenvironment
+    environment: ${{ inputs.code_signing && 'code_signing' || '' }} # コード署名用のenvironment
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## 内容

タイトルのとおりです。

0.16に間に合わせられない気がするので、ちょっとダウンローダーだけ署名なしにしようと思います！

## その他
