### PR TITLE
ci: issue templateの「OSの種類」にAndroidとiOSを加える

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugreport.md
+++ b/.github/ISSUE_TEMPLATE/bugreport.md
@@ -33,6 +33,8 @@ labels: バグ
 - [ ] Windows
 - [ ] macOS
 - [ ] Linux
+- [ ] Android
+- [ ] iOS
 
 <!--
 なるべく詳しく書いてください 記述例:

--- a/.github/ISSUE_TEMPLATE/featurerequest.md
+++ b/.github/ISSUE_TEMPLATE/featurerequest.md
@@ -34,6 +34,8 @@ labels: 機能向上
 - [ ] Windows
 - [ ] macOS
 - [ ] Linux
+- [ ] Android
+- [ ] iOS
 
 <!--
 なるべく詳しく書いてください 記述例:

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -21,6 +21,8 @@ labels: 要議論
 - [ ] Windows
 - [ ] macOS
 - [ ] Linux
+- [ ] Android
+- [ ] iOS
 
 <!--
 なるべく詳しく書いてください 記述例:


### PR DESCRIPTION
## 内容

## 関連 Issue

## その他

#1106 の実施を前提とし、Issue Labelerには手を加えない。

また、できることならCOREに関係する以下のリポジトリでも行いたいです。というよりVOICEVOX/.githubで設定してもよさそうかもしれません。

- VOICEVOX/kanalizer
- VOICEVOX/onnxruntime-builder
- VOICEVOX/open\_jtalk
- VOICEVOX/open\_jtalk-rs
- VOICEVOX/ort
- VOICEVOX/process\_path
- VOICEVOX/voicevox\_vvm
