### PR TITLE
ci: `check-shebangs-and-filemodes`ワークフローを追加

### DIFF
--- a/.github/workflows/check-shebangs-and-filemodes.yml
+++ b/.github/workflows/check-shebangs-and-filemodes.yml
@@ -22,33 +22,33 @@ jobs:
             first_line=$(head -n 1 "$filename")
             shebang_line=$(grep '^#!/' <<< "$first_line" || true)
 
-            has-shebang() {
+            has_shebang() {
               [ -n "$shebang_line" ]
             }
 
-            is-shellscript() {
+            is_shellscript() {
               [[ "$filename" =~ \.(ba)?sh$ ]]
             }
 
-            is-executable() {
+            is_executable() {
               [ "$filemode" = 100755 ]
             }
 
             echo -n "$filename ($filemode): "
 
-            if has-shebang && ! is-executable; then
+            if has_shebang && ! is_executable; then
               # shellcheck disable=SC2016
               echo 'A shebanged file must be executable (note: if you are using Windows, please change the filemode with `git update-index --chmod+x`)'
               exit 1
             fi
 
-            if is-shellscript && ! is-executable; then
+            if is_shellscript && ! is_executable; then
               # shellcheck disable=SC2016
               echo 'A shell script file must be executable (note: if you are using Windows, please change the filemode with `git update-index --chmod+x`)'
               exit 1
             fi
 
-            if is-executable && ! has-shebang; then
+            if is_executable && ! has_shebang; then
               echo 'An executable blob must have a shebang'
               exit 1
             fi

--- a/.github/workflows/check-shebangs-and-filemodes.yml
+++ b/.github/workflows/check-shebangs-and-filemodes.yml
@@ -1,0 +1,55 @@
+# shebangとfilemodeが一貫しているかをチェックする。またbashファイルについてもこの両者についてチェックする。
+name: Check shebangs and filemodes
+
+on:
+  push:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check shebangs and filemodes
+        run: |
+          blobs=$(git ls-files -s | grep '^100')
+
+          while read -r blob; do
+            filemode=$(awk '{ print $1 }' <<< "$blob")
+            filename=$(awk '{ print $4 }' <<< "$blob")
+
+            first_line=$(head -n 1 "$filename")
+            shebang_line=$(grep '^#!/' <<< "$first_line" || true)
+
+            has-shebang() {
+              [ -n "$shebang_line" ]
+            }
+
+            is-shellscript() {
+              [[ "$filename" =~ \.(ba)?sh$ ]]
+            }
+
+            is-executable() {
+              [ "$filemode" = 100755 ]
+            }
+
+            echo -n "$filename ($filemode): "
+
+            if has-shebang && ! is-executable; then
+              echo 'A shebanged file must be executable'
+              exit 1
+            fi
+
+            if is-shellscript && ! is-executable; then
+              echo 'A shell script file must be executable'
+              exit 1
+            fi
+
+            if is-executable && ! has-shebang; then
+              echo 'An executable blob must have a shebang'
+              exit 1
+            fi
+
+            echo OK
+          done <<< "$blobs"

--- a/.github/workflows/check-shebangs-and-filemodes.yml
+++ b/.github/workflows/check-shebangs-and-filemodes.yml
@@ -37,12 +37,14 @@ jobs:
             echo -n "$filename ($filemode): "
 
             if has-shebang && ! is-executable; then
-              echo 'A shebanged file must be executable'
+              # shellcheck disable=SC2016
+              echo 'A shebanged file must be executable (note: if you are using Windows, please change the filemode with `git update-index --chmod+x`)'
               exit 1
             fi
 
             if is-shellscript && ! is-executable; then
-              echo 'A shell script file must be executable'
+              # shellcheck disable=SC2016
+              echo 'A shell script file must be executable (note: if you are using Windows, please change the filemode with `git update-index --chmod+x`)'
               exit 1
             fi
 


### PR DESCRIPTION
## 内容

#1077 の続き。

このリポジトリ内のすべてのファイルに対し、以下のチェックを義務付ける。

```bash
if has_shebang && ! is_executable; then
  # shellcheck disable=SC2016
  echo 'A shebanged file must be executable (note: if you are using Windows, please change the filemode with `git update-index --chmod+x`)'
  exit 1
fi

if is_shellscript && ! is_executable; then
  # shellcheck disable=SC2016
  echo 'A shell script file must be executable (note: if you are using Windows, please change the filemode with `git update-index --chmod+x`)'
  exit 1
fi

if is_executable && ! has_shebang; then
  echo 'An executable blob must have a shebang'
  exit 1
fi
```

## 関連 Issue

## その他
