### PR TITLE
feat(downloader): COREとしてのバージョンを出す`-V, --version`

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -191,7 +191,7 @@ jobs:
         run: cargo binstall cargo-edit@^0.11 --no-confirm --log-level debug
       - name: set cargo version
         run: |
-          cargo set-version "$VERSION" --exclude voicevox_core_python_api --exclude downloader --exclude xtask
+          cargo set-version "$VERSION" --exclude voicevox_core_python_api --exclude xtask
           if ${{ matrix.python_whl }}; then
             sed -i_ 's/version = "\(0\.0\.0\)"/version = "'"$VERSION"'"/' ./crates/voicevox_core_python_api/pyproject.toml
           fi

--- a/.github/workflows/build_and_deploy_downloader.yml
+++ b/.github/workflows/build_and_deploy_downloader.yml
@@ -77,6 +77,15 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@cargo-binstall
+
+      - name: Install cargo-edit
+        run: cargo binstall cargo-edit@^0.13 --no-confirm --log-level debug
+
+      - name: Set version
+        run: cargo set-version "$VERSION" --exclude voicevox_core_python_api --exclude xtask
+
       - name: Build downloader
         run: cargo build -v --release -p downloader --target ${{ matrix.target }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,7 +118,7 @@
           - `Mora`
       </details>
 
-- バージョン0.14.0からの歴史をまとめた[Keep a Changelog](https://keepachangelog.com)形式のCHANGELOG.mdが追加されます。またこのバージョンから、GitHub Releasesの本文にも同じ内容が載るようになります ([#1109])。
+- バージョン0.14.0からの歴史をまとめた[Keep a Changelog](https://keepachangelog.com)形式のCHANGELOG.mdが追加されます。またこのバージョンから、GitHub Releasesの本文にも同じ内容が載るようになります ([#1109], [#1116])。
 
 - \[Rust\] Rust Analyzerが、C APIから参照する目的で[0.16.0-preview.0](#0160-preview0---2025-03-01-0900)の[#976]にて導入した`doc(alias)`に反応しないようになります ([#1099])。
 
@@ -163,7 +163,7 @@
     ```
     </details>
 
-- \[ダウンローダー\] ダウンローダーは正式にVOICEVOX COREの一部と定められ、バージョンを共にするようになります。それに伴い、`-V, --version`でVOICEVOX CORE兼ダウンローダーのバージョンを取得できるようになります ([#1116])。
+- \[ダウンローダー\] ダウンローダーは正式にVOICEVOX COREの一部と定められ、バージョンを共にするようになります。それに伴い、`-V, --version`でVOICEVOX CORE兼ダウンローダーのバージョンを見ることができるようになります ([#1116])。
 
     ```console
       -V, --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,7 +172,7 @@
 
     ```console
     ❯ download -V
-    VOICEVOX CORE 0.16.1
+    VOICEVOX CORE 0.16.1 downloader
     ```
 
 - \[ダウンローダー\] 不要である[Oniguruma](https://github.com/kkos/oniguruma)のリンクをやめます ([#1082])。
@@ -517,6 +517,8 @@
 - \[ダウンローダー\] \[BREAKING\] `onnxruntime`（新規追加）および`models`のダウンロードの際、利用規約への同意が求められるようになります ([VOICEVOX/voicevox\_vvm#1], [#928], [VOICEVOX/voicevox\_vvm#5], [#964], [#983], [#989], [#1006], [#1011])。
 
 - \[ダウンローダー\] \[BREAKING\] `<TARGET>`のうち`core`は`c-api`に改名され、それに伴い`-v, --version`も`--c-api-version`、`--core-repo`も`--c-api-repo`に改名されます ([#942], [#1019])。
+
+    補足: [#1116]にて`--version`は、VOICEVOX COREとしてのバージョンを出力するフラグになります。
 
 - \[ダウンローダー\] \[BREAKING\] `<TARGET>`ごとにディレクトリが切られるようになります ([#944], [#969])。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,18 @@
     ```
     </details>
 
+- \[ダウンローダー\] 同様の ([#????])。
+
+    ```console
+      -V, --version
+              Print version
+    ```
+
+    ```console
+    ❯ download -V
+    downloader 0.0.0
+    ```
+
 - \[ダウンローダー\] 不要である[Oniguruma](https://github.com/kkos/oniguruma)のリンクをやめます ([#1082])。
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,7 +163,7 @@
     ```
     </details>
 
-- \[ダウンローダー\] 同様の ([#????])。
+- \[ダウンローダー\] ダウンローダーは正式にVOICEVOX COREの一部と定められ、バージョンを共にするようになります。それに伴い、`-V, --version`でVOICEVOX CORE兼ダウンローダーのバージョンを取得できるようになります ([#1116])。
 
     ```console
       -V, --version
@@ -172,7 +172,7 @@
 
     ```console
     ❯ download -V
-    downloader 0.0.0
+    VOICEVOX CORE 0.16.1
     ```
 
 - \[ダウンローダー\] 不要である[Oniguruma](https://github.com/kkos/oniguruma)のリンクをやめます ([#1082])。
@@ -1299,6 +1299,7 @@ Windows版ダウンローダーのビルドに失敗しています。
 [#1108]: https://github.com/VOICEVOX/voicevox_core/pull/1108
 [#1109]: https://github.com/VOICEVOX/voicevox_core/pull/1109
 [#1111]: https://github.com/VOICEVOX/voicevox_core/pull/1111
+[#1116]: https://github.com/VOICEVOX/voicevox_core/pull/1116
 
 [VOICEVOX/onnxruntime-builder#25]: https://github.com/VOICEVOX/onnxruntime-builder/pull/25
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ camino = "1.1.9"
 cargo_metadata = "0.18.1"
 cbindgen = "0.28.0"
 chrono = { version = "0.4.38", default-features = false }
-clap = "4.5.19"
+clap = { version = "4.5.19", features = ["cargo"] }
 color-eyre = "0.6.3"
 colorchoice = "1.0.2"
 comrak = { version = "0.26.0", default-features = false }

--- a/crates/downloader/Cargo.toml
+++ b/crates/downloader/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "downloader"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/downloader/src/main.rs
+++ b/crates/downloader/src/main.rs
@@ -84,6 +84,7 @@ static PROGRESS_STYLE2: LazyLock<ProgressStyle> =
     LazyLock::new(|| ProgressStyle::with_template("{prefix:55} {spinner} {msg}").unwrap());
 
 #[derive(clap::Parser)]
+#[command(version)]
 struct Args {
     /// ダウンロード対象を限定する
     #[arg(

--- a/crates/downloader/src/main.rs
+++ b/crates/downloader/src/main.rs
@@ -84,7 +84,7 @@ static PROGRESS_STYLE2: LazyLock<ProgressStyle> =
     LazyLock::new(|| ProgressStyle::with_template("{prefix:55} {spinner} {msg}").unwrap());
 
 #[derive(clap::Parser)]
-#[command(version)]
+#[command(name("VOICEVOX CORE"), version)]
 struct Args {
     /// ダウンロード対象を限定する
     #[arg(

--- a/crates/downloader/src/main.rs
+++ b/crates/downloader/src/main.rs
@@ -14,7 +14,7 @@ use std::{
 use anyhow::{Context as _, anyhow, bail, ensure};
 use base64::{Engine as _, prelude::BASE64_STANDARD};
 use bytes::Bytes;
-use clap::{Parser as _, ValueEnum};
+use clap::{Parser as _, ValueEnum, crate_version};
 use easy_ext::ext;
 use flate2::read::GzDecoder;
 use futures_core::Stream;
@@ -84,7 +84,7 @@ static PROGRESS_STYLE2: LazyLock<ProgressStyle> =
     LazyLock::new(|| ProgressStyle::with_template("{prefix:55} {spinner} {msg}").unwrap());
 
 #[derive(clap::Parser)]
-#[command(name("VOICEVOX CORE"), version)]
+#[command(name("VOICEVOX CORE"), version(concat!(crate_version!(), " downloader")))]
 struct Args {
     /// ダウンロード対象を限定する
     #[arg(


### PR DESCRIPTION
## 内容

#1115 の結論によりダウンローダーとコアはバージョンを共にするということになったので、以下のように`-V, --version`で「VOICEVOX COREのバージョン」を出力できるようにする。

```console
❯ download -V
VOICEVOX CORE 0.16.1 downloader
```

## 関連 Issue

Resolves: #1115

## その他
