### PR TITLE
ci: `build-{windows,unix}-cpp-example`を`build-and-test-…`に

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,8 +181,7 @@ jobs:
           cargo xtask update-c-header --verify
           git diff
 
-  # TODO: "build-and-test-…"にする
-  build-unix-cpp-example:
+  build-and-test-unix-cpp-example:
     strategy:
       fail-fast: false
       matrix:
@@ -200,16 +199,18 @@ jobs:
         uses: taiki-e/install-action@cargo-binstall
       - name: build voicevox_core_c_api
         run: cargo build -p voicevox_core_c_api --features load-onnxruntime -v
+      - name: run test_util's build script
+        run: cargo check -vp test_util # build scriptにより/crates/test_util/data/の生成
       - name: 必要なfileをunix用exampleのディレクトリに移動させる
         run: |
-          mkdir -p example/cpp/unix/voicevox_core/c_api/{include,lib}
+          mkdir -p example/cpp/unix/voicevox_core/{c_api/{include,lib},dict,models,onnxruntime}
           sed 's:^//\(#define VOICEVOX_LOAD_ONNXRUNTIME\)$:\1:' \
             crates/voicevox_core_c_api/include/voicevox_core.h \
             > example/cpp/unix/voicevox_core/c_api/include/voicevox_core.h
           cp -v target/debug/libvoicevox_core.{so,dylib} example/cpp/unix/voicevox_core/c_api/lib/ || true
-          # FIXME: ↓この二つ要らないのでは？
-          cp -v target/debug/libonnxruntime.so.* example/cpp/unix/voicevox_core/ || true
-          cp -v target/debug/libonnxruntime.*.dylib example/cpp/unix/voicevox_core/ || true
+          cp -vr crates/test_util/data/lib example/cpp/unix/voicevox_core/onnxruntime/
+          cp -r crates/test_util/data/model example/cpp/unix/voicevox_core/onnxruntime/models/vvms
+          cp -vr crates/test_util/data/open_jtalk_dic_utf_8-1.11 example/cpp/unix/voicevox_core/dict/
 
       - if: startsWith(matrix.os, 'mac')
         uses: jwlawson/actions-setup-cmake@v2
@@ -223,9 +224,12 @@ jobs:
           cd example/cpp/unix
           cmake -S . -B build
           cmake --build build
+      - name: Run
+        run: |
+          ./build/simple_tts この音声は、ボイスボックスを使用して、出力されています。
+          [ "$(file audio.wav)" = 'audio.wav: RIFF (little-endian) data, WAVE audio, Microsoft PCM, 16 bit, mono 24000 Hz' ]
 
-  # TODO: "build-and-test-…"にする
-  build-windows-cpp-example:
+  build-and-test-windows-cpp-example:
     strategy:
       fail-fast: false
     runs-on: windows-latest
@@ -246,14 +250,20 @@ jobs:
         uses: taiki-e/install-action@cargo-binstall
       - name: build voicevox_core_c_api
         run: cargo build -p voicevox_core_c_api --features load-onnxruntime -v
+      - name: run test_util's build script
+        run: cargo check -vp test_util # build scriptにより/crates/test_util/data/の生成
       - name: 必要なfileをexampleのディレクトリに移動させる
         shell: bash
         run: |
-          mkdir -p example/cpp/windows/simple_tts/lib/x64
+          mkdir -p example/cpp/windows/simple_tts/{bin/x64/Debug,lib/x64}
           sed 's:^//\(#define VOICEVOX_LOAD_ONNXRUNTIME\)$:\1:' \
             crates/voicevox_core_c_api/include/voicevox_core.h \
             > example/cpp/windows/simple_tts/voicevox_core.h
           cp target/debug/voicevox_core.dll.lib example/cpp/windows/simple_tts/lib/x64/voicevox_core.lib
+          cp target/debug/voicevox_core.dll example/cpp/windows/simple_tts/bin/x64/Debug/
+          cp -r crates/test_util/data/lib example/cpp/windows/simple_tts/bin/x64/Debug/
+          cp -r crates/test_util/data/model example/cpp/windows/simple_tts/bin/x64/Debug/models
+          cp -r crates/test_util/data/open_jtalk_dic_utf_8-1.11 example/cpp/windows/simple_tts/bin/x64/Debug/
 
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@v2
@@ -264,6 +274,9 @@ jobs:
       - name: Build
         working-directory: ${{env.GITHUB_WORKSPACE}}
         run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+      - name: Run
+        shell: bash
+        run: simple_tts/bin/x64/Debug/simple_tts.exe <<< この音声は、ボイスボックスを使用して、出力されています。
 
   build-and-test-python-api:
     strategy:


### PR DESCRIPTION
## 内容

以下のtodoコメント（2箇所）を解消する。

```yaml
  # TODO: "build-and-test-…"にする
```

## 関連 Issue

## その他
