### PR TITLE
refactor(cargo): `default-features = false`を`workspace`側のみに

### DIFF
--- a/crates/downloader/Cargo.toml
+++ b/crates/downloader/Cargo.toml
@@ -14,7 +14,7 @@ base64.workspace = true
 binstall-tar.workspace = true
 bytes.workspace = true
 clap = { workspace = true, features = ["derive"] }
-comrak = { workspace = true, default-features = false }
+comrak.workspace = true
 easy-ext.workspace = true
 flate2.workspace = true
 fs-err = { workspace = true, features = ["tokio"] }
@@ -24,10 +24,10 @@ indexmap.workspace = true
 indicatif.workspace = true
 itertools.workspace = true
 minus = { workspace = true, features = ["static_output"] }
-octocrab = { workspace = true, default-features = false, features = ["rustls-tls", "stream"] }
+octocrab = { workspace = true, features = ["rustls-tls", "stream"] }
 parse-display.workspace = true
 rayon.workspace = true
-reqwest = { workspace = true, default-features = false, features = ["rustls-tls", "stream"] }
+reqwest = { workspace = true, features = ["rustls-tls", "stream"] }
 rprompt.workspace = true
 scraper.workspace = true
 semver.workspace = true

--- a/crates/voicevox_core_c_api/Cargo.toml
+++ b/crates/voicevox_core_c_api/Cargo.toml
@@ -19,11 +19,11 @@ load-onnxruntime = ["voicevox_core/load-onnxruntime"]
 link-onnxruntime = ["voicevox_core/link-onnxruntime"]
 
 [dependencies]
-anstream = { workspace = true, default-features = false, features = ["auto"] }
+anstream = { workspace = true, features = ["auto"] }
 anstyle-query.workspace = true
 boxcar.workspace = true
 camino.workspace = true
-chrono = { workspace = true, default-features = false, features = ["clock"] }
+chrono = { workspace = true, features = ["clock"] }
 colorchoice.workspace = true
 const_format.workspace = true
 duplicate.workspace = true

--- a/crates/voicevox_core_java_api/Cargo.toml
+++ b/crates/voicevox_core_java_api/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 android_logger.workspace = true
-chrono = { workspace = true, default-features = false, features = ["clock"] }
+chrono = { workspace = true, features = ["clock"] }
 derive_more = { workspace = true, features = ["from"] }
 duplicate.workspace = true
 easy-ext.workspace = true


### PR DESCRIPTION
## 内容

`default-features = false`は`workspace.dependencies`と各パッケージ側の`dependencies`の両方に記述する必要は無いため、前者のみを書くように統一する。

## 関連 Issue

## その他
