### PR TITLE
fix(downloader): fixup #1098: エラー表示を改善

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,7 +118,7 @@
           - `Mora`
       </details>
 
-- バージョン0.14.0からの歴史をまとめた[Keep a Changelog](https://keepachangelog.com)形式のCHANGELOG.mdが追加されます。またこのバージョンから、GitHub Releasesの本文にも同じ内容が載るようになります ([#1109], [#1116], [#1117], [#1124], [#1125], [#1126], [#1128], [#1131], [#1132], [#1123], [#1133], [#1134], [#1137], [#1136], [#1138])。
+- バージョン0.14.0からの歴史をまとめた[Keep a Changelog](https://keepachangelog.com)形式のCHANGELOG.mdが追加されます。またこのバージョンから、GitHub Releasesの本文にも同じ内容が載るようになります ([#1109], [#1116], [#1117], [#1124], [#1125], [#1126], [#1128], [#1131], [#1132], [#1123], [#1133], [#1134], [#1137], [#1136], [#1138], [#1139])。
 
 - \[Rust\] Rust Analyzerが、C APIから参照する目的で[0.16.0-preview.0](#0160-preview0---2025-03-01-0900)の[#976]にて導入した`doc(alias)`に反応しないようになります ([#1099])。
 
@@ -137,7 +137,7 @@
                  └── voicevoxcore-android/
     ```
 
-- \[ダウンローダー\] :tada: リトライ機構が導入され、デフォルトで4回のリトライを行うようになります ([#1098] by [@shuntia], [#1111], [#1121])。
+- \[ダウンローダー\] :tada: リトライ機構が導入され、デフォルトで4回のリトライを行うようになります ([#1098] by [@shuntia], [#1111], [#1121], [#1139])。
 
     ```console
       -t, --tries <NUMBER>
@@ -1352,6 +1352,7 @@ Windows版ダウンローダーのビルドに失敗しています。
 [#1136]: https://github.com/VOICEVOX/voicevox_core/pull/1136
 [#1137]: https://github.com/VOICEVOX/voicevox_core/pull/1137
 [#1138]: https://github.com/VOICEVOX/voicevox_core/pull/1138
+[#1139]: https://github.com/VOICEVOX/voicevox_core/pull/1139
 
 [VOICEVOX/onnxruntime-builder#25]: https://github.com/VOICEVOX/onnxruntime-builder/pull/25
 

--- a/crates/downloader/src/main.rs
+++ b/crates/downloader/src/main.rs
@@ -711,9 +711,9 @@ fn octocrab() -> octocrab::Result<Arc<Octocrab>> {
     octocrab.build().map(Arc::new)
 }
 
-async fn retry<E, F>(tries: Tries, mut f: F) -> Result<(), E>
+async fn retry<F>(tries: Tries, mut f: F) -> anyhow::Result<()>
 where
-    F: AsyncFnMut() -> Result<(), E>,
+    F: AsyncFnMut() -> anyhow::Result<()>,
 {
     match tries {
         Tries::Infinite => loop {
@@ -722,12 +722,26 @@ where
             }
         },
         Tries::Finite(nonzero) => {
+            let mut attempt = async || {
+                f().await.map_err(|err| {
+                    err.chain().skip(1).fold(format!("- {err}"), |msg, cause| {
+                        format!("{msg}\n  Caused by: {cause}")
+                    })
+                })
+            };
+
+            let mut result = attempt().await;
             for _ in 0..nonzero.get() - 1 {
-                if let Ok(o) = f().await {
-                    return Ok(o);
+                if let Err(err1) = result {
+                    result = attempt().await.map_err(|err2| format!("{err1}\n{err2}"));
+                } else {
+                    break;
                 }
             }
-            f().await
+            result.map_err(|causes| {
+                anyhow!("{causes}")
+                    .context(format!("{nonzero}回のダウンロード試行がすべて失敗しました"))
+            })
         }
     }
 }

--- a/crates/downloader/src/main.rs
+++ b/crates/downloader/src/main.rs
@@ -739,7 +739,7 @@ where
                 }
             }
             result.map_err(|causes| {
-                anyhow!("{causes}")
+                anyhow::Error::msg(causes)
                     .context(format!("{nonzero}回のダウンロード試行がすべて失敗しました"))
             })
         }


### PR DESCRIPTION
## 内容

#1098 で導入されたリトライ機構においてリトライ回数を使いきったとき、最後のエラーのみが表示される仕様だった。これを改め、すべてのエラーを並べて表示するようにする。

```console
Error: 5回のダウンロード試行がすべて失敗しました

Caused by:
    - failed to create directory `./voicevox_core/c_api`
      Caused by: File exists (os error 17)
    - failed to create directory `./voicevox_core/c_api`
      Caused by: File exists (os error 17)
    - failed to create directory `./voicevox_core/c_api`
      Caused by: File exists (os error 17)
    - failed to create directory `./voicevox_core/c_api`
      Caused by: File exists (os error 17)
    - failed to create directory `./voicevox_core/c_api`
      Caused by: File exists (os error 17)
```

#1127 のうちエラー表示の部分の解決になる。

## 関連 Issue

## その他
