### PR TITLE
docs: Java APIの封を解く

### DIFF
--- a/docs/ghpages/apis/index.html
+++ b/docs/ghpages/apis/index.html
@@ -9,10 +9,7 @@
       <li><a href="./rust_api/voicevox_core">Rust API</a></li>
       <li><a href="./c_api/voicevox__core_8h.html">C API</a></li>
       <li><a href="./python_api/autoapi/voicevox_core/index.html">Python API</a></li>
-      <!--
-        TODO: Java APIが正式版になったらコメントアウトをやめる
-        <li><a href="./java_api">Java API</a></li>
-      -->
+      <li><a href="./java_api">Java API</a></li>
     </ul>
   </body>
 </html>


### PR DESCRIPTION
## 内容

#1044 で行ったコメントアウトを取り止める。

理由としては、[その後結局0.16.0でJava APIをリリースしちゃっているはず]なので。

[その後結局0.16.0でJava APIをリリースしちゃっているはず]: https://github.com/VOICEVOX/voicevox_core/releases/tag/0.16.0

## 関連 Issue

## その他
