### PR TITLE
build(android): update NDK to r27c

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -22,6 +22,8 @@ env:
   VERSION: ${{ github.event.release.tag_name || inputs.version || '0.0.0' }}
   # 簡易テストとするかどうか。releaseとworkflow_dispatch以外は簡易テストとする
   IS_SIMPLE_TEST: ${{ github.event_name != 'release' && github.event_name != 'workflow_dispatch' }}
+  # Android用
+  NDK_VERSION: r27c
 
 defaults:
   run:
@@ -183,7 +185,7 @@ jobs:
       - uses: nttld/setup-ndk@v1
         if: endsWith(matrix.target, '-linux-android')
         with:
-          ndk-version: r25b
+          ndk-version: ${{ env.NDK_VERSION }}
       - name: Set path for android
         if: endsWith(matrix.target, '-linux-android')
         run: |
@@ -353,7 +355,7 @@ jobs:
       - uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
-          ndk-version: r25b
+          ndk-version: ${{ env.NDK_VERSION }}
       - name: Install cargo-binstall
         uses: taiki-e/install-action@cargo-binstall
       - name: Install cargo-edit


### PR DESCRIPTION
## 内容

NDKのバージョンを #444 にて設定されたr25bから、最新のLTSであるr27cに引き上げる。

これにより、AndroidビルドにおけるC++シンボルの問題が解決されるはずである。

## 関連 Issue

Fixes: #1103

## その他
