### PR TITLE
docs: ドキュメント内のwhlファイルの古いバージョン記述を更新

### DIFF
--- a/docs/guide/user/usage.md
+++ b/docs/guide/user/usage.md
@@ -71,7 +71,7 @@ Raspberry Pi 用の ONNX Runtime は以下からダウンロードできます�
 `pip install`で Python ライブラリをインストールします。使いたい OS・アーキテクチャ・デバイス・バージョンによって URL が変わるので、[最新のリリース](https://github.com/VOICEVOX/voicevox_core/releases/latest/)の`Python wheel`に合わせます。
 
 ```sh
-pip install https://github.com/VOICEVOX/voicevox_core/releases/download/[バージョン]/voicevox_core-[バージョン]+[デバイス]-cp38-abi3-[OS・アーキテクチャ].whl
+pip install https://github.com/VOICEVOX/voicevox_core/releases/download/[バージョン]/voicevox_core-[バージョン]+[デバイス]-cp310-abi3-[OS・アーキテクチャ].whl
 ```
 
 ## テキスト音声合成

--- a/example/python/README.md
+++ b/example/python/README.md
@@ -10,10 +10,10 @@ voicevox_core ライブラリ の Python バインディングを使った音声
 `[バージョン]`の部分は適宜書き換えてください。
 
 ```console
-❯ pip install https://github.com/VOICEVOX/voicevox_core/releases/download/[バージョン]/voicevox_core-[バージョン]+cpu-cp38-abi3-linux_x86_64.whl
+❯ pip install https://github.com/VOICEVOX/voicevox_core/releases/download/[バージョン]/voicevox_core-[バージョン]+cpu-cp310-abi3-linux_x86_64.whl
 ```
 
-cpu-cp38-abi3-linux_x86_64 のところはアーキテクチャや OS によって適宜読み替えてください。
+cpu-cp310-abi3-linux_x86_64 のところはアーキテクチャや OS によって適宜読み替えてください。
 https://github.com/VOICEVOX/voicevox_core/releases/latest
 
 2. ダウンローダーを使って環境構築します。


### PR DESCRIPTION
## 内容

#926 によってwhlファイルの名前に含まれるPythonバージョンが、`cp38`から`cp310`に変更されましたが、ドキュメントが追従していなかったので更新します。

## 関連 Issue

ref #915 
ref #926 

## その他
