### PR TITLE
fix: restore voicevox_core-ios-xcframework-cpu-{version}.zip

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -361,7 +361,7 @@ jobs:
       - name: Create xcframework
         id: create-xcframework
         run: |
-          build_util/make_xcframework.bash
+          build_util/make_compat_ios_xcframework.bash
           echo "output_asset_path=${OUTPUT_ASSET_PATH}" >> "$GITHUB_OUTPUT"
         env:
           OUTPUT_ASSET_PATH: artifact/voicevox_core-ios-xcframework-cpu

--- a/build_util/make_compat_ios_xcframework.bash
+++ b/build_util/make_compat_ios_xcframework.bash
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# TODO: `build_and_deploy`の`build_compat_ios_xcframework`と同様、このスクリプトは0.17.0をリリースする際に消す。
+set -eu
+
+if [ ! -v IOS_X86_64_PATH ]; then # X86_64用のモジュールのディレクトリ(simulator)
+    echo "IOS_X86_64_PATHが未定義です"
+    exit 1
+fi
+if [ ! -v IOS_AARCH64_SIM_PATH ]; then # AARCH64_SIM用のモジュールのディレクトリ(simulator)
+    echo "IOS_AARCH64_SIM_PATHが未定義です"
+    exit 1
+fi
+if [ ! -v IOS_AARCH64_PATH ]; then # AARCH64用のモジュールのディレクトリ(実機)
+    echo "IOS_AARCH64_PATHが未定義です"
+    exit 1
+fi
+if [ ! -v OUTPUT_ASSET_PATH ]; then # 出力するASSETのディレクトリ
+    echo "OUTPUT_ASSET_PATHが未定義です"
+    exit 1
+fi
+
+echo "* Get original onnxruntime file name from rpath"
+output=$(otool -L "${IOS_AARCH64_PATH}/lib/libvoicevox_core.dylib")
+matched_line=$(echo "$output" | grep "@rpath" | grep "libonnxruntime")
+if [[ $matched_line ]]; then
+    if [[ $matched_line =~ (@rpath/([^ ]+\.dylib)) ]]; then
+        dylib_string=${BASH_REMATCH[2]}
+    else
+        echo "Expected pattern not found in the matched line"
+        echo "$output"
+        exit 1
+    fi
+else
+    echo "No line containing '@rpath' and 'libonnxruntime' found"
+    echo "$output"
+    exit 1
+fi
+echo "Original onnx dylib file name: $dylib_string"
+
+echo "* Copy Framework template"
+platforms=("ios" "sim")
+artifacts=("${IOS_AARCH64_PATH}" "${IOS_AARCH64_SIM_PATH}")
+for i in "${!platforms[@]}"; do
+    platform="${platforms[$i]}"
+    artifact="${artifacts[$i]}"
+    echo "* Copy Framework-${platform} template"
+    mkdir -p "Framework-${platform}/voicevox_core.framework/Headers"
+    cp -vr "crates/voicevox_core_c_api/xcframework/Frameworks/${platform}/" "Framework-${platform}/"
+    cp -v "${artifact}/include/voicevox_core.h" \
+        "Framework-${platform}/voicevox_core.framework/Headers/voicevox_core.h"
+done
+
+echo "* Create dylib"
+# iosはdylibをコピー
+cp -v "${IOS_AARCH64_PATH}/lib/libvoicevox_core.dylib" \
+    "Framework-ios/voicevox_core.framework/voicevox_core"
+
+# simはx86_64とarrch64を合わせてdylib作成
+lipo -create "${IOS_X86_64_PATH}/lib/libvoicevox_core.dylib" \
+    "${IOS_AARCH64_SIM_PATH}/lib/libvoicevox_core.dylib" \
+    -output "Framework-sim/voicevox_core.framework/voicevox_core"
+
+for platform in "${platforms[@]}"; do
+    echo "* Change ${platform} @rpath"
+    # 自身への@rpathを変更
+    install_name_tool -id "@rpath/voicevox_core.framework/voicevox_core" \
+        "Framework-${platform}/voicevox_core.framework/voicevox_core"
+
+    # onnxruntimeへの@rpathを、voicevox_onnxruntimeのXCFrameworkに変更
+    install_name_tool -change "@rpath/$dylib_string" \
+        "@rpath/voicevox_onnxruntime.framework/voicevox_onnxruntime" \
+        "Framework-${platform}/voicevox_core.framework/voicevox_core"
+done
+
+echo "* Create XCFramework"
+mkdir -p "${OUTPUT_ASSET_PATH}"
+xcodebuild -create-xcframework \
+    -framework "Framework-sim/voicevox_core.framework" \
+    -framework "Framework-ios/voicevox_core.framework" \
+    -output "${OUTPUT_ASSET_PATH}/voicevox_core.xcframework"


### PR DESCRIPTION
## 内容

#1056 で改名される前のvoicevox\_core-ios-xcframework-cpu-{version}.zipを、macOS入りXCFrameworkの横に並べる形で残すようにする。 #1056 が0.16.0 → 0.16.1における破壊的変更になるのを防ぐのが目的。

実装については[CORE 0.17をそろそろ出していいのではという考え](https://github.com/VOICEVOX/ort/issues/15#issuecomment-3124327130)もあり、0.17を出す際にリバートが容易になるよう、#1056以前の機構のコピペを追加するという形にした。

Discordでの話: <https://discord.com/channels/879570910208733277/893889888208977960/1397191749805281374>

## 関連 Issue

## その他

- :x: ~~<https://github.com/qryxip/voicevox_core/actions/runs/16550814817>~~
- :heavy_check_mark: : <https://github.com/qryxip/voicevox_core/actions/runs/16551275673>
  <https://github.com/qryxip/voicevox_core/releases/tag/0.16.1-dev.20250727214422>
