### PR TITLE
feat(downloader): downloader.mdの内容を`--help`に追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,7 +118,7 @@
           - `Mora`
       </details>
 
-- バージョン0.14.0からの歴史をまとめた[Keep a Changelog](https://keepachangelog.com)形式のCHANGELOG.mdが追加されます。またこのバージョンから、GitHub Releasesの本文にも同じ内容が載るようになります ([#1109], [#1116], [#1117])。
+- バージョン0.14.0からの歴史をまとめた[Keep a Changelog](https://keepachangelog.com)形式のCHANGELOG.mdが追加されます。またこのバージョンから、GitHub Releasesの本文にも同じ内容が載るようになります ([#1109], [#1116], [#1117], [#1125])。
 
 - \[Rust\] Rust Analyzerが、C APIから参照する目的で[0.16.0-preview.0](#0160-preview0---2025-03-01-0900)の[#976]にて導入した`doc(alias)`に反応しないようになります ([#1099])。
 
@@ -175,9 +175,18 @@
     VOICEVOX CORE 0.16.1 downloader
     ```
 
-- \[ダウンローダー\] リポジトリ指定オプション (`--{target}-repo <REPOSITORY>`)にhelpの文章が書かれます ([#1117])。
+- \[ダウンローダー\] helpの文章が充実します ([#1117], [#1125])。
+
+    - リポジトリ指定オプション (`--{target}-repo <REPOSITORY>`)には何も書かれていませんでしたが、書かれます。
+    - `-h`ではなく`--help`のみ、オプションの説明の下に"TARGETS"と"EXAMPLES"の章が追加されます。内容は[https://github.com/VOICEVOX/voicevox_core/blob/main/docs/guide/user/downloader.md](https://github.com/VOICEVOX/voicevox_core/blob/main/docs/guide/user/downloader.md)に書かれているものとほぼ同じです。
 
 - \[ダウンローダー\] 不要である[Oniguruma](https://github.com/kkos/oniguruma)のリンクをやめます ([#1082])。
+
+### Changed
+
+- \[ダウンローダー\] `-h`と`--help`は別々の表示をするようになります ([#1125])。
+
+    簡潔な説明は`-h`で、詳細な説明は`--help`で行われます。
 
 ### Removed
 
@@ -1306,6 +1315,7 @@ Windows版ダウンローダーのビルドに失敗しています。
 [#1116]: https://github.com/VOICEVOX/voicevox_core/pull/1116
 [#1117]: https://github.com/VOICEVOX/voicevox_core/pull/1117
 [#1121]: https://github.com/VOICEVOX/voicevox_core/pull/1121
+[#1125]: https://github.com/VOICEVOX/voicevox_core/pull/1125
 
 [VOICEVOX/onnxruntime-builder#25]: https://github.com/VOICEVOX/onnxruntime-builder/pull/25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,6 +643,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "color-print"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aa954171903797d5623e047d9ab69d91b493657917bdfb8c2c80ecaf9cdb6f4"
+dependencies = [
+ "color-print-proc-macro",
+]
+
+[[package]]
+name = "color-print-proc-macro"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692186b5ebe54007e45a59aea47ece9eb4108e141326c304cdc91699a7118a22"
+dependencies = [
+ "nom",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "color-spantrace"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1112,6 +1133,7 @@ dependencies = [
  "binstall-tar",
  "bytes",
  "clap",
+ "color-print",
  "comrak",
  "easy-ext",
  "flate2",
@@ -1119,8 +1141,10 @@ dependencies = [
  "futures-core",
  "futures-util",
  "glob",
+ "heck 0.5.0",
  "indexmap 2.6.0",
  "indicatif",
+ "indoc",
  "itertools 0.10.5",
  "minus",
  "octocrab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ cbindgen = "0.28.0"
 chrono = { version = "0.4.38", default-features = false }
 clap = { version = "4.5.19", features = ["cargo"] }
 color-eyre = "0.6.3"
+color-print = "0.3.7"
 colorchoice = "1.0.2"
 comrak = { version = "0.26.0", default-features = false }
 const_format = "0.2.33"

--- a/crates/downloader/Cargo.toml
+++ b/crates/downloader/Cargo.toml
@@ -15,6 +15,7 @@ base64.workspace = true
 binstall-tar.workspace = true
 bytes.workspace = true
 clap = { workspace = true, features = ["derive"] }
+color-print.workspace = true
 comrak.workspace = true
 easy-ext.workspace = true
 flate2.workspace = true
@@ -22,8 +23,10 @@ fs-err = { workspace = true, features = ["tokio"] }
 futures-core.workspace = true
 futures-util.workspace = true
 glob.workspace = true
+heck.workspace = true
 indexmap.workspace = true
 indicatif.workspace = true
+indoc.workspace = true
 itertools.workspace = true
 minus = { workspace = true, features = ["static_output"] }
 octocrab = { workspace = true, features = ["rustls-tls", "stream"] }

--- a/crates/downloader/src/main.rs
+++ b/crates/downloader/src/main.rs
@@ -111,7 +111,7 @@ static PROGRESS_STYLE2: LazyLock<ProgressStyle> =
 
                 download --devices cuda
 
-            デフォルト(CPU 版)をダウンロードする場合:
+            一部の音声モデル（VVMファイル）だけダウンロードする場合:
 
                 download --models-pattern 0.vvm # 0.vvmのみダウンロード
 


### PR DESCRIPTION
## 内容

docs/guide/user/downloader.mdの「ダウンローダーがダウンロードするもの」と「…する場合」の内容を、"Options:"の下に続く形でhelpに書く。ただし`-h`ではなく`--help`に対してのみ。

これにより、`-h`と`--help`で別々の表示がされるようになる。

<details><summary><code>-h</code>の表示 (従来の形式)</summary>

```console
簡潔な説明を見るには`-h`、詳細な説明を見るには`--help`を使ってください。

Usage: download [OPTIONS]

Options:
      --only <TARGET>...
          ダウンロード対象を限定する [possible values: c-api, onnxruntime, additional-libraries, models, dict]
      --exclude <TARGET>...
          ダウンロード対象を除外する [possible values: c-api, onnxruntime, additional-libraries, models, dict]
      --min
          `--only c-api`のエイリアス
  -o, --output <DIRECTORY>
          出力先の指定 [default: ./voicevox_core]
      --c-api-version <GIT_TAG_OR_LATEST>
          ダウンロードするVOICEVOX CORE C APIのバージョンの指定 [default: latest]
      --onnxruntime-version <GIT_TAG_OR_LATEST>
          ダウンロードするONNX Runtimeのバージョンの指定 [default: latest]
      --additional-libraries-version <GIT_TAG_OR_LATEST>
          追加でダウンロードするライブラリのバージョン [default: latest]
      --models-pattern <GLOB>
          ダウンロードするVVMファイルのファイル名パターン [default: *]
      --devices <DEVICES>...
          ダウンロードするデバイスを指定する(cudaはlinuxのみ) [default: cpu] [possible values: cpu, cuda, directml]
      --cpu-arch <CPU_ARCH>
          ダウンロードするcpuのアーキテクチャを指定する [default: x64] [possible values: x86, x64, arm64]
      --os <OS>
          ダウンロードする対象のOSを指定する [default: linux] [possible values: windows, linux, osx]
  -t, --tries <NUMBER>
          ダウンロードにおける試行回数。'0'か'inf'で無限にリトライ [default: 5]
      --c-api-repo <REPOSITORY>
          VOICEVOX CORE C API (`c-api`)のリポジトリ [default: VOICEVOX/voicevox_core]
      --onnxruntime-builder-repo <REPOSITORY>
          (VOICEVOX) ONNX Runtime (`onnxruntime`)のリポジトリ [default: VOICEVOX/onnxruntime-builder]
      --additional-libraries-repo <REPOSITORY>
          追加でダウンロードするライブラリ (`additional-libraries`)のリポジトリ [default: VOICEVOX/voicevox_additional_libraries]
      --models-repo <REPOSITORY>
          VOICEVOX音声モデル (`models`)のリポジトリ [default: VOICEVOX/voicevox_vvm]
  -h, --help
          Print help (see more with '--help')
  -V, --version
          Print version
```
</details>

<details><summary><code>--help</code>の表示</summary>

```console
簡潔な説明を見るには`-h`、詳細な説明を見るには`--help`を使ってください。

Usage: download [OPTIONS]

Options:
      --only <TARGET>...
          ダウンロード対象を限定する。

          ダウンロード対象の詳細はTARGETSの章で説明。

          [possible values: c-api, onnxruntime, additional-libraries, models, dict]

      --exclude <TARGET>...
          ダウンロード対象を除外する。

          ダウンロード対象の詳細はTARGETSの章で説明。

          [possible values: c-api, onnxruntime, additional-libraries, models, dict]

      --min
          `--only c-api`のエイリアス。

  -o, --output <DIRECTORY>
          出力先の指定。

          [default: ./voicevox_core]

      --c-api-version <GIT_TAG_OR_LATEST>
          ダウンロードするVOICEVOX CORE C APIのバージョンの指定。

          [default: latest]

      --onnxruntime-version <GIT_TAG_OR_LATEST>
          ダウンロードするONNX Runtimeのバージョンの指定。

          [default: latest]

      --additional-libraries-version <GIT_TAG_OR_LATEST>
          追加でダウンロードするライブラリのバージョン。

          [default: latest]

      --models-pattern <GLOB>
          ダウンロードするVVMファイルのファイル名パターン。

          [default: *]

      --devices <DEVICES>...
          ダウンロードするデバイスを指定する(cudaはlinuxのみ)。

          [default: cpu]
          [possible values: cpu, cuda, directml]

      --cpu-arch <CPU_ARCH>
          ダウンロードするcpuのアーキテクチャを指定する。

          [default: x64]
          [possible values: x86, x64, arm64]

      --os <OS>
          ダウンロードする対象のOSを指定する。

          [default: linux]
          [possible values: windows, linux, osx]

  -t, --tries <NUMBER>
          ダウンロードにおける試行回数。'0'か'inf'で無限にリトライ。

          [default: 5]

      --c-api-repo <REPOSITORY>
          VOICEVOX CORE C API (`c-api`)のリポジトリ。

          [default: VOICEVOX/voicevox_core]

      --onnxruntime-builder-repo <REPOSITORY>
          (VOICEVOX) ONNX Runtime (`onnxruntime`)のリポジトリ。

          [default: VOICEVOX/onnxruntime-builder]

      --additional-libraries-repo <REPOSITORY>
          追加でダウンロードするライブラリ (`additional-libraries`)のリポジトリ。

          [default: VOICEVOX/voicevox_additional_libraries]

      --models-repo <REPOSITORY>
          VOICEVOX音声モデル (`models`)のリポジトリ。

          [default: VOICEVOX/voicevox_vvm]

  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version

Targets:

  `--only`や`--exclude`で特に指定しない場合、ダウンローダーは次のすべてをダウンロードします。

  • c-api (展開先: {output}/c_api/):
          VOICEVOX CORE C APIのビルド済みバイナリおよびその利用規約ファイル等。

  • onnxruntime (展開先: {output}/onnxruntime/):
          (VOICEVOX) ONNX Runtime。

  • additional-libraries (展開先: {output}/additional_libraries/):
          `--devices`で指定したDirectMLやCUDA。

  • models (展開先: {output}/models/):
          VOICEVOX音声モデル（VVMファイル）。

  • dict (展開先: {output}/dict/):
          Open JTalkのシステム辞書。

Examples:

  デフォルト(CPU 版)をダウンロードする場合:

      download

  DirectML 版をダウンロードする場合:

      download --devices directml

  CUDA 版をダウンロードする場合:

      download --devices cuda

  デフォルト(CPU 版)をダウンロードする場合:

      download --models-pattern 0.vvm # 0.vvmのみダウンロード

      download --models-pattern '[0-9]*.vvm' # トーク用VVMに絞り、ソング用VVMをダウンロードしないように
```
</details>

## 関連 Issue

## その他
