### PR TITLE
feat(rust): MSRVを1.84.0に戻す

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,8 +70,8 @@ jobs:
           rust_version=$(
             jq -r '
               .workspace_default_members[] as $id
-                | .packages[] | select(.id == $id)
-                | .rust_version
+                | .packages[]
+                | select(.id == $id).rust_version
               ' <<< "$metadata"
           )
           echo "rust-version=$rust_version" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Extract Rust API's MSRV
         id: msrv-for-rust-api
         run: |
-          metadata=$(cargo metadata --format-version 1 --manifest-path ./crates/voicevox_core/Cargo.toml)
+          metadata=$(cargo metadata --format-version 1 --manifest-path ./crates/voicevox_core/Cargo.toml --no-deps)
           rust_version=$(
             jq -r '
               .workspace_default_members[] as $id

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,24 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Rust
+      - name: Extract Rust API's MSRV
+        id: msrv-for-rust-api
+        run: |
+          metadata=$(cargo metadata --format-version 1 --manifest-path ./crates/voicevox_core/Cargo.toml)
+          rust_version=$(
+            jq -r '
+              .workspace_default_members[] as $id
+                | .packages[] | select(.id == $id)
+                | .rust_version
+              ' <<< "$metadata"
+          )
+          echo "rust-version=$rust_version" >> "$GITHUB_OUTPUT"
+      - name: Set up Rust (for Rust API)
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.msrv-for-rust-api.outputs.rust-version }}
+          components: clippy
+      - name: Set up Rust (for rest packages)
         uses: ./.github/actions/rust-toolchain-from-file
         with:
           components: clippy,rustfmt
@@ -76,6 +93,18 @@ jobs:
       - run: cargo clippy -v --features load-onnxruntime -- -D clippy::all -D warnings --no-deps
       - run: cargo clippy -v -p voicevox_core -p voicevox_core_c_api --features link-onnxruntime --tests -- -D clippy::all -D warnings --no-deps
       - run: cargo clippy -v -p voicevox_core -p voicevox_core_c_api --features link-onnxruntime -- -D clippy::all -D warnings --no-deps
+      - name: Do `cargo check` the Rust API with its MSRV
+        run: |
+          rust_api=$(realpath ./crates/voicevox_core)
+          mkdir /tmp/use-rust-api
+          cd "$_"
+          rustup override set ${{ steps.msrv-for-rust-api.outputs.rust-version }}
+          cargo init
+          cargo add --path "$rust_api" --features load-onnxruntime
+          cargo check
+          cargo rm voicevox_core
+          cargo add --path "$rust_api" --features link-onnxruntime
+          cargo check
       - run: cargo fmt -- --check
 
   rust-unit-test:

--- a/crates/voicevox_core/Cargo.toml
+++ b/crates/voicevox_core/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "voicevox_core"
 version.workspace = true
-edition.workspace = true
+edition = "2021"
 publish.workspace = true
-rust-version.workspace = true
+rust-version = "1.84.0" # TODO: Rust 1.88以降にするときは、 #1083 (async closures) および #1104 (let chain, `#[cfg(false)]`) と同じことをする
 license.workspace = true
 
 [package.metadata.docs.rs]

--- a/crates/voicevox_core/src/__internal/interop.rs
+++ b/crates/voicevox_core/src/__internal/interop.rs
@@ -5,8 +5,8 @@ pub use crate::{
     core::metas::merge as merge_metas,
     engine::talk::user_dict::{DEFAULT_PRIORITY, DEFAULT_WORD_TYPE},
     synthesizer::{
-        BlockingTextAnalyzerExt, DEFAULT_CPU_NUM_THREADS, DEFAULT_ENABLE_INTERROGATIVE_UPSPEAK,
-        DEFAULT_HEAVY_INFERENCE_CANCELLABLE, MARGIN, NonblockingTextAnalyzerExt,
-        blocking::PerformInference,
+        blocking::PerformInference, BlockingTextAnalyzerExt, NonblockingTextAnalyzerExt,
+        DEFAULT_CPU_NUM_THREADS, DEFAULT_ENABLE_INTERROGATIVE_UPSPEAK,
+        DEFAULT_HEAVY_INFERENCE_CANCELLABLE, MARGIN,
     },
 };

--- a/crates/voicevox_core/src/core/infer.rs
+++ b/crates/voicevox_core/src/core/infer.rs
@@ -11,8 +11,8 @@ use ndarray::{Array, ArrayD, Dimension, ShapeError};
 use thiserror::Error;
 
 use crate::{
-    StyleType, SupportedDevices,
     asyncs::{Async, BlockingThreadPool, SingleTasked},
+    StyleType, SupportedDevices,
 };
 
 use super::{

--- a/crates/voicevox_core/src/core/infer/runtimes/onnxruntime.rs
+++ b/crates/voicevox_core/src/core/infer/runtimes/onnxruntime.rs
@@ -277,9 +277,9 @@ fn extract_outputs(outputs: &ort::SessionOutputs<'_, '_>) -> anyhow::Result<Vec<
 
 pub(crate) mod blocking {
     use ort::EnvHandle;
-    use ref_cast::{RefCastCustom, ref_cast_custom};
+    use ref_cast::{ref_cast_custom, RefCastCustom};
 
-    use crate::{SupportedDevices, error::ErrorRepr};
+    use crate::{error::ErrorRepr, SupportedDevices};
 
     use super::super::super::InferenceRuntime;
 
@@ -470,7 +470,7 @@ pub(crate) mod blocking {
 }
 
 pub(crate) mod nonblocking {
-    use ref_cast::{RefCastCustom, ref_cast_custom};
+    use ref_cast::{ref_cast_custom, RefCastCustom};
 
     use crate::SupportedDevices;
 

--- a/crates/voicevox_core/src/core/manifest.rs
+++ b/crates/voicevox_core/src/core/manifest.rs
@@ -8,14 +8,14 @@ use derive_getters::Getters;
 use derive_more::{Deref, Index};
 use derive_new::new;
 use enum_map::EnumMap;
-use serde::{Deserialize, Deserializer, Serialize, de};
-use serde_with::{DisplayFromStr, serde_as};
+use serde::{de, Deserialize, Deserializer, Serialize};
+use serde_with::{serde_as, DisplayFromStr};
 
 use crate::{StyleId, VoiceModelId};
 
 use super::infer::domains::{
-    ExperimentalTalkOperation, FrameDecodeOperation, InferenceDomainMap, SingingTeacherOperation,
-    TalkOperation, inference_domain_map_values,
+    inference_domain_map_values, ExperimentalTalkOperation, FrameDecodeOperation,
+    InferenceDomainMap, SingingTeacherOperation, TalkOperation,
 };
 
 #[derive(Clone, Debug)]

--- a/crates/voicevox_core/src/core/status.rs
+++ b/crates/voicevox_core/src/core/status.rs
@@ -10,19 +10,20 @@ use indexmap::IndexMap;
 use itertools::iproduct;
 
 use crate::{
-    Result,
     error::{ErrorRepr, LoadModelError, LoadModelErrorKind, LoadModelResult},
+    Result,
 };
 
 use super::{
     infer::{
-        self, InferenceDomain, InferenceInputSignature, InferenceRuntime, InferenceSessionOptions,
-        InferenceSignature,
+        self,
         domains::{
-            ExperimentalTalkDomain, FrameDecodeDomain, InferenceDomainMap, SingingTeacherDomain,
-            TalkDomain, inference_domain_map_values,
+            inference_domain_map_values, ExperimentalTalkDomain, FrameDecodeDomain,
+            InferenceDomainMap, SingingTeacherDomain, TalkDomain,
         },
         session_set::{InferenceSessionCell, InferenceSessionSet},
+        InferenceDomain, InferenceInputSignature, InferenceRuntime, InferenceSessionOptions,
+        InferenceSignature,
     },
     manifest::{InnerVoiceId, StyleIdToInnerVoiceId},
     metas::{self, CharacterMeta, StyleId, StyleMeta, VoiceModelMeta},
@@ -415,11 +416,11 @@ mod tests {
         super::{
             devices::{DeviceSpec, GpuSpec},
             infer::{
-                InferenceSessionOptions,
                 domains::{
                     ExperimentalTalkOperation, FrameDecodeOperation, InferenceDomainMap,
                     SingingTeacherOperation, TalkOperation,
                 },
+                InferenceSessionOptions,
             },
         },
         Status,

--- a/crates/voicevox_core/src/core/voice_model.rs
+++ b/crates/voicevox_core/src/core/voice_model.rs
@@ -329,6 +329,7 @@ impl<A: Async> Inner<A> {
             })
         });
 
+        // TODO: Rust 1.85にしたらasync closureに戻す
         let talk = OptionFuture::from(talk.map(|(entries, style_id_to_inner_voice_id)| async {
             let [predict_duration, predict_intonation, decode] = entries.into_array();
 
@@ -343,6 +344,7 @@ impl<A: Async> Inner<A> {
         .await
         .transpose()?;
 
+        // TODO: Rust 1.85にしたらasync closureに戻す
         let experimental_talk = OptionFuture::from(experimental_talk.map(
             |(entries, style_id_to_inner_voice_id)| async {
                 let [predict_duration, predict_intonation, predict_spectrogram, run_vocoder] =
@@ -366,6 +368,7 @@ impl<A: Async> Inner<A> {
         .await
         .transpose()?;
 
+        // TODO: Rust 1.85にしたらasync closureに戻す
         let singing_teacher = OptionFuture::from(singing_teacher.map(
             |(entries, style_id_to_inner_voice_id)| async {
                 let [predict_sing_consonant_length, predict_sing_f0, predict_sing_volume] =
@@ -387,6 +390,7 @@ impl<A: Async> Inner<A> {
         .await
         .transpose()?;
 
+        // TODO: Rust 1.85にしたらasync closureに戻す
         let frame_decode = OptionFuture::from(frame_decode.map(
             |(entries, style_id_to_inner_voice_id)| async {
                 let [sf_decode] = entries.into_array();

--- a/crates/voicevox_core/src/engine/acoustic_feature_extractor.rs
+++ b/crates/voicevox_core/src/engine/acoustic_feature_extractor.rs
@@ -84,6 +84,8 @@ impl OjtPhoneme {
 
     pub(super) fn convert(phonemes: &[OjtPhoneme]) -> Vec<OjtPhoneme> {
         let mut phonemes = phonemes.to_owned();
+        #[cfg(any())]
+        __! {
         if let Some(first_phoneme) = phonemes.first_mut()
             && first_phoneme.phoneme.contains("sil")
         {
@@ -93,6 +95,17 @@ impl OjtPhoneme {
             && last_phoneme.phoneme.contains("sil")
         {
             last_phoneme.phoneme = OjtPhoneme::space_phoneme();
+        }
+        }
+        if let Some(first_phoneme) = phonemes.first_mut() {
+            if first_phoneme.phoneme.contains("sil") {
+                first_phoneme.phoneme = OjtPhoneme::space_phoneme();
+            }
+        }
+        if let Some(last_phoneme) = phonemes.last_mut() {
+            if last_phoneme.phoneme.contains("sil") {
+                last_phoneme.phoneme = OjtPhoneme::space_phoneme();
+            }
         }
         phonemes
     }

--- a/crates/voicevox_core/src/engine/acoustic_feature_extractor.rs
+++ b/crates/voicevox_core/src/engine/acoustic_feature_extractor.rs
@@ -84,6 +84,7 @@ impl OjtPhoneme {
 
     pub(super) fn convert(phonemes: &[OjtPhoneme]) -> Vec<OjtPhoneme> {
         let mut phonemes = phonemes.to_owned();
+        // TODO: Rust 2024にしたらlet chainに戻す
         #[cfg(any())]
         __! {
         if let Some(first_phoneme) = phonemes.first_mut()

--- a/crates/voicevox_core/src/engine/talk.rs
+++ b/crates/voicevox_core/src/engine/talk.rs
@@ -7,6 +7,6 @@ pub(crate) mod text_analyzer;
 pub(crate) mod user_dict;
 
 pub(crate) use self::full_context_label::extract_full_context_label;
-pub(crate) use self::interpret_query::{DecoderFeature, initial_process, split_mora};
-pub(crate) use self::kana_parser::{KanaParseError, create_kana, parse_kana};
+pub(crate) use self::interpret_query::{initial_process, split_mora, DecoderFeature};
+pub(crate) use self::kana_parser::{create_kana, parse_kana, KanaParseError};
 pub use self::model::{AccentPhrase, AudioQuery, Mora};

--- a/crates/voicevox_core/src/engine/talk/full_context_label.rs
+++ b/crates/voicevox_core/src/engine/talk/full_context_label.rs
@@ -133,18 +133,15 @@ fn generate_moras(accent_phrase: &[Label]) -> std::result::Result<Vec<crate::Mor
 
             // 音素が3つ以上ある場合：
             // position_forwardとposition_backwardが飽和している場合は無視する
-            [
-                Label {
-                    mora:
-                        Some(jlabel::Mora {
-                            position_forward: 49,
-                            position_backward: 49,
-                            ..
-                        }),
-                    ..
-                },
-                ..,
-            ] => {}
+            [Label {
+                mora:
+                    Some(jlabel::Mora {
+                        position_forward: 49,
+                        position_backward: 49,
+                        ..
+                    }),
+                ..
+            }, ..] => {}
             _ => {
                 return Err(ErrorKind::TooLongMora);
             }
@@ -204,9 +201,9 @@ mod tests {
     use crate::AccentPhrase;
 
     use super::super::{
-        Mora,
         full_context_label::{extract_full_context_label, generate_accent_phrases},
         open_jtalk::FullcontextExtractor,
+        Mora,
     };
 
     fn mora(text: &str, consonant: Option<&str>, vowel: &str) -> Mora {

--- a/crates/voicevox_core/src/engine/talk/interpret_query.rs
+++ b/crates/voicevox_core/src/engine/talk/interpret_query.rs
@@ -1,6 +1,6 @@
 //! [`AudioQuery`]から特徴量を取り出す処理を集めたもの。
 
-use super::{super::OjtPhoneme, AccentPhrase, AudioQuery, Mora, full_context_label::mora_to_text};
+use super::{super::OjtPhoneme, full_context_label::mora_to_text, AccentPhrase, AudioQuery, Mora};
 
 pub(crate) fn initial_process(accent_phrases: &[AccentPhrase]) -> (Vec<Mora>, Vec<OjtPhoneme>) {
     let flatten_moras = to_flatten_moras(accent_phrases);

--- a/crates/voicevox_core/src/engine/talk/open_jtalk.rs
+++ b/crates/voicevox_core/src/engine/talk/open_jtalk.rs
@@ -34,13 +34,13 @@ pub(crate) mod blocking {
 
     use anyhow::Context as _;
     use camino::{Utf8Path, Utf8PathBuf};
-    use open_jtalk::{JpCommon, ManagedResource, Mecab, Njd, mecab_dict_index, text2mecab};
+    use open_jtalk::{mecab_dict_index, text2mecab, JpCommon, ManagedResource, Mecab, Njd};
     use tempfile::NamedTempFile;
 
     use crate::error::ErrorRepr;
 
     use super::{
-        super::{AccentPhrase, extract_full_context_label},
+        super::{extract_full_context_label, AccentPhrase},
         FullcontextExtractor, OpenjtalkFunctionError,
     };
 
@@ -249,7 +249,7 @@ pub(crate) mod blocking {
 pub(crate) mod nonblocking {
     use camino::Utf8Path;
 
-    use super::super::{AccentPhrase, extract_full_context_label};
+    use super::super::{extract_full_context_label, AccentPhrase};
 
     /// テキスト解析器としてのOpen JTalk。
     ///
@@ -279,7 +279,7 @@ pub(crate) mod nonblocking {
             &self,
             user_dict: &crate::nonblocking::UserDict,
         ) -> crate::result::Result<()> {
-            let inner = self.0.0.clone();
+            let inner = self.0 .0.clone();
             let words = user_dict.to_mecab_format();
             crate::task::asyncify(move || inner.use_user_dict(&words)).await
         }
@@ -290,7 +290,7 @@ pub(crate) mod nonblocking {
             if text.is_empty() {
                 return Ok(Vec::new());
             }
-            let inner = self.0.0.clone();
+            let inner = self.0 .0.clone();
             let text = text.to_owned();
             crate::task::asyncify(move || extract_full_context_label(&*inner, &text))
                 .await

--- a/crates/voicevox_core/src/engine/talk/user_dict.rs
+++ b/crates/voicevox_core/src/engine/talk/user_dict.rs
@@ -2,7 +2,7 @@ pub(crate) mod dict;
 mod part_of_speech_data;
 mod word;
 
+pub(crate) use self::word::{to_zenkaku, validate_pronunciation, InvalidWordError};
 pub use self::word::{
-    DEFAULT_PRIORITY, DEFAULT_WORD_TYPE, UserDictWord, UserDictWordBuilder, UserDictWordType,
+    UserDictWord, UserDictWordBuilder, UserDictWordType, DEFAULT_PRIORITY, DEFAULT_WORD_TYPE,
 };
-pub(crate) use self::word::{InvalidWordError, to_zenkaku, validate_pronunciation};

--- a/crates/voicevox_core/src/engine/talk/user_dict/dict.rs
+++ b/crates/voicevox_core/src/engine/talk/user_dict/dict.rs
@@ -114,7 +114,7 @@ pub(crate) mod blocking {
     use indexmap::IndexMap;
     use uuid::Uuid;
 
-    use crate::{Result, asyncs::SingleTasked, future::FutureExt as _};
+    use crate::{asyncs::SingleTasked, future::FutureExt as _, Result};
 
     use super::{super::word::UserDictWord, Inner};
 
@@ -194,7 +194,7 @@ pub(crate) mod nonblocking {
     use indexmap::IndexMap;
     use uuid::Uuid;
 
-    use crate::{Result, asyncs::BlockingThreadPool};
+    use crate::{asyncs::BlockingThreadPool, Result};
 
     use super::{super::word::UserDictWord, Inner};
 

--- a/crates/voicevox_core/src/engine/talk/user_dict/word.rs
+++ b/crates/voicevox_core/src/engine/talk/user_dict/word.rs
@@ -1,12 +1,12 @@
 use std::{ops::RangeToInclusive, sync::LazyLock};
 
 use regex::Regex;
-use serde::{Deserialize, Serialize, Serializer, de::Error as _};
+use serde::{de::Error as _, Deserialize, Serialize, Serializer};
 
 use crate::{error::ErrorRepr, result::Result};
 
 use super::part_of_speech_data::{
-    MAX_PRIORITY, MIN_PRIORITY, PART_OF_SPEECH_DETAIL, PartOfSpeechDetail, priority2cost,
+    priority2cost, PartOfSpeechDetail, MAX_PRIORITY, MIN_PRIORITY, PART_OF_SPEECH_DETAIL,
 };
 
 /// ユーザー辞書の単語。

--- a/crates/voicevox_core/src/error.rs
+++ b/crates/voicevox_core/src/error.rs
@@ -1,7 +1,7 @@
 use crate::{
-    StyleId, StyleType, VoiceModelId,
     core::devices::DeviceAvailabilities,
-    engine::talk::{KanaParseError, user_dict::InvalidWordError},
+    engine::talk::{user_dict::InvalidWordError, KanaParseError},
+    StyleId, StyleType, VoiceModelId,
 };
 //use engine::
 use duplicate::duplicate_item;

--- a/crates/voicevox_core/src/lib.rs
+++ b/crates/voicevox_core/src/lib.rs
@@ -30,7 +30,7 @@
 //! };
 //!
 //! // ダウンローダーにて`onnxruntime`としてダウンロードできるもの
-//! # #[cfg(false)]
+//! # #[cfg(any())]
 //! const VVORT: &str = concatcp!(
 //!     "./voicevox_core/onnxruntime/lib/",
 //!     Onnxruntime::LIB_VERSIONED_FILENAME,
@@ -38,20 +38,20 @@
 //! # use test_util::ONNXRUNTIME_DYLIB_PATH as VVORT;
 //!
 //! // ダウンローダーにて`dict`としてダウンロードできるもの
-//! # #[cfg(false)]
+//! # #[cfg(any())]
 //! const OJT_DIC: &str = "./voicevox_core/dict/open_jtalk_dic_utf_8-1.11";
 //! # use test_util::OPEN_JTALK_DIC_DIR as OJT_DIC;
 //!
 //! // ダウンローダーにて`models`としてダウンロードできるもの
-//! # #[cfg(false)]
+//! # #[cfg(any())]
 //! const VVM: &str = "./voicevox_core/models/vvms/0.vvm";
 //! # use test_util::SAMPLE_VOICE_MODEL_FILE_PATH as VVM;
 //!
-//! # #[cfg(false)]
+//! # #[cfg(any())]
 //! const TARGET_CHARACTER_NAME: &str = "ずんだもん";
 //! # const TARGET_CHARACTER_NAME: &str = "dummy1";
 //! #
-//! # #[cfg(false)]
+//! # #[cfg(any())]
 //! const TARGET_STYLE_NAME: &str = "ノーマル";
 //! # const TARGET_STYLE_NAME: &str = "style1";
 //! #
@@ -118,11 +118,11 @@
 //!
 //! fn f(synth: &Synthesizer<impl TextAnalyzer>) -> anyhow::Result<()> {
 //! #    const TEXT: &str = "";
-//! #   #[cfg(false)]
+//! #   #[cfg(any())]
 //!     const TEXT: &str = _;
 //! #
 //! #   const STYLE_ID: StyleId = StyleId(0);
-//! #   #[cfg(false)]
+//! #   #[cfg(any())]
 //!     const STYLE_ID: StyleId = _;
 //!
 //!     let wav1 = synth.tts(TEXT, STYLE_ID).perform()?;
@@ -278,8 +278,8 @@ pub use self::{
         voice_model::VoiceModelId,
     },
     engine::talk::{
-        AccentPhrase, AudioQuery, Mora,
         user_dict::{UserDictWord, UserDictWordBuilder, UserDictWordType},
+        AccentPhrase, AudioQuery, Mora,
     },
     error::{Error, ErrorKind},
     result::Result,

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -15,35 +15,35 @@ use std::{
 use tracing::info;
 
 use crate::{
-    AccentPhrase, AudioQuery, Result, StyleId, VoiceModelId, VoiceModelMeta,
     asyncs::{Async, BlockingThreadPool, SingleTasked},
     core::{
         devices::{self, DeviceSpec, GpuSpec},
         ensure_minimum_phoneme_length,
         infer::{
-            self, InferenceRuntime, InferenceSessionOptions,
+            self,
             domains::{
-                DecodeInput, DecodeOutput, ExperimentalTalkDomain, ExperimentalTalkOperation,
-                FrameDecodeDomain, FrameDecodeOperation, GenerateFullIntermediateInput,
-                GenerateFullIntermediateOutput, InferenceDomainMap,
+                experimental_talk, talk, DecodeInput, DecodeOutput, ExperimentalTalkDomain,
+                ExperimentalTalkOperation, FrameDecodeDomain, FrameDecodeOperation,
+                GenerateFullIntermediateInput, GenerateFullIntermediateOutput, InferenceDomainMap,
                 PredictSingConsonantLengthInput, PredictSingConsonantLengthOutput,
                 PredictSingF0Input, PredictSingF0Output, PredictSingVolumeInput,
                 PredictSingVolumeOutput, RenderAudioSegmentInput, RenderAudioSegmentOutput,
                 SfDecodeInput, SfDecodeOutput, SingingTeacherDomain, SingingTeacherOperation,
-                TalkDomain, TalkOperation, experimental_talk, talk,
+                TalkDomain, TalkOperation,
             },
+            InferenceRuntime, InferenceSessionOptions,
         },
         pad_decoder_feature,
         status::Status,
         voice_model,
     },
     engine::{
-        OjtPhoneme,
-        talk::{DecoderFeature, Mora, create_kana, initial_process, parse_kana, split_mora},
-        to_s16le_pcm, wav_from_s16le,
+        talk::{create_kana, initial_process, parse_kana, split_mora, DecoderFeature, Mora},
+        to_s16le_pcm, wav_from_s16le, OjtPhoneme,
     },
     error::ErrorRepr,
     future::FutureExt as _,
+    AccentPhrase, AudioQuery, Result, StyleId, VoiceModelId, VoiceModelMeta,
 };
 
 pub const DEFAULT_CPU_NUM_THREADS: u16 = 0;
@@ -1209,7 +1209,7 @@ fn list_windows_video_cards() {
     use humansize::BINARY;
     use tracing::{error, info};
     use windows::Win32::Graphics::Dxgi::{
-        CreateDXGIFactory, DXGI_ADAPTER_DESC, DXGI_ERROR_NOT_FOUND, IDXGIFactory,
+        CreateDXGIFactory, IDXGIFactory, DXGI_ADAPTER_DESC, DXGI_ERROR_NOT_FOUND,
     };
 
     info!("検出されたGPU (DirectMLにはGPU 0が使われます):");
@@ -1318,8 +1318,8 @@ pub(crate) mod blocking {
     use easy_ext::ext;
 
     use crate::{
-        AccentPhrase, AudioQuery, StyleId, VoiceModelId, VoiceModelMeta, asyncs::SingleTasked,
-        future::FutureExt as _,
+        asyncs::SingleTasked, future::FutureExt as _, AccentPhrase, AudioQuery, StyleId,
+        VoiceModelId, VoiceModelMeta,
     };
 
     use super::{
@@ -1970,8 +1970,8 @@ pub(crate) mod nonblocking {
     use easy_ext::ext;
 
     use crate::{
-        AccentPhrase, AudioQuery, Result, StyleId, VoiceModelId, VoiceModelMeta,
-        asyncs::BlockingThreadPool,
+        asyncs::BlockingThreadPool, AccentPhrase, AudioQuery, Result, StyleId, VoiceModelId,
+        VoiceModelMeta,
     };
 
     use super::{
@@ -2471,8 +2471,8 @@ pub(crate) mod nonblocking {
 mod tests {
     use super::{AccelerationMode, AsInner as _, DEFAULT_HEAVY_INFERENCE_CANCELLABLE};
     use crate::{
-        AccentPhrase, Result, StyleId, asyncs::BlockingThreadPool, engine::talk::Mora,
-        macros::tests::assert_debug_fmt_eq,
+        asyncs::BlockingThreadPool, engine::talk::Mora, macros::tests::assert_debug_fmt_eq,
+        AccentPhrase, Result, StyleId,
     };
     use ::test_util::OPEN_JTALK_DIC_DIR;
     use rstest::rstest;

--- a/crates/voicevox_core_macros/Cargo.toml
+++ b/crates/voicevox_core_macros/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "voicevox_core_macros"
 version.workspace = true
-edition.workspace = true
+edition = "2021"
 publish.workspace = true
-rust-version.workspace = true
+rust-version = "1.84.0"
 license.workspace = true
 
 [lib]

--- a/crates/voicevox_core_macros/src/extract.rs
+++ b/crates/voicevox_core_macros/src/extract.rs
@@ -1,5 +1,5 @@
 use syn::{
-    Attribute, Data, DataEnum, DataStruct, DataUnion, Field, Fields, Type, spanned::Spanned as _,
+    spanned::Spanned as _, Attribute, Data, DataEnum, DataStruct, DataUnion, Field, Fields, Type,
 };
 
 pub(crate) fn struct_fields(data: &Data) -> syn::Result<Vec<(&[Attribute], &syn::Ident, &Type)>> {

--- a/crates/voicevox_core_macros/src/inference_domain.rs
+++ b/crates/voicevox_core_macros/src/inference_domain.rs
@@ -1,10 +1,10 @@
 use indexmap::IndexMap;
 use quote::quote;
 use syn::{
-    Attribute, Data, DataEnum, DataStruct, DataUnion, DeriveInput, Fields, Generics, ItemType,
-    Type, Variant,
     parse::{Parse, ParseStream},
     spanned::Spanned as _,
+    Attribute, Data, DataEnum, DataStruct, DataUnion, DeriveInput, Fields, Generics, ItemType,
+    Type, Variant,
 };
 
 pub(crate) fn derive_inference_operation(

--- a/crates/voicevox_core_macros/src/inference_domains.rs
+++ b/crates/voicevox_core_macros/src/inference_domains.rs
@@ -1,8 +1,9 @@
 use derive_syn_parse::Parse;
 use quote::ToTokens as _;
 use syn::{
-    Path, PathArguments, PathSegment, Token, Type, TypePath, parse_quote,
+    parse_quote,
     visit_mut::{self, VisitMut},
+    Path, PathArguments, PathSegment, Token, Type, TypePath,
 };
 
 pub(crate) fn substitute_type(input: Substitution) -> syn::Result<proc_macro2::TokenStream> {
@@ -46,22 +47,19 @@ pub(crate) fn substitute_type(input: Substitution) -> syn::Result<proc_macro2::T
             };
 
             match &mut *segments.iter_mut().collect::<Vec<_>>() {
-                [
-                    PathSegment {
-                        ident,
-                        arguments: PathArguments::None,
-                    },
-                ] if *ident == self.arg => {
+                [PathSegment {
+                    ident,
+                    arguments: PathArguments::None,
+                }] if *ident == self.arg => {
                     let replacement = self.replacement.clone();
                     *i = parse_quote!(#replacement);
                 }
-                [
-                    PathSegment {
-                        ident: ident1,
-                        arguments: PathArguments::None,
-                    },
-                    seg,
-                ] if *ident1 == self.arg => {
+                [PathSegment {
+                    ident: ident1,
+                    arguments: PathArguments::None,
+                }, seg]
+                    if *ident1 == self.arg =>
+                {
                     let replacement = self.replacement.clone();
                     let replacement_as = self.replacement_as.clone();
                     *i = parse_quote!(<#replacement as #replacement_as>::#seg);


### PR DESCRIPTION
## 内容

MSRVを0.16.0のものにすることで #1130 を先延ばしにする。また、MSRVで`cargo check`を行うCIも追加する。

## 関連 Issue

## その他

diffの大半はedition違いのRustfmtによるもの。
