### PR TITLE
fix(downloader): `-t, --tries`のhelpを正確に書く

### DIFF
--- a/crates/downloader/src/main.rs
+++ b/crates/downloader/src/main.rs
@@ -130,8 +130,8 @@ struct Args {
     #[arg(value_enum, long, default_value(Os::default_opt().map(<&str>::from)))]
     os: Os,
 
-    /// ダウンロードする場合のリトライ回数
-    #[arg(short, long, default_value("5"))]
+    /// ダウンロードにおける試行回数。'0'か'inf'で無限にリトライ
+    #[arg(short, long, value_name("NUMBER"), default_value("5"))]
     tries: Tries,
 
     #[arg(long, value_name("REPOSITORY"), default_value(DEFAULT_C_API_REPO))]


### PR DESCRIPTION
## 内容

#1098 で追加した`-t, --tries`のhelp表示を直す。「リトライ回数」は不正確なので「試行回数」とし、[`value_name`](https://docs.rs/clap/4/clap/struct.Arg.html#method.value_name)も`<NUMBER>`にしておく。Wgetと同じようにする。

```
  -t, --tries <NUMBER>
          ダウンロードにおける試行回数。'0'か'inf'で無限にリトライ [default: 5]
```

```console
❯ man wget 2>/dev/null | rg -e '-t number' -A 3
       -t number
       --tries=number
           Set number of tries to number. Specify 0 or inf for infinite retrying.  The default is to retry 20 times, with the  exception  of  fatal  errors
           like "connection refused" or "not found" (404), which are not retried.
```

## 関連 Issue

## その他

#1109 をやっているときに気付きました。
