### PR TITLE
build!: drop `windows-2019`

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           includes='[
             {
-              "os": "windows-2019",
+              "os": "windows-2022",
               "target": "x86_64-pc-windows-msvc",
               "artifact_name": "windows-x64",
               "c_release_format": "plain-cdylib",
@@ -55,7 +55,7 @@ jobs:
               "can_skip_in_simple_test": false
             },
             {
-              "os": "windows-2019",
+              "os": "windows-2022",
               "target": "i686-pc-windows-msvc",
               "artifact_name": "windows-x86",
               "c_release_format": "plain-cdylib",

--- a/.github/workflows/build_and_deploy_downloader.yml
+++ b/.github/workflows/build_and_deploy_downloader.yml
@@ -43,7 +43,7 @@ jobs:
         include:
           - name: download-windows-x64.exe
             target: x86_64-pc-windows-msvc
-            os: windows-2019
+            os: windows-2022
 
           - name: download-linux-x64
             target: x86_64-unknown-linux-gnu

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,9 +104,10 @@ jobs:
       - name: declare strategy matrix
         id: strategy-matrix
         run: |
+          # FIXME: `windows-2022`はテスト対象に含むべき
           includes='[
-            { "os": "windows-2019", "can_skip_in_simple_test": true },
             { "os": "windows-2022", "can_skip_in_simple_test": true },
+            { "os": "windows-2025", "can_skip_in_simple_test": true },
             { "os": "macos-13", "can_skip_in_simple_test": false },
             { "os": "macos-14", "can_skip_in_simple_test": true },
             { "os": "ubuntu-22.04", "can_skip_in_simple_test": false },


### PR DESCRIPTION
## 内容

[brownoutが始まった](https://github.com/actions/runner-images/issues/12045)ため。

BREAKING-CHANGE: リリースにおけるWindowsのランナーが`windows-2022`になる。ただしVOICEVOX ONNX Runtimeの方は元々`windows-2022`でビルドされているため、通常の用途においては特に変わらないはず。

## 関連 Issue

## その他
