### PR TITLE
feat(rust,python,java): 基礎的なインターフェイスを完備

### DIFF
--- a/crates/voicevox_core/Cargo.toml
+++ b/crates/voicevox_core/Cargo.toml
@@ -26,7 +26,7 @@ camino.workspace = true
 const_format.workspace = true
 derive-getters.workspace = true
 derive-new.workspace = true
-derive_more = { workspace = true, features = ["add", "deref", "display", "from", "from_str", "index"] }
+derive_more = { workspace = true, features = ["add", "as_ref", "debug", "deref", "display", "from", "from_str", "index", "into"] }
 duplicate.workspace = true
 easy-ext.workspace = true
 educe.workspace = true

--- a/crates/voicevox_core/src/__internal/interop/raii.rs
+++ b/crates/voicevox_core/src/__internal/interop/raii.rs
@@ -2,6 +2,7 @@ use std::{marker::PhantomData, ops::Deref};
 
 use ouroboros::self_referencing;
 
+#[derive(Debug)]
 pub enum MaybeClosed<T> {
     Open(T),
     Closed,

--- a/crates/voicevox_core/src/asyncs.rs
+++ b/crates/voicevox_core/src/asyncs.rs
@@ -69,6 +69,8 @@ impl Async for SingleTasked {
     }
 }
 
+#[derive(derive_more::Debug)]
+#[debug("{_0:?}")]
 pub(crate) struct StdMutex<T>(std::sync::Mutex<T>);
 
 impl<T> From<T> for StdMutex<T> {
@@ -83,6 +85,8 @@ impl<T: Send + Sync + Unpin> Mutex<T> for StdMutex<T> {
     }
 }
 
+#[derive(derive_more::Debug)]
+#[debug("{_0:?}")]
 pub(crate) struct StdFile(std::fs::File);
 
 impl AsyncRead for StdFile {
@@ -136,6 +140,7 @@ impl<T: Send + Sync + Unpin> Mutex<T> for async_lock::Mutex<T> {
 }
 
 // TODO: `async_fs::File::into_std_file`みたいなのがあればこんなの↓は作らなくていいはず。PR出す？
+#[derive(Debug)]
 pub(crate) struct AsyncRoFile {
     // `poll_read`と`poll_seek`しかしない
     unblock: Unblock<std::fs::File>,

--- a/crates/voicevox_core/src/core/infer/domains.rs
+++ b/crates/voicevox_core/src/core/infer/domains.rs
@@ -3,6 +3,8 @@ mod frame_decode;
 mod singing_teacher;
 pub(crate) mod talk;
 
+use std::fmt::Debug;
+
 use educe::Educe;
 use serde::{Deserialize, Deserializer};
 
@@ -23,9 +25,14 @@ pub(crate) use self::{
 #[derive(Educe)]
 // TODO: `bounds`に`V: ?Sized`も入れようとすると、よくわからない理由で弾かれる。最新版のeduce
 // でもそうなのか？また最新版でも駄目だとしたら、弾いている理由は何なのか？
-#[educe(Clone(
-    bound = "V: InferenceDomainMapValues, V::Talk: Clone, V::ExperimentalTalk: Clone, V::SingingTeacher: Clone, V::FrameDecode: Clone"
-))]
+#[educe(
+    Clone(
+        bound = "V: InferenceDomainMapValues, V::Talk: Clone, V::ExperimentalTalk: Clone, V::SingingTeacher: Clone, V::FrameDecode: Clone"
+    ),
+    Debug(
+        bound = "V: InferenceDomainMapValues, V::Talk: Debug, V::ExperimentalTalk: Debug, V::SingingTeacher: Debug, V::FrameDecode: Debug"
+    )
+)]
 pub(crate) struct InferenceDomainMap<V: InferenceDomainMapValues + ?Sized> {
     pub(crate) talk: V::Talk,
     pub(crate) experimental_talk: V::ExperimentalTalk,

--- a/crates/voicevox_core/src/core/infer/domains/experimental_talk.rs
+++ b/crates/voicevox_core/src/core/infer/domains/experimental_talk.rs
@@ -25,7 +25,7 @@ impl InferenceDomain for ExperimentalTalkDomain {
     }
 }
 
-#[derive(Clone, Copy, Deserialize, Enum, InferenceOperation)]
+#[derive(Clone, Copy, Debug, Deserialize, Enum, InferenceOperation)]
 #[serde(rename_all = "snake_case")]
 #[inference_operation(
     type Domain = ExperimentalTalkDomain;

--- a/crates/voicevox_core/src/core/infer/domains/frame_decode.rs
+++ b/crates/voicevox_core/src/core/infer/domains/frame_decode.rs
@@ -25,7 +25,7 @@ impl InferenceDomain for FrameDecodeDomain {
     }
 }
 
-#[derive(Clone, Copy, Deserialize, Enum, InferenceOperation)]
+#[derive(Clone, Copy, Debug, Deserialize, Enum, InferenceOperation)]
 #[serde(rename_all = "snake_case")]
 #[inference_operation(
     type Domain = FrameDecodeDomain;

--- a/crates/voicevox_core/src/core/infer/domains/singing_teacher.rs
+++ b/crates/voicevox_core/src/core/infer/domains/singing_teacher.rs
@@ -25,7 +25,7 @@ impl InferenceDomain for SingingTeacherDomain {
     }
 }
 
-#[derive(Clone, Copy, Deserialize, Enum, InferenceOperation)]
+#[derive(Clone, Copy, Debug, Deserialize, Enum, InferenceOperation)]
 #[serde(rename_all = "snake_case")]
 #[inference_operation(
     type Domain = SingingTeacherDomain;

--- a/crates/voicevox_core/src/core/infer/domains/talk.rs
+++ b/crates/voicevox_core/src/core/infer/domains/talk.rs
@@ -25,7 +25,7 @@ impl InferenceDomain for TalkDomain {
     }
 }
 
-#[derive(Clone, Copy, Deserialize, Enum, InferenceOperation)]
+#[derive(Clone, Copy, Debug, Deserialize, Enum, InferenceOperation)]
 #[serde(rename_all = "snake_case")]
 #[inference_operation(
     type Domain = TalkDomain;

--- a/crates/voicevox_core/src/core/infer/runtimes/onnxruntime.rs
+++ b/crates/voicevox_core/src/core/infer/runtimes/onnxruntime.rs
@@ -436,6 +436,7 @@ pub(crate) mod blocking {
     /// [`Onnxruntime::load_once`]のビルダー。
     #[cfg(feature = "load-onnxruntime")]
     #[must_use = "this is a builder. it does nothing until `perform`ed"]
+    #[derive(Debug)]
     pub struct LoadOnce {
         filename: std::ffi::OsString,
     }
@@ -591,7 +592,8 @@ pub(crate) mod nonblocking {
 
     /// [`Onnxruntime::load_once`]のビルダー。
     #[cfg(feature = "load-onnxruntime")]
-    #[derive(Default)]
+    #[derive(Default, derive_more::Debug)]
+    #[debug("{_0:?}")]
     #[must_use = "this is a builder. it does nothing until `perform`ed"]
     pub struct LoadOnce(super::blocking::LoadOnce);
 

--- a/crates/voicevox_core/src/core/manifest.rs
+++ b/crates/voicevox_core/src/core/manifest.rs
@@ -18,7 +18,7 @@ use super::infer::domains::{
     TalkOperation, inference_domain_map_values,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct FormatVersionV1;
 
 impl<'de> Deserialize<'de> for FormatVersionV1 {
@@ -71,7 +71,7 @@ impl Display for InnerVoiceId {
     }
 }
 
-#[derive(Deserialize, Getters)]
+#[derive(Debug, Deserialize, Getters)]
 pub struct Manifest {
     #[expect(dead_code, reason = "現状はバリデーションのためだけに存在")]
     vvm_format_version: FormatVersionV1,
@@ -84,7 +84,7 @@ pub struct Manifest {
 pub(super) type ManifestDomains = inference_domain_map_values!(for<D> Option<D::Manifest>);
 
 // TODO: #825 が終わったら`singing_teacher`と`frame_decode`のやつと統一する
-#[derive(Index, Deserialize)]
+#[derive(Debug, Index, Deserialize)]
 #[cfg_attr(test, derive(Default))]
 pub(crate) struct TalkManifest {
     #[index]
@@ -96,7 +96,7 @@ pub(crate) struct TalkManifest {
 }
 
 // TODO: #825 が終わったら`singing_teacher`と`frame_decode`のやつと統一する
-#[derive(Index, Deserialize)]
+#[derive(Debug, Index, Deserialize)]
 #[cfg_attr(test, derive(Default))]
 pub(crate) struct ExperimentalTalkManifest {
     #[index]
@@ -107,7 +107,7 @@ pub(crate) struct ExperimentalTalkManifest {
     pub(super) style_id_to_inner_voice_id: StyleIdToInnerVoiceId,
 }
 
-#[derive(Index, Deserialize)]
+#[derive(Debug, Index, Deserialize)]
 #[cfg_attr(test, derive(Default))]
 pub(crate) struct SingingTeacherManifest {
     #[index]
@@ -119,7 +119,7 @@ pub(crate) struct SingingTeacherManifest {
 }
 
 // TODO: #825 が終わったら`singing_teacher`と`frame_decode`のやつと統一する
-#[derive(Index, Deserialize)]
+#[derive(Debug, Index, Deserialize)]
 #[cfg_attr(test, derive(Default))]
 pub(crate) struct FrameDecodeManifest {
     #[index]
@@ -130,7 +130,7 @@ pub(crate) struct FrameDecodeManifest {
     pub(super) style_id_to_inner_voice_id: StyleIdToInnerVoiceId,
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Debug)]
 pub(crate) struct ModelFile {
     pub(super) r#type: ModelFileType,
     pub(super) filename: Arc<str>,
@@ -146,7 +146,7 @@ impl Default for ModelFile {
     }
 }
 
-#[derive(Deserialize, Clone, Copy)]
+#[derive(Deserialize, Clone, Copy, Debug)]
 #[serde(rename_all = "snake_case")]
 pub(super) enum ModelFileType {
     Onnx,
@@ -154,7 +154,8 @@ pub(super) enum ModelFileType {
 }
 
 #[serde_as]
-#[derive(Default, Clone, Deref, Deserialize)]
+#[derive(Default, Clone, derive_more::Debug, Deref, Deserialize)]
+#[debug("{_0:?}")]
 #[deref(forward)]
 pub(crate) struct StyleIdToInnerVoiceId(
     #[serde_as(as = "Arc<BTreeMap<DisplayFromStr, _>>")] Arc<BTreeMap<StyleId, InnerVoiceId>>,

--- a/crates/voicevox_core/src/core/metas.rs
+++ b/crates/voicevox_core/src/core/metas.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Debug, Display};
 
-use derive_more::From;
+use derive_more::{AsMut, AsRef, Binary, From, Into, LowerHex, Octal, UpperHex};
 use derive_new::new;
 use indexmap::IndexMap;
 use itertools::Itertools as _;
@@ -53,11 +53,16 @@ pub fn merge<'a>(metas: impl IntoIterator<Item = &'a CharacterMeta>) -> Vec<Char
     Hash,
     PartialOrd,
     From,
+    Into,
     derive_more::FromStr,
     Deserialize,
     Serialize,
     new,
     Debug,
+    UpperHex,
+    LowerHex,
+    Octal,
+    Binary,
 )]
 #[cfg_attr(doc, doc(alias = "VoicevoxStyleId"))]
 pub struct StyleId(pub u32);
@@ -71,7 +76,9 @@ impl Display for StyleId {
 /// [<i>キャラクター</i>]のバージョン。
 ///
 /// [<i>キャラクター</i>]: CharacterMeta
-#[derive(PartialEq, Eq, Clone, Ord, PartialOrd, Deserialize, Serialize, new, Debug)]
+#[derive(
+    PartialEq, Eq, Clone, Ord, PartialOrd, Deserialize, Serialize, new, Hash, Debug, AsRef, AsMut,
+)]
 pub struct CharacterVersion(pub String);
 
 impl Display for CharacterVersion {
@@ -144,7 +151,7 @@ impl CharacterMeta {
 }
 
 /// <i>スタイル</i>のメタ情報。
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, PartialEq, Debug)]
 #[non_exhaustive]
 pub struct StyleMeta {
     /// スタイルID。

--- a/crates/voicevox_core/src/core/status.rs
+++ b/crates/voicevox_core/src/core/status.rs
@@ -1,4 +1,7 @@
-use std::any;
+use std::{
+    any,
+    fmt::{self, Debug},
+};
 
 use duplicate::{duplicate, duplicate_item};
 use educe::Educe;
@@ -26,6 +29,7 @@ use super::{
     voice_model::{ModelBytesWithInnerVoiceIdsByDomain, VoiceModelHeader, VoiceModelId},
 };
 
+#[derive(Debug)]
 pub(crate) struct Status<R: InferenceRuntime> {
     pub(crate) rt: &'static R,
     loaded_models: std::sync::Mutex<LoadedModels<R>>,
@@ -139,6 +143,14 @@ impl<R: InferenceRuntime> Status<R> {
 #[derive(Educe)]
 #[educe(Default(bound = "R: InferenceRuntime"))]
 struct LoadedModels<R: InferenceRuntime>(IndexMap<VoiceModelId, LoadedModel<R>>);
+
+impl<R: InferenceRuntime> Debug for LoadedModels<R> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_map()
+            .entries(self.0.keys().map(|id| (id, format_args!("_"))))
+            .finish()
+    }
+}
 
 struct LoadedModel<R: InferenceRuntime> {
     metas: VoiceModelMeta,

--- a/crates/voicevox_core/src/core/voice_model.rs
+++ b/crates/voicevox_core/src/core/voice_model.rs
@@ -4,6 +4,7 @@
 
 use std::{
     collections::HashMap,
+    fmt::{self, Debug},
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -416,9 +417,25 @@ impl<A: Async> Inner<A> {
     }
 }
 
+impl<A: Async> Inner<A> {
+    fn fill_debug_struct_body(&self, mut fmt: fmt::DebugStruct<'_, '_>) -> fmt::Result
+    where
+        A::Mutex<A::RoFile>: Debug,
+    {
+        fmt.field("header", self.header());
+        self.with_inference_model_entries(|inference_model_entries| {
+            fmt.field("inference_model_entries", inference_model_entries)
+        });
+        self.with_zip(|zip| fmt.field("zip", zip));
+        fmt.finish()
+    }
+}
+
 type InferenceModelEntries<'manifest> =
     inference_domain_map_values!(for<D> Option<InferenceModelEntry<D, &'manifest D::Manifest>>);
 
+#[derive(derive_more::Debug)]
+#[debug(bound(D::Operation: Debug))]
 struct InferenceModelEntry<D: InferenceDomain, M> {
     indices: EnumMap<D::Operation, usize>,
     manifest: M,
@@ -476,6 +493,7 @@ impl<R: AsyncBufRead + AsyncSeek + Unpin> async_zip::base::read::seek::ZipFileRe
 /// 音声モデルが持つ、各モデルファイルの実体を除く情報。
 ///
 /// モデルの`[u8]`と分けて`Status`に渡す。
+#[derive(Debug)]
 pub(crate) struct VoiceModelHeader {
     pub(super) manifest: Manifest,
     /// メタ情報。
@@ -594,7 +612,10 @@ impl InferenceDomainMap<ManifestDomains> {
 }
 
 pub(crate) mod blocking {
-    use std::path::Path;
+    use std::{
+        fmt::{self, Debug},
+        path::Path,
+    };
 
     use crate::{VoiceModelMeta, asyncs::SingleTasked, future::FutureExt as _};
 
@@ -635,10 +656,20 @@ pub(crate) mod blocking {
             self.0.metas()
         }
     }
+
+    impl Debug for VoiceModelFile {
+        fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let fmt = fmt.debug_struct("VoiceModelFile");
+            self.0.fill_debug_struct_body(fmt)
+        }
+    }
 }
 
 pub(crate) mod nonblocking {
-    use std::path::Path;
+    use std::{
+        fmt::{self, Debug},
+        path::Path,
+    };
 
     use crate::{Result, VoiceModelMeta, asyncs::BlockingThreadPool};
 
@@ -681,6 +712,13 @@ pub(crate) mod nonblocking {
         /// メタ情報。
         pub fn metas(&self) -> &VoiceModelMeta {
             self.0.metas()
+        }
+    }
+
+    impl Debug for VoiceModelFile {
+        fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let fmt = fmt.debug_struct("VoiceModelFile");
+            self.0.fill_debug_struct_body(fmt)
         }
     }
 }

--- a/crates/voicevox_core/src/engine/talk/model.rs
+++ b/crates/voicevox_core/src/engine/talk/model.rs
@@ -52,7 +52,7 @@ impl AccentPhrase {
 /// VOICEVOX ENGINEと同じスキーマになっている。ただし今後の破壊的変更にて変わる可能性がある。[データのシリアライゼーション]を参照。
 ///
 /// [データのシリアライゼーション]: https://github.com/VOICEVOX/voicevox_core/blob/main/docs/guide/user/serialization.md
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct AudioQuery {
     /// アクセント句の配列。

--- a/crates/voicevox_core/src/engine/talk/open_jtalk.rs
+++ b/crates/voicevox_core/src/engine/talk/open_jtalk.rs
@@ -27,6 +27,7 @@ pub(crate) trait FullcontextExtractor {
 
 pub(crate) mod blocking {
     use std::{
+        fmt::{self, Debug},
         io::Write as _,
         sync::{Arc, Mutex},
     };
@@ -151,6 +152,20 @@ pub(crate) mod blocking {
         }
     }
 
+    impl Debug for self::OpenJtalk {
+        fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let Self(inner) = self;
+            let Inner {
+                resources,
+                dict_dir,
+            } = &**inner;
+            fmt.debug_struct("OpenJtalk")
+                .field("resources", resources)
+                .field("dict_dir", dict_dir)
+                .finish()
+        }
+    }
+
     pub(super) struct Inner {
         resources: std::sync::Mutex<Resources>,
         dict_dir: Utf8PathBuf,
@@ -213,6 +228,22 @@ pub(crate) mod blocking {
         njd: ManagedResource<Njd>,
         jpcommon: ManagedResource<JpCommon>,
     }
+
+    impl Debug for Resources {
+        fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+            // FIXME: open_jtalk-rs側に`Debug`実装を入れる
+            let Self {
+                mecab: _,
+                njd: _,
+                jpcommon: _,
+            } = self;
+            fmt.debug_struct("Resources")
+                .field("mecab", &format_args!("_"))
+                .field("njd", &format_args!("_"))
+                .field("jpcommon", &format_args!("_"))
+                .finish()
+        }
+    }
 }
 
 pub(crate) mod nonblocking {
@@ -228,7 +259,8 @@ pub(crate) mod nonblocking {
     ///
     /// [blocking]: https://docs.rs/crate/blocking
     /// [`nonblocking`モジュールのドキュメント]: crate::nonblocking
-    #[derive(Clone)]
+    #[derive(Clone, derive_more::Debug)]
+    #[debug("{_0:?}")]
     pub struct OpenJtalk(pub(in super::super) super::blocking::OpenJtalk);
 
     impl self::OpenJtalk {

--- a/crates/voicevox_core/src/engine/talk/user_dict/word.rs
+++ b/crates/voicevox_core/src/engine/talk/user_dict/word.rs
@@ -17,7 +17,7 @@ use super::part_of_speech_data::{
 ///
 /// [データのシリアライゼーション]: https://github.com/VOICEVOX/voicevox_core/blob/main/docs/guide/user/serialization.md
 #[cfg_attr(doc, doc(alias = "VoicevoxUserDictWord"))]
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct UserDictWord {
     /// 単語の表記。
     surface: String,
@@ -145,6 +145,7 @@ impl Serialize for UserDictWord {
 }
 
 /// [`UserDictWord`]のビルダー。
+#[derive(Debug)]
 pub struct UserDictWordBuilder {
     word_type: UserDictWordType,
     priority: u32,
@@ -360,7 +361,7 @@ impl Default for UserDictWordBuilder {
 
 /// ユーザー辞書の単語の種類。
 #[cfg_attr(doc, doc(alias = "VoicevoxUserDictWordType"))]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum UserDictWordType {
     /// 固有名詞。

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -5,7 +5,13 @@
 use easy_ext::ext;
 use enum_map::enum_map;
 use futures_util::TryFutureExt as _;
-use std::{future::Future, marker::PhantomData, ops::Range, sync::Arc};
+use std::{
+    fmt::{self, Debug},
+    future::Future,
+    marker::PhantomData,
+    ops::Range,
+    sync::Arc,
+};
 use tracing::info;
 
 use crate::{
@@ -45,6 +51,8 @@ pub const DEFAULT_ENABLE_INTERROGATIVE_UPSPEAK: bool = true;
 pub const DEFAULT_HEAVY_INFERENCE_CANCELLABLE: bool =
     <BlockingThreadPool as infer::AsyncExt>::DEFAULT_HEAVY_INFERENCE_CANCELLABLE;
 
+#[derive(derive_more::Debug)]
+#[debug(bounds(A::Cancellable: Debug))]
 struct SynthesisOptions<A: infer::AsyncExt> {
     enable_interrogative_upspeak: bool,
     cancellable: A::Cancellable,
@@ -75,6 +83,8 @@ impl<A: infer::AsyncExt> From<&TtsOptions<A>> for SynthesisOptions<A> {
     }
 }
 
+#[derive(derive_more::Debug)]
+#[debug(bounds(A::Cancellable: Debug))]
 struct TtsOptions<A: infer::AsyncExt> {
     enable_interrogative_upspeak: bool,
     cancellable: A::Cancellable,
@@ -95,7 +105,7 @@ impl<A: infer::AsyncExt> Default for TtsOptions<A> {
     clippy::manual_non_exhaustive,
     reason = "バインディングを作るときはexhaustiveとして扱いたい"
 )]
-#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum AccelerationMode {
     /// 実行環境に合った適切なハードウェアアクセラレーションモードを選択する。
     #[default]
@@ -108,6 +118,7 @@ pub enum AccelerationMode {
     __NonExhaustive,
 }
 
+#[derive(Debug)]
 struct InitializeOptions {
     acceleration_mode: AccelerationMode,
     cpu_num_threads: u16,
@@ -179,6 +190,7 @@ fn trim_margin_from_wave(wave_with_margin: ndarray::Array1<f32>) -> ndarray::Arr
 // TODO: 後で復活させる
 // https://github.com/VOICEVOX/voicevox_core/issues/970
 #[doc(hidden)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct AudioFeature {
     /// (フレーム数, 特徴数)の形を持つ音声特徴量。
     internal_state: ndarray::Array2<f32>,
@@ -192,16 +204,22 @@ pub struct AudioFeature {
     audio_query: AudioQuery,
 }
 
+#[derive(derive_more::Debug)]
+#[debug(bounds(T: Debug))]
 struct Inner<T, A: Async> {
     status: Arc<Status<crate::blocking::Onnxruntime>>,
     text_analyzer: T,
     use_gpu: bool,
+    #[debug(ignore)]
     _marker: PhantomData<fn(A) -> A>,
 }
 
+#[derive(derive_more::Debug)]
+#[debug(bounds())]
 struct InnerRefWithoutTextAnalyzer<'a, A: Async> {
     status: &'a Arc<Status<crate::blocking::Onnxruntime>>,
     use_gpu: bool,
+    #[debug(ignore)]
     _marker: PhantomData<fn(A) -> A>,
 }
 
@@ -218,6 +236,8 @@ impl<T> From<Inner<T, BlockingThreadPool>>
     }
 }
 
+#[derive(derive_more::Debug)]
+#[debug("{_0:?}")]
 struct AssumeSingleTasked<T>(T);
 
 impl<T: crate::blocking::TextAnalyzer> crate::nonblocking::TextAnalyzer for AssumeSingleTasked<T> {
@@ -326,6 +346,23 @@ impl<T, A: AsyncExt> Inner<T, A> {
             use_gpu: self.use_gpu,
             _marker: PhantomData,
         }
+    }
+
+    fn fill_debug_struct_body(&self, mut fmt: fmt::DebugStruct<'_, '_>) -> fmt::Result
+    where
+        T: Debug,
+    {
+        let Self {
+            status,
+            text_analyzer,
+            use_gpu,
+            _marker: _,
+        } = self;
+
+        fmt.field("status", status)
+            .field("text_analyzer", text_analyzer)
+            .field("use_gpu", use_gpu)
+            .finish_non_exhaustive()
     }
 }
 
@@ -1274,7 +1311,10 @@ impl From<Vec<AccentPhrase>> for AudioQuery {
               形を考えると、ここの引数を構造体にまとめたりしても可読性に寄与しない"
 )]
 pub(crate) mod blocking {
-    use std::ops::Range;
+    use std::{
+        fmt::{self, Debug},
+        ops::Range,
+    };
 
     use easy_ext::ext;
 
@@ -1659,6 +1699,13 @@ pub(crate) mod blocking {
         }
     }
 
+    impl<T: Debug> Debug for self::Synthesizer<T> {
+        fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let fmt = fmt.debug_struct("Synthesizer");
+            self.0.fill_debug_struct_body(fmt)
+        }
+    }
+
     #[ext(PerformInference)]
     impl self::Synthesizer<()> {
         pub fn predict_duration(
@@ -1786,6 +1833,7 @@ pub(crate) mod blocking {
     }
 
     #[must_use]
+    #[derive(Debug)]
     pub struct Builder<T> {
         onnxruntime: &'static crate::blocking::Onnxruntime,
         text_analyzer: T,
@@ -1825,6 +1873,7 @@ pub(crate) mod blocking {
     }
 
     #[must_use = "this is a builder. it does nothing until `perform`ed"]
+    #[derive(Debug)]
     pub struct PrecomputeRender<'a> {
         synthesizer: InnerRefWithoutTextAnalyzer<'a, SingleTasked>,
         audio_query: &'a AudioQuery,
@@ -1847,6 +1896,7 @@ pub(crate) mod blocking {
     }
 
     #[must_use = "this is a builder. it does nothing until `perform`ed"]
+    #[derive(Debug)]
     pub struct Synthesis<'a> {
         synthesizer: InnerRefWithoutTextAnalyzer<'a, SingleTasked>,
         audio_query: &'a AudioQuery,
@@ -1869,6 +1919,7 @@ pub(crate) mod blocking {
     }
 
     #[must_use = "this is a builder. it does nothing until `perform`ed"]
+    #[derive(Debug)]
     pub struct TtsFromKana<'a> {
         synthesizer: InnerRefWithoutTextAnalyzer<'a, SingleTasked>,
         kana: &'a str,
@@ -1891,6 +1942,7 @@ pub(crate) mod blocking {
     }
 
     #[must_use = "this is a builder. it does nothing until `perform`ed"]
+    #[derive(Debug)]
     pub struct Tts<'a, T> {
         synthesizer: &'a Inner<AssumeSingleTasked<T>, SingleTasked>,
         text: &'a str,
@@ -1914,6 +1966,8 @@ pub(crate) mod blocking {
 }
 
 pub(crate) mod nonblocking {
+    use std::fmt::{self, Debug};
+
     use easy_ext::ext;
 
     use crate::{
@@ -2257,6 +2311,13 @@ pub(crate) mod nonblocking {
         }
     }
 
+    impl<T: Debug> Debug for self::Synthesizer<T> {
+        fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let fmt = fmt.debug_struct("Synthesizer");
+            self.0.fill_debug_struct_body(fmt)
+        }
+    }
+
     #[ext(IntoBlocking)]
     impl<T> self::Synthesizer<T> {
         pub fn into_blocking(self) -> super::blocking::Synthesizer<AssumeBlockable<T>> {
@@ -2266,6 +2327,7 @@ pub(crate) mod nonblocking {
     }
 
     #[must_use]
+    #[derive(Debug)]
     pub struct Builder<T> {
         onnxruntime: &'static crate::nonblocking::Onnxruntime,
         text_analyzer: T,
@@ -2307,6 +2369,7 @@ pub(crate) mod nonblocking {
     }
 
     #[must_use = "this is a builder. it does nothing until `perform`ed"]
+    #[derive(Debug)]
     pub struct Synthesis<'a> {
         synthesizer: InnerRefWithoutTextAnalyzer<'a, BlockingThreadPool>,
         audio_query: &'a AudioQuery,
@@ -2339,6 +2402,7 @@ pub(crate) mod nonblocking {
     }
 
     #[must_use = "this is a builder. it does nothing until `perform`ed"]
+    #[derive(Debug)]
     pub struct TtsFromKana<'a> {
         synthesizer: InnerRefWithoutTextAnalyzer<'a, BlockingThreadPool>,
         kana: &'a str,
@@ -2371,6 +2435,7 @@ pub(crate) mod nonblocking {
     }
 
     #[must_use = "this is a builder. it does nothing until `perform`ed"]
+    #[derive(Debug)]
     pub struct Tts<'a, T> {
         synthesizer: &'a Inner<T, BlockingThreadPool>,
         text: &'a str,

--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/AccentPhrase.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/AccentPhrase.java
@@ -42,4 +42,18 @@ public class AccentPhrase {
     this.pauseMora = null;
     this.isInterrogative = false;
   }
+
+  // `moras`の型が`List`のため、`clone`は実装できない
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof AccentPhrase)) {
+      return false;
+    }
+    AccentPhrase other = (AccentPhrase) obj;
+    return moras.equals(other.moras)
+        && accent == other.accent
+        && pauseMora == other.pauseMora
+        && isInterrogative == other.isInterrogative;
+  }
 }

--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/AudioQuery.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/AudioQuery.java
@@ -74,6 +74,23 @@ public class AudioQuery {
     this.kana = null;
   }
 
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof AudioQuery)) {
+      return false;
+    }
+    AudioQuery other = (AudioQuery) obj;
+    return accentPhrases.equals(other.accentPhrases)
+        && speedScale == other.speedScale
+        && pitchScale == other.pitchScale
+        && intonationScale == other.intonationScale
+        && volumeScale == other.volumeScale
+        && prePhonemeLength == other.prePhonemeLength
+        && postPhonemeLength == other.postPhonemeLength
+        && outputSamplingRate == other.outputSamplingRate
+        && outputStereo == other.outputStereo;
+  }
+
   public static AudioQuery fromAccentPhrases(List<AccentPhrase> accentPhrases) {
     Gson gson = new Gson();
     String queryJson = rsFromAccentPhrases(gson.toJson(accentPhrases));

--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/CharacterMeta.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/CharacterMeta.java
@@ -11,7 +11,7 @@ import jakarta.annotation.Nullable;
  * <p>現在この型はGSONに対応しているが、将来的には <a href="https://github.com/VOICEVOX/voicevox_core/issues/984"
  * target="_blank">Jacksonに切り替わる予定</a> 。
  */
-public class CharacterMeta {
+public class CharacterMeta implements Cloneable {
   /** キャラクター名。 */
   @SerializedName("name")
   @Expose
@@ -54,5 +54,32 @@ public class CharacterMeta {
     this.speakerUuid = "";
     this.version = "";
     this.order = null;
+  }
+
+  private CharacterMeta(
+      String name, StyleMeta[] styles, String speakerUuid, String version, Integer order) {
+    this.name = name;
+    this.styles = styles;
+    this.speakerUuid = speakerUuid;
+    this.version = version;
+    this.order = order;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof CharacterMeta)) {
+      return false;
+    }
+    CharacterMeta other = (CharacterMeta) obj;
+    return name.equals(other.name)
+        && styles.equals(other.styles)
+        && speakerUuid.equals(other.speakerUuid)
+        && version.equals(other.version)
+        && order.equals(other.order);
+  }
+
+  @Override
+  public CharacterMeta clone() {
+    return new CharacterMeta(name, styles.clone(), speakerUuid, version, order);
   }
 }

--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/Mora.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/Mora.java
@@ -11,7 +11,7 @@ import jakarta.annotation.Nullable;
  * <p>現在この型はGSONに対応しているが、将来的には <a href="https://github.com/VOICEVOX/voicevox_core/issues/984"
  * target="_blank">Jacksonに切り替わる予定</a> 。
  */
-public class Mora {
+public class Mora implements Cloneable {
   /** 文字。 */
   @SerializedName("text")
   @Expose
@@ -54,5 +54,30 @@ public class Mora {
     this.vowel = "";
     this.vowelLength = 0.0;
     this.pitch = 0.0;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof Mora)) {
+      return false;
+    }
+    Mora other = (Mora) obj;
+    return text.equals(other.text)
+        && consonant.equals(other.consonant)
+        && vowel.equals(other.vowel)
+        && vowelLength == other.vowelLength
+        && pitch == other.pitch;
+  }
+
+  @Override
+  public Mora clone() {
+    Mora ret = new Mora();
+    ret.text = text;
+    ret.consonant = consonant;
+    ret.consonantLength = consonantLength;
+    ret.vowel = vowel;
+    ret.vowelLength = vowelLength;
+    ret.pitch = pitch;
+    return ret;
   }
 }

--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/StyleMeta.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/StyleMeta.java
@@ -11,7 +11,7 @@ import jakarta.annotation.Nullable;
  * <p>現在この型はGSONに対応しているが、将来的には <a href="https://github.com/VOICEVOX/voicevox_core/issues/984"
  * target="_blank">Jacksonに切り替わる予定</a> 。
  */
-public class StyleMeta {
+public class StyleMeta implements Cloneable {
   /** スタイル名。 */
   @SerializedName("name")
   @Expose
@@ -44,5 +44,29 @@ public class StyleMeta {
     this.id = 0;
     this.type = StyleType.TALK;
     this.order = null;
+  }
+
+  private StyleMeta(String name, int id, StyleType type, Integer order) {
+    this.name = name;
+    this.id = id;
+    this.type = type;
+    this.order = order;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof StyleMeta)) {
+      return false;
+    }
+    StyleMeta other = (StyleMeta) obj;
+    return name.equals(other.name)
+        && id == other.id
+        && type == other.type
+        && order.equals(other.order);
+  }
+
+  @Override
+  public StyleMeta clone() {
+    return new StyleMeta(name, id, type, order);
   }
 }

--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/SupportedDevices.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/SupportedDevices.java
@@ -15,7 +15,7 @@ import jakarta.annotation.Nonnull;
  *
  * <p>{@code Gson#fromJson} でJSONから変換することはできない。その試みは {@link UnsupportedOperationException} となる。
  */
-public class SupportedDevices {
+public class SupportedDevices implements Cloneable {
   /**
    * CPUが利用可能。
    *
@@ -54,10 +54,23 @@ public class SupportedDevices {
     throw new UnsupportedOperationException("You cannot deserialize `SupportedDevices`");
   }
 
-  /** accessed only via JNI */
   private SupportedDevices(boolean cpu, boolean cuda, boolean dml) {
     this.cpu = cpu;
     this.cuda = cuda;
     this.dml = dml;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof SupportedDevices)) {
+      return false;
+    }
+    SupportedDevices other = (SupportedDevices) obj;
+    return cpu == other.cpu && cuda == other.cuda && dml == other.dml;
+  }
+
+  @Override
+  public SupportedDevices clone() {
+    return new SupportedDevices(cpu, cuda, dml);
   }
 }

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/asyncio.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/asyncio.pyi
@@ -30,6 +30,7 @@ class VoiceModelFile:
             VVMファイルへのパス。
         """
         ...
+    def __repr__(self) -> str: ...
     async def close(self) -> None:
         """
         VVMファイルを閉じる。
@@ -121,6 +122,7 @@ class Onnxruntime:
             の引数に使われる。
         """
         ...
+    def __repr__(self) -> str: ...
     def supported_devices(self) -> SupportedDevices:
         """
         このライブラリで利用可能なデバイスの情報を取得する。
@@ -144,6 +146,7 @@ class OpenJtalk:
             Open JTalkの辞書ディレクトリ。
         """
         ...
+    def __repr__(self) -> str: ...
     async def use_user_dict(self, user_dict: UserDict) -> None:
         """
         ユーザー辞書を設定する。
@@ -503,6 +506,7 @@ class UserDict:
         """このオプジェクトを :class:`dict` に変換する。"""
         ...
     def __init__(self) -> None: ...
+    def __repr__(self) -> str: ...
     async def load(self, path: str | PathLike[str]) -> None:
         """ファイルに保存されたユーザー辞書を読み込む。
 

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
@@ -30,6 +30,7 @@ class VoiceModelFile:
             VVMファイルへのパス。
         """
         ...
+    def __repr__(self) -> str: ...
     def close(self) -> None:
         """
         VVMファイルを閉じる。
@@ -121,6 +122,7 @@ class Onnxruntime:
             の引数に使われる。
         """
         ...
+    def __repr__(self) -> str: ...
     def supported_devices(self) -> SupportedDevices:
         """
         このライブラリで利用可能なデバイスの情報を取得する。
@@ -138,6 +140,7 @@ class OpenJtalk:
     """
 
     def __init__(self, open_jtalk_dict_dir: str | PathLike[str]) -> None: ...
+    def __repr__(self) -> str: ...
     def use_user_dict(self, user_dict: UserDict) -> None:
         """
         ユーザー辞書を設定する。
@@ -494,6 +497,7 @@ class UserDict:
         """このオプジェクトを :class:`dict` に変換する。"""
         ...
     def __init__(self) -> None: ...
+    def __repr__(self) -> str: ...
     def load(self, path: str | PathLike[str]) -> None:
         """ファイルに保存されたユーザー辞書を読み込む。
 


### PR DESCRIPTION
## 内容

[Rust API GuidelinesのInteroperabilityの章](https://rust-lang.github.io/api-guidelines/interoperability.html)に従って基礎的なトレイトを実装する。またPythonの特殊メソッドおよびJavaのインターフェイスについても、適切と考えられるものは全部実装してしまう。

- C-COMMON-TRAITS基準
    - `Debug`/`__repr__`
    - `(Partial)Eq`/`__eq__`/`Object.equals`
    - `(Partial)Ord` (Rustのnewtypeやenumにのみ実装)
    - `Hash` (Rustのnewtypeやenumにのみ実装)
    - `Clone`/`Clonable`, `Copy`
    - `Default`
- C-CONV-TRAITS基準
    - `From`
    - `AsRef`/`AsMut`
- C-NUM-FMT基準
    - `std::fmt::UpperHex`
    - `std::fmt::LowerHex`
    - `std::fmt::Octal`
    - `std::fmt::Binary`

以下判断メモ。

- `==`はできる限り実装する。Rust以外の言語では、あらゆるオブジェクトを`==`で比較してしまえるため
- Rustにおいては:
    - `Default`の実装には慎重に
    - `(Partial)Ord`の実装も慎重に。
    - `Partial`じゃない`Eq`、および`Hash`の実装も慎重に。`f32`などを入れたくなったときに困るため
    - newtypeはその限りではないので、中身が実装しているトレイトを制覇するつもりで書く
    - ビルダー型は`Debug`だけ実装しておく
- Pythonにおいては:
    - `__repr__`の実装は作法に従い、<code>\<voicevox\_core.blocking.VoiceModelFile rust=\`RustのDebug表示\`\></code>のようにする
- Javaにおいては:
    - Lombokが激烈に欲しくなってきたが、このPRでは全部手で実装することにする

## 関連 Issue

## その他
