### PR TITLE
fix(compatible-engine): `load_model`が"reinit"できるように直す

### DIFF
--- a/crates/voicevox_core_c_api/src/compatible_engine.rs
+++ b/crates/voicevox_core_c_api/src/compatible_engine.rs
@@ -172,8 +172,11 @@ pub extern "C" fn load_model(style_id: i64) -> bool {
     if let Some(model_id) = model_set.style_model_map.get(&style_id) {
         let vvm = model_set.model_map.get(model_id).unwrap();
         let synthesizer = &mut *lock_synthesizer();
-        let result = ensure_initialized!(synthesizer).load_voice_model(vvm);
-        if let Some(err) = result.err() {
+        let synthesizer = ensure_initialized!(synthesizer);
+        if let Err(err) = synthesizer.unload_voice_model(*model_id) {
+            assert_eq!(voicevox_core::ErrorKind::ModelNotFound, err.kind());
+        }
+        if let Err(err) = synthesizer.load_voice_model(vvm) {
             set_message(&format!("{err}"));
             false
         } else {


### PR DESCRIPTION
## 内容

`/initialize_speaker?skip_reinit=false`での"reinit"ができなくなっていたので、できるようにする。

## 関連 Issue

## その他

Before:
![image](https://github.com/user-attachments/assets/cd82443a-d6d9-4deb-8d27-07c533b3e4af)

After:
![image](https://github.com/user-attachments/assets/c20c5c5d-5fbf-4c36-a14f-d1b12a9e1c6d)

