### PR TITLE
refactor(ci): 撲滅可能なUUOCを撲滅する

### DIFF
--- a/.github/actions/rust-toolchain-from-file/action.yml
+++ b/.github/actions/rust-toolchain-from-file/action.yml
@@ -12,7 +12,7 @@ runs:
   steps:
     - id: read-rust-toolchain
       shell: bash
-      run: echo "toolchain=$(cat ./rust-toolchain)" >> "$GITHUB_OUTPUT"
+      run: echo "toolchain=$(< ./rust-toolchain)" >> "$GITHUB_OUTPUT"
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ steps.read-rust-toolchain.outputs.toolchain }}

--- a/.github/workflows/download_test.yml
+++ b/.github/workflows/download_test.yml
@@ -170,7 +170,7 @@ jobs:
       - name: Check downloaded version
         run: |
           [ -e "${{ matrix.download_dir }}/c_api/VERSION" ]
-          [ "$(cat "${{ matrix.download_dir }}/c_api/VERSION")" = "${{ env.VERSION }}" ]
+          [ "$(< "${{ matrix.download_dir }}/c_api/VERSION")" = "${{ env.VERSION }}" ]
       - name: Check downloaded files
         run: |
           mapfile -t items < <(echo -n '${{ matrix.check_items }}')


### PR DESCRIPTION
## 内容

撲滅可能なUUOC (**U**seless **u**se **o**f <code>**c**at</code>)を撲滅する。以下の`cat`の利用は放置。

- `cat <<EOF | while read -r line; do; …`
    - `cat`を抜こうとすると、ヒアドキュメントを後ろの方に持って来なければならないため。
    - arrayに格納してからforループにしたい気持ちがあるが、とりあえずこのまま
- `<(cat <<< "$variable")`

CIによるチェックは入れない。というより簡単にできるかがわからない。[VOICEVOX organizationにおける"uuoc"の検索結果](https://github.com/search?q=org:VOICEVOX+"uuoc")に引っ掛かるよう、判例を作るのが目的。

## 関連 Issue

## その他
