### PR TITLE
fix(downloader): 壊れたzipとtgzに対しては明示的にエラーにする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,7 +118,7 @@
           - `Mora`
       </details>
 
-- バージョン0.14.0からの歴史をまとめた[Keep a Changelog](https://keepachangelog.com)形式のCHANGELOG.mdが追加されます。またこのバージョンから、GitHub Releasesの本文にも同じ内容が載るようになります ([#1109], [#1116], [#1117], [#1124], [#1125], [#1126], [#1128], [#1131])。
+- バージョン0.14.0からの歴史をまとめた[Keep a Changelog](https://keepachangelog.com)形式のCHANGELOG.mdが追加されます。またこのバージョンから、GitHub Releasesの本文にも同じ内容が載るようになります ([#1109], [#1116], [#1117], [#1124], [#1125], [#1126], [#1128], [#1131], [#1132])。
 
 - \[Rust\] Rust Analyzerが、C APIから参照する目的で[0.16.0-preview.0](#0160-preview0---2025-03-01-0900)の[#976]にて導入した`doc(alias)`に反応しないようになります ([#1099])。
 
@@ -208,6 +208,7 @@
 - \[Python\] リポジトリにあるMarkdownドキュメントの誤記が修正されます ([#1063])。
 - \[Java\] \[Android\] GHAのUbuntuイメージ備え付けの`$ANDROID_NDK` (現時点ではバージョン27)を使ったリリースがされるようになります。これにより、[#1103]で報告されたAndroidビルドにおけるC++シンボルの問題が解決されます ([#1108])。
 - \[Java\] Javaのファイナライザから中身のRustオブジェクトのデストラクトがされない問題が解決されます ([#1085])。
+- \[ダウンローダー\] `c-api`, `onnxruntime`, `additional-libraries`において、ダウンロードされたzipやgzipが壊れていたときのエラーの出かたが改善されます ([#1132])。
 - \[ダウンローダー\] `--devices <DEVICES>...`のhelpにはダウンローダーの誕生 ([#249])からずっと「(cudaはlinuxのみ)」と書かれていましたが、この記述は当時から正しくなかったので消されます ([#1124])。
 - \[ダウンローダー\] \[Windows\] GitHub Releasesにおいて、再び署名がされるようになります ([#1060])。
 
@@ -1329,6 +1330,7 @@ Windows版ダウンローダーのビルドに失敗しています。
 [#1125]: https://github.com/VOICEVOX/voicevox_core/pull/1125
 [#1128]: https://github.com/VOICEVOX/voicevox_core/pull/1128
 [#1131]: https://github.com/VOICEVOX/voicevox_core/pull/1131
+[#1132]: https://github.com/VOICEVOX/voicevox_core/pull/1132
 
 [VOICEVOX/onnxruntime-builder#25]: https://github.com/VOICEVOX/onnxruntime-builder/pull/25
 

--- a/crates/downloader/src/main.rs
+++ b/crates/downloader/src/main.rs
@@ -1358,19 +1358,16 @@ async fn download(
 // ただしどちらもoctocrab側の対応が必要。
 // cf. https://github.com/VOICEVOX/voicevox_core/issues/1120
 /// [`octocrab::repo::ReleasesHandler::stream_asset`]でダウンロードしたものを検証する。
-fn validate_github_asset_content(
-    asset_content: Vec<u8>,
-    kind: GhAssetKind,
-) -> anyhow::Result<Vec<u8>> {
-    match (kind, &*asset_content) {
+fn validate_github_asset_content(content: Vec<u8>, kind: GhAssetKind) -> anyhow::Result<Vec<u8>> {
+    match (kind, &*content) {
         (GhAssetKind::Archive(ArchiveKind::Zip), [0x50, 0x4b, 0x03, 0x04, ..])
-        | (GhAssetKind::Archive(ArchiveKind::Tgz), [0x1f, 0x8b, 0x08, ..]) => Ok(asset_content),
-        (_, asset_content) => Err({
+        | (GhAssetKind::Archive(ArchiveKind::Tgz), [0x1f, 0x8b, 0x08, ..]) => Ok(content),
+        (_, content) => Err({
             let mut msg = "予期しない応答をGitHubが返しました".to_owned();
-            if let Ok(asset_content) = str::from_utf8(asset_content) {
+            if let Ok(content) = str::from_utf8(content) {
                 msg += ": ";
-                msg += asset_content.trim_end();
-                if asset_content.contains("API rate limit exceeded for") {
+                msg += content.trim_end();
+                if content.contains("API rate limit exceeded for") {
                     msg += " (note: レートリミットによるエラーのようです。\
                             認証トークンを設定することでレートリミットは緩和されます。\
                             詳細は`--help`をご覧ください)";

--- a/crates/downloader/src/main.rs
+++ b/crates/downloader/src/main.rs
@@ -1368,8 +1368,8 @@ fn validate_github_asset_content(content: Vec<u8>, kind: GhAssetKind) -> anyhow:
                 msg += ": ";
                 msg += content.trim_end();
                 if content.contains("API rate limit exceeded for") {
-                    msg += " (note: レートリミットによるエラーのようです。\
-                            認証トークンを設定することでレートリミットは緩和されます。\
+                    msg += " (Note: レートリミットによるエラーの可能性があります。\
+                            認証トークンを設定すると制限が緩和されます。\
                             詳細は`--help`をご覧ください)";
                 }
             }


### PR DESCRIPTION
## 内容

`c-api`, `onnxruntime`, `additional-libraries`でダウンロードされるzipやtgzに対しては、HTTPステータスもSHA-256もチェックされていなかった。そのためレートリミットに到達したときやGitHubの調子が悪いときは、壊れたzip/tgzを解凍しようとして失敗するという挙動になっていた（はず）。そこで壊れていそうなzip/tgzをダウンロードしてしまったときに明示的なエラーを出すようにする。エラーメッセージの文面を少々適当にしてしまったが、この対応がワークアラウンドである間しかこの文面は存在しないはずなので、あまり深く考えていない。

```console
Error: 予期しない応答をGitHubが返しました: {"message":"API rate limit exceeded for {ip-address}. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"} (Note: レートリミットによるエラーの可能性があります。認証トークンを設定すると制限が緩和されます。詳細は`--help`をご覧ください)
```

また #1118 では`models`もGitHub Releasesからの取得になるため、そのための準備でもある (チェック機構を何も入れない場合、zipの解凍は行われないため、エラーメッセージのJSONに化けたVVMをダウンロードしたまま正常終了してしまう)。

根本的な解決にはoctocrab側の対応が必要であり、時間がかかりそうなので今回はワークアラウンドとして実装している。

## 関連 Issue

Resolves: #1120

## その他
