### PR TITLE
refactor(downloader): `i64`→`usize`→`u64`の変換から`usize`を抜く

### DIFF
--- a/crates/downloader/src/main.rs
+++ b/crates/downloader/src/main.rs
@@ -904,7 +904,7 @@ fn download_and_extract_from_gh(
     tries: Tries,
 ) -> anyhow::Result<impl Future<Output = anyhow::Result<()>> + use<>> {
     let archive_kind = ArchiveKind::from_filename(&name)?;
-    let pb = add_progress_bar(progresses, size as _, name);
+    let pb = add_progress_bar(progresses, size, name);
 
     Ok(retry(tries, async move || {
         let bytes_stream = octocrab
@@ -916,7 +916,7 @@ fn download_and_extract_from_gh(
 
         download_and_extract(
             bytes_stream,
-            Some(size as _),
+            Some(size),
             archive_kind,
             stripping,
             &output,
@@ -973,7 +973,7 @@ async fn download_models(
     let models = models
         .into_iter()
         .map(|model| {
-            let pb = add_progress_bar(progresses, model.size as _, model.name.clone());
+            let pb = add_progress_bar(progresses, model.size, model.name.clone());
             (model, pb)
         })
         .collect::<Vec<_>>();
@@ -1196,7 +1196,7 @@ struct GhAsset {
     body: Option<String>,
     id: AssetId,
     name: String,
-    size: usize,
+    size: u64,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
## 内容

`size`という変数が`i64`→`usize`→`u64`という形でキャストされていたので、これを`i64`→`u64`にする。ちなみに`i64`は[octocrab](https://docs.rs/crate/octocrab)が返してくるもので、`u64`は[indicatif](https://docs.rs/crate/indicatif)が要求するもの。

最終的な`u64`に影響があるとしたらそれは「ダウンローダーを32-bitでビルドして動かし、4GB超えのアセットを扱う」というケースであるが、その場合32-bitアプリケーションとして4GB超えのファイルを扱えないことには変わりない。よってこのPRは表面的な変化をもたらさないと考えられるため、このPRの題名は"refactor"としてある。

## 関連 Issue

## その他
