### PR TITLE
feat(rust): Rust Analyzerが`doc(alias)`に反応しないようにする

### DIFF
--- a/crates/voicevox_core/src/core/infer/runtimes/onnxruntime.rs
+++ b/crates/voicevox_core/src/core/infer/runtimes/onnxruntime.rs
@@ -310,7 +310,7 @@ pub(crate) mod blocking {
     /// ```
     ///
     /// [voicevox-ort]: https://github.com/VOICEVOX/ort
-    #[doc(alias = "VoicevoxOnnxruntime")]
+    #[cfg_attr(doc, doc(alias = "VoicevoxOnnxruntime"))]
     #[derive(Debug, RefCastCustom)]
     #[repr(transparent)]
     pub struct Onnxruntime {
@@ -335,7 +335,7 @@ pub(crate) mod blocking {
         /// [`LIB_NAME`]: Self::LIB_NAME
         /// [`LIB_VERSION`]: Self::LIB_VERSION
         /// [`LIB_UNVERSIONED_FILENAME`]: Self::LIB_UNVERSIONED_FILENAME
-        #[doc(alias = "voicevox_get_onnxruntime_lib_versioned_filename")]
+        #[cfg_attr(doc, doc(alias = "voicevox_get_onnxruntime_lib_versioned_filename"))]
         #[cfg(feature = "load-onnxruntime")]
         #[cfg_attr(docsrs, doc(cfg(feature = "load-onnxruntime")))]
         pub const LIB_VERSIONED_FILENAME: &'static str = if cfg!(target_os = "linux") {
@@ -360,7 +360,7 @@ pub(crate) mod blocking {
         /// [`LIB_NAME`]からなる動的ライブラリのファイル名。
         ///
         /// [`LIB_NAME`]: Self::LIB_NAME
-        #[doc(alias = "voicevox_get_onnxruntime_lib_unversioned_filename")]
+        #[cfg_attr(doc, doc(alias = "voicevox_get_onnxruntime_lib_unversioned_filename"))]
         #[cfg(feature = "load-onnxruntime")]
         #[cfg_attr(docsrs, doc(cfg(feature = "load-onnxruntime")))]
         pub const LIB_UNVERSIONED_FILENAME: &'static str = const_format::concatcp!(
@@ -375,7 +375,7 @@ pub(crate) mod blocking {
         /// インスタンスが既に作られているならそれを得る。
         ///
         /// 作られていなければ`None`を返す。
-        #[doc(alias = "voicevox_onnxruntime_get")]
+        #[cfg_attr(doc, doc(alias = "voicevox_onnxruntime_get"))]
         pub fn get() -> Option<&'static Self> {
             EnvHandle::get().map(Self::new)
         }
@@ -393,7 +393,7 @@ pub(crate) mod blocking {
         /// ONNX Runtimeをロードして初期化する。
         ///
         /// 一度成功したら、以後は引数を無視して同じ参照を返す。
-        #[doc(alias = "voicevox_onnxruntime_load_once")]
+        #[cfg_attr(doc, doc(alias = "voicevox_onnxruntime_load_once"))]
         #[cfg(feature = "load-onnxruntime")]
         #[cfg_attr(docsrs, doc(cfg(feature = "load-onnxruntime")))]
         pub fn load_once() -> LoadOnce {
@@ -403,7 +403,7 @@ pub(crate) mod blocking {
         /// ONNX Runtimeを初期化する。
         ///
         /// 一度成功したら以後は同じ参照を返す。
-        #[doc(alias = "voicevox_onnxruntime_init_once")]
+        #[cfg_attr(doc, doc(alias = "voicevox_onnxruntime_init_once"))]
         #[cfg(feature = "link-onnxruntime")]
         #[cfg_attr(docsrs, doc(cfg(feature = "link-onnxruntime")))]
         pub fn init_once() -> crate::Result<&'static Self> {
@@ -427,7 +427,7 @@ pub(crate) mod blocking {
         }
 
         /// ONNX Runtimeとして利用可能なデバイスの情報を取得する。
-        #[doc(alias = "voicevox_onnxruntime_create_supported_devices_json")]
+        #[cfg_attr(doc, doc(alias = "voicevox_onnxruntime_create_supported_devices_json"))]
         pub fn supported_devices(&self) -> crate::Result<SupportedDevices> {
             <Self as InferenceRuntime>::supported_devices(self)
         }

--- a/crates/voicevox_core/src/core/metas.rs
+++ b/crates/voicevox_core/src/core/metas.rs
@@ -59,7 +59,7 @@ pub fn merge<'a>(metas: impl IntoIterator<Item = &'a CharacterMeta>) -> Vec<Char
     new,
     Debug,
 )]
-#[doc(alias = "VoicevoxStyleId")]
+#[cfg_attr(doc, doc(alias = "VoicevoxStyleId"))]
 pub struct StyleId(pub u32);
 
 impl Display for StyleId {

--- a/crates/voicevox_core/src/core/voice_model.rs
+++ b/crates/voicevox_core/src/core/voice_model.rs
@@ -41,7 +41,7 @@ pub(super) type ModelBytesWithInnerVoiceIdsByDomain = inference_domain_map_value
 );
 
 /// 音声モデルID。
-#[doc(alias = "VoicevoxVoiceModelId")]
+#[cfg_attr(doc, doc(alias = "VoicevoxVoiceModelId"))]
 #[derive(
     PartialEq,
     Eq,
@@ -603,12 +603,12 @@ pub(crate) mod blocking {
     /// 音声モデルファイル。
     ///
     /// VVMファイルと対応する。
-    #[doc(alias = "VoicevoxVoiceModelFile")]
+    #[cfg_attr(doc, doc(alias = "VoicevoxVoiceModelFile"))]
     pub struct VoiceModelFile(Inner<SingleTasked>);
 
     impl self::VoiceModelFile {
         /// VVMファイルを開く。
-        #[doc(alias = "voicevox_voice_model_file_open")]
+        #[cfg_attr(doc, doc(alias = "voicevox_voice_model_file_open"))]
         pub fn open(path: impl AsRef<Path>) -> crate::Result<Self> {
             Inner::open(path).block_on().map(Self)
         }
@@ -624,13 +624,13 @@ pub(crate) mod blocking {
         }
 
         /// ID。
-        #[doc(alias = "voicevox_voice_model_file_id")]
+        #[cfg_attr(doc, doc(alias = "voicevox_voice_model_file_id"))]
         pub fn id(&self) -> VoiceModelId {
             self.0.id()
         }
 
         /// メタ情報。
-        #[doc(alias = "voicevox_voice_model_file_create_metas_json")]
+        #[cfg_attr(doc, doc(alias = "voicevox_voice_model_file_create_metas_json"))]
         pub fn metas(&self) -> &VoiceModelMeta {
             self.0.metas()
         }

--- a/crates/voicevox_core/src/engine/talk/open_jtalk.rs
+++ b/crates/voicevox_core/src/engine/talk/open_jtalk.rs
@@ -44,12 +44,12 @@ pub(crate) mod blocking {
     };
 
     /// テキスト解析器としてのOpen JTalk。
-    #[doc(alias = "OpenJtalkRc")]
+    #[cfg_attr(doc, doc(alias = "OpenJtalkRc"))]
     #[derive(Clone)]
     pub struct OpenJtalk(pub(super) Arc<Inner>);
 
     impl self::OpenJtalk {
-        #[doc(alias = "voicevox_open_jtalk_rc_new")]
+        #[cfg_attr(doc, doc(alias = "voicevox_open_jtalk_rc_new"))]
         pub fn new(open_jtalk_dict_dir: impl AsRef<Utf8Path>) -> crate::result::Result<Self> {
             let dict_dir = open_jtalk_dict_dir.as_ref().to_owned();
 
@@ -75,7 +75,7 @@ pub(crate) mod blocking {
         /// ユーザー辞書を設定する。
         ///
         /// この関数を呼び出した後にユーザー辞書を変更した場合は、再度この関数を呼ぶ必要がある。
-        #[doc(alias = "voicevox_open_jtalk_rc_use_user_dict")]
+        #[cfg_attr(doc, doc(alias = "voicevox_open_jtalk_rc_use_user_dict"))]
         pub fn use_user_dict(
             &self,
             user_dict: &crate::blocking::UserDict,

--- a/crates/voicevox_core/src/engine/talk/user_dict/dict.rs
+++ b/crates/voicevox_core/src/engine/talk/user_dict/dict.rs
@@ -121,18 +121,18 @@ pub(crate) mod blocking {
     /// ユーザー辞書。
     ///
     /// 単語はJSONとの相互変換のために挿入された順序を保つ。
-    #[doc(alias = "VoicevoxUserDict")]
+    #[cfg_attr(doc, doc(alias = "VoicevoxUserDict"))]
     #[derive(Debug, Default)]
     pub struct UserDict(Inner<SingleTasked>);
 
     impl self::UserDict {
         /// ユーザー辞書を作成する。
-        #[doc(alias = "voicevox_user_dict_new")]
+        #[cfg_attr(doc, doc(alias = "voicevox_user_dict_new"))]
         pub fn new() -> Self {
             Default::default()
         }
 
-        #[doc(alias = "voicevox_user_dict_to_json")]
+        #[cfg_attr(doc, doc(alias = "voicevox_user_dict_to_json"))]
         pub fn to_json(&self) -> String {
             self.0.to_json()
         }
@@ -146,37 +146,37 @@ pub(crate) mod blocking {
         /// # Errors
         ///
         /// ファイルが読めなかった、または内容が不正だった場合はエラーを返す。
-        #[doc(alias = "voicevox_user_dict_load")]
+        #[cfg_attr(doc, doc(alias = "voicevox_user_dict_load"))]
         pub fn load(&self, store_path: impl AsRef<Path>) -> Result<()> {
             self.0.load(store_path).block_on()
         }
 
         /// ユーザー辞書に単語を追加する。
-        #[doc(alias = "voicevox_user_dict_add_word")]
+        #[cfg_attr(doc, doc(alias = "voicevox_user_dict_add_word"))]
         pub fn add_word(&self, word: UserDictWord) -> Result<Uuid> {
             self.0.add_word(word)
         }
 
         /// ユーザー辞書の単語を変更する。
-        #[doc(alias = "voicevox_user_dict_update_word")]
+        #[cfg_attr(doc, doc(alias = "voicevox_user_dict_update_word"))]
         pub fn update_word(&self, word_uuid: Uuid, new_word: UserDictWord) -> Result<()> {
             self.0.update_word(word_uuid, new_word)
         }
 
         /// ユーザー辞書から単語を削除する。
-        #[doc(alias = "voicevox_user_dict_remove_word")]
+        #[cfg_attr(doc, doc(alias = "voicevox_user_dict_remove_word"))]
         pub fn remove_word(&self, word_uuid: Uuid) -> Result<UserDictWord> {
             self.0.remove_word(word_uuid)
         }
 
         /// 他のユーザー辞書をインポートする。
-        #[doc(alias = "voicevox_user_dict_import")]
+        #[cfg_attr(doc, doc(alias = "voicevox_user_dict_import"))]
         pub fn import(&self, other: &Self) -> Result<()> {
             self.0.import(&other.0)
         }
 
         /// ユーザー辞書を保存する。
-        #[doc(alias = "voicevox_user_dict_save")]
+        #[cfg_attr(doc, doc(alias = "voicevox_user_dict_save"))]
         pub fn save(&self, store_path: impl AsRef<Path>) -> Result<()> {
             self.0.save(store_path).block_on()
         }

--- a/crates/voicevox_core/src/engine/talk/user_dict/word.rs
+++ b/crates/voicevox_core/src/engine/talk/user_dict/word.rs
@@ -16,7 +16,7 @@ use super::part_of_speech_data::{
 /// VOICEVOX ENGINEと同じスキーマになっている。ただし今後の破壊的変更にて変わる可能性がある。[データのシリアライゼーション]を参照。
 ///
 /// [データのシリアライゼーション]: https://github.com/VOICEVOX/voicevox_core/blob/main/docs/guide/user/serialization.md
-#[doc(alias = "VoicevoxUserDictWord")]
+#[cfg_attr(doc, doc(alias = "VoicevoxUserDictWord"))]
 #[derive(Clone, Debug)]
 pub struct UserDictWord {
     /// 単語の表記。
@@ -192,7 +192,7 @@ static MORA_REGEX: LazyLock<Regex> = LazyLock::new(|| {
 static SPACE_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\p{Z}").unwrap());
 
 impl UserDictWord {
-    #[doc(alias = "voicevox_user_dict_word_make")]
+    #[cfg_attr(doc, doc(alias = "voicevox_user_dict_word_make"))]
     pub fn builder() -> UserDictWordBuilder {
         Default::default()
     }
@@ -359,7 +359,7 @@ impl Default for UserDictWordBuilder {
 }
 
 /// ユーザー辞書の単語の種類。
-#[doc(alias = "VoicevoxUserDictWordType")]
+#[cfg_attr(doc, doc(alias = "VoicevoxUserDictWordType"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum UserDictWordType {

--- a/crates/voicevox_core/src/error.rs
+++ b/crates/voicevox_core/src/error.rs
@@ -128,7 +128,7 @@ pub(crate) enum ErrorRepr {
     clippy::manual_non_exhaustive,
     reason = "バインディングを作るときはexhaustiveとして扱いたい"
 )]
-#[doc(alias = "VoicevoxResultCode")]
+#[cfg_attr(doc, doc(alias = "VoicevoxResultCode"))]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum ErrorKind {
     /// open_jtalk辞書ファイルが読み込まれていない。

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -90,7 +90,7 @@ impl<A: infer::AsyncExt> Default for TtsOptions<A> {
 }
 
 /// ハードウェアアクセラレーションモードを設定する設定値。
-#[doc(alias = "VoicevoxAccelerationMode")]
+#[cfg_attr(doc, doc(alias = "VoicevoxAccelerationMode"))]
 #[expect(
     clippy::manual_non_exhaustive,
     reason = "バインディングを作るときはexhaustiveとして扱いたい"
@@ -1205,7 +1205,7 @@ fn list_windows_video_cards() {
 
 impl AudioQuery {
     /// アクセント句の配列からAudioQueryを作る。
-    #[doc(alias = "voicevox_audio_query_create_from_accent_phrases")]
+    #[cfg_attr(doc, doc(alias = "voicevox_audio_query_create_from_accent_phrases"))]
     pub fn from_accent_phrases(accent_phrases: Vec<AccentPhrase>) -> Self {
         let kana = create_kana(&accent_phrases);
         Self {
@@ -1291,7 +1291,7 @@ pub(crate) mod blocking {
     pub use super::AudioFeature;
 
     /// 音声シンセサイザ。
-    #[doc(alias = "VoicevoxSynthesizer")]
+    #[cfg_attr(doc, doc(alias = "VoicevoxSynthesizer"))]
     pub struct Synthesizer<T>(pub(super) Inner<AssumeSingleTasked<T>, SingleTasked>);
 
     impl self::Synthesizer<()> {
@@ -1325,7 +1325,7 @@ pub(crate) mod blocking {
         /// # Ok(())
         /// # }
         /// ```
-        #[doc(alias = "voicevox_synthesizer_new")]
+        #[cfg_attr(doc, doc(alias = "voicevox_synthesizer_new"))]
         pub fn builder(onnxruntime: &'static crate::blocking::Onnxruntime) -> Builder<()> {
             Builder {
                 onnxruntime,
@@ -1336,7 +1336,7 @@ pub(crate) mod blocking {
     }
 
     impl<T> self::Synthesizer<T> {
-        #[doc(alias = "voicevox_synthesizer_get_onnxruntime")]
+        #[cfg_attr(doc, doc(alias = "voicevox_synthesizer_get_onnxruntime"))]
         pub fn onnxruntime(&self) -> &'static crate::blocking::Onnxruntime {
             self.0.onnxruntime()
         }
@@ -1347,13 +1347,13 @@ pub(crate) mod blocking {
         }
 
         /// ハードウェアアクセラレーションがGPUモードか判定する。
-        #[doc(alias = "voicevox_synthesizer_is_gpu_mode")]
+        #[cfg_attr(doc, doc(alias = "voicevox_synthesizer_is_gpu_mode"))]
         pub fn is_gpu_mode(&self) -> bool {
             self.0.is_gpu_mode()
         }
 
         /// 音声モデルを読み込む。
-        #[doc(alias = "voicevox_synthesizer_load_voice_model")]
+        #[cfg_attr(doc, doc(alias = "voicevox_synthesizer_load_voice_model"))]
         pub fn load_voice_model(
             &self,
             model: &crate::blocking::VoiceModelFile,
@@ -1362,13 +1362,13 @@ pub(crate) mod blocking {
         }
 
         /// 音声モデルの読み込みを解除する。
-        #[doc(alias = "voicevox_synthesizer_unload_voice_model")]
+        #[cfg_attr(doc, doc(alias = "voicevox_synthesizer_unload_voice_model"))]
         pub fn unload_voice_model(&self, voice_model_id: VoiceModelId) -> crate::Result<()> {
             self.0.unload_voice_model(voice_model_id)
         }
 
         /// 指定したIDの音声モデルが読み込まれているか判定する。
-        #[doc(alias = "voicevox_synthesizer_is_loaded_voice_model")]
+        #[cfg_attr(doc, doc(alias = "voicevox_synthesizer_is_loaded_voice_model"))]
         pub fn is_loaded_voice_model(&self, voice_model_id: VoiceModelId) -> bool {
             self.0.is_loaded_voice_model(voice_model_id)
         }
@@ -1379,7 +1379,7 @@ pub(crate) mod blocking {
         }
 
         /// 今読み込んでいる音声モデルのメタ情報を返す。
-        #[doc(alias = "voicevox_synthesizer_create_metas_json")]
+        #[cfg_attr(doc, doc(alias = "voicevox_synthesizer_create_metas_json"))]
         pub fn metas(&self) -> VoiceModelMeta {
             self.0.metas()
         }
@@ -1414,7 +1414,7 @@ pub(crate) mod blocking {
         }
 
         /// AudioQueryから直接WAVフォーマットで音声波形を生成する。
-        #[doc(alias = "voicevox_synthesizer_synthesis")]
+        #[cfg_attr(doc, doc(alias = "voicevox_synthesizer_synthesis"))]
         pub fn synthesis<'a>(
             &'a self,
             audio_query: &'a AudioQuery,
@@ -1454,7 +1454,10 @@ pub(crate) mod blocking {
         /// # Ok(())
         /// # }
         /// ```
-        #[doc(alias = "voicevox_synthesizer_create_accent_phrases_from_kana")]
+        #[cfg_attr(
+            doc,
+            doc(alias = "voicevox_synthesizer_create_accent_phrases_from_kana")
+        )]
         pub fn create_accent_phrases_from_kana(
             &self,
             kana: &str,
@@ -1472,7 +1475,7 @@ pub(crate) mod blocking {
         /// [`replace_phoneme_length`]: Self::replace_phoneme_length
         /// [`replace_mora_pitch`]: Self::replace_mora_pitch
         /// [音声の調整]: ../index.html#音声の調整
-        #[doc(alias = "voicevox_synthesizer_replace_mora_data")]
+        #[cfg_attr(doc, doc(alias = "voicevox_synthesizer_replace_mora_data"))]
         pub fn replace_mora_data(
             &self,
             accent_phrases: &[AccentPhrase],
@@ -1484,7 +1487,7 @@ pub(crate) mod blocking {
         }
 
         /// AccentPhraseの配列の音素長を、特定の声で生成しなおす。
-        #[doc(alias = "voicevox_synthesizer_replace_phoneme_length")]
+        #[cfg_attr(doc, doc(alias = "voicevox_synthesizer_replace_phoneme_length"))]
         pub fn replace_phoneme_length(
             &self,
             accent_phrases: &[AccentPhrase],
@@ -1496,7 +1499,7 @@ pub(crate) mod blocking {
         }
 
         /// AccentPhraseの配列の音高を、特定の声で生成しなおす。
-        #[doc(alias = "voicevox_synthesizer_replace_mora_pitch")]
+        #[cfg_attr(doc, doc(alias = "voicevox_synthesizer_replace_mora_pitch"))]
         pub fn replace_mora_pitch(
             &self,
             accent_phrases: &[AccentPhrase],
@@ -1534,7 +1537,7 @@ pub(crate) mod blocking {
         /// ```
         ///
         /// [AudioQuery]: crate::AudioQuery
-        #[doc(alias = "voicevox_synthesizer_create_audio_query_from_kana")]
+        #[cfg_attr(doc, doc(alias = "voicevox_synthesizer_create_audio_query_from_kana"))]
         pub fn create_audio_query_from_kana(
             &self,
             kana: &str,
@@ -1546,7 +1549,7 @@ pub(crate) mod blocking {
         }
 
         /// AquesTalk風記法から音声合成を行う。
-        #[doc(alias = "voicevox_synthesizer_tts_from_kana")]
+        #[cfg_attr(doc, doc(alias = "voicevox_synthesizer_tts_from_kana"))]
         pub fn tts_from_kana<'a>(&'a self, kana: &'a str, style_id: StyleId) -> TtsFromKana<'a> {
             TtsFromKana {
                 synthesizer: self.0.without_text_analyzer(),
@@ -1589,7 +1592,7 @@ pub(crate) mod blocking {
         /// [`TextAnalyzer::analyze`]: crate::blocking::TextAnalyzer::analyze
         /// [`replace_mora_data`]: Self::replace_mora_data
         /// [音声の調整]: ../index.html#音声の調整
-        #[doc(alias = "voicevox_synthesizer_create_accent_phrases")]
+        #[cfg_attr(doc, doc(alias = "voicevox_synthesizer_create_accent_phrases"))]
         pub fn create_accent_phrases(
             &self,
             text: &str,
@@ -1629,7 +1632,7 @@ pub(crate) mod blocking {
         /// [AudioQuery]: crate::AudioQuery
         /// [`create_accent_phrases`]: Self::create_accent_phrases
         /// [音声の調整]: ../index.html#音声の調整
-        #[doc(alias = "voicevox_synthesizer_create_audio_query")]
+        #[cfg_attr(doc, doc(alias = "voicevox_synthesizer_create_audio_query"))]
         pub fn create_audio_query(
             &self,
             text: &str,
@@ -1645,7 +1648,7 @@ pub(crate) mod blocking {
         /// [`create_audio_query`]: Self::create_audio_query
         /// [`synthesis`]: Self::synthesis
         /// [音声の調整]: ../index.html#音声の調整
-        #[doc(alias = "voicevox_synthesizer_tts")]
+        #[cfg_attr(doc, doc(alias = "voicevox_synthesizer_tts"))]
         pub fn tts<'a>(&'a self, text: &'a str, style_id: StyleId) -> Tts<'a, T> {
             Tts {
                 synthesizer: &self.0,

--- a/crates/voicevox_core/src/version.rs
+++ b/crates/voicevox_core/src/version.rs
@@ -1,5 +1,5 @@
 /// 本クレートの`package.version`。
-#[doc(alias = "voicevox_get_version")]
+#[cfg_attr(doc, doc(alias = "voicevox_get_version"))]
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg(test)]


### PR DESCRIPTION
## 内容

#976 で入れた`#[doc(alias)]`が補完に出て邪魔なので、rustdocの検索にだけ出現するようにする。

## 関連 Issue

## その他
