### PR TITLE
build(java): gradle → gradlew

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -385,7 +385,7 @@ jobs:
           copy_dll osx-x64 macos-x64
           copy_dll osx-arm64 macos-arm64
 
-          OS=desktop gradle publishToMavenLocal
+          OS=desktop ./gradlew publishToMavenLocal
 
           # android
           clean_dlls
@@ -395,7 +395,7 @@ jobs:
           cp "$ANDROID_NDK"/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so lib/src/main/resources/jniLibs/arm64-v8a/
           cp "$ANDROID_NDK"/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/x86_64-linux-android/libc++_shared.so lib/src/main/resources/jniLibs/x86_64/
 
-          OS=android gradle publishToMavenLocal
+          OS=android ./gradlew publishToMavenLocal
 
       - name: Package
         run: |


### PR DESCRIPTION
## 内容

CIではgradlewが使われていたが、`build_and_deploy`では #621 から`ubuntu-latest`のgradleが使われていた。先日の actions/runner-images#12702 によりGradleが9.0.0になって`build_and_deploy`が壊れたため、まずはgradleではなくgradlewを使うようにする。

<details><summary>ビルドログ</summary>

```console
Starting a Gradle Daemon (subsequent builds will be faster)
> Task :lib:compileJava
> Task :lib:processResources
> Task :lib:classes
> Task :lib:jar
> Task :lib:javadoc
> Task :lib:javadocJar
> Task :lib:sourcesJar
> Task :lib:generateMetadataFileForMavenPublication
> Task :lib:generatePomFileForMavenPublication
> Task :lib:publishMavenPublicationToMavenLocal
> Task :lib:publishToMavenLocal

BUILD SUCCESSFUL in 35s
9 actionable tasks: 9 executed
Consider enabling configuration cache to speed up this build: https://docs.gradle.org/9.0.0/userguide/configuration_cache_enabling.html
'../../artifacts/voicevox_core_java_api-android-arm64/libvoicevox_core_java_api.so' -> 'lib/src/main/resources/jniLibs/arm64-v8a/libvoicevox_core_java_api.so'
'../../artifacts/voicevox_core_java_api-android-x86_64/libvoicevox_core_java_api.so' -> 'lib/src/main/resources/jniLibs/x86_64/libvoicevox_core_java_api.so'


FAILURE: Build completed with 2 failures.

1: Task failed with an exception.
-----------
* What went wrong:
org/gradle/api/internal/HasConvention
> org.gradle.api.internal.HasConvention

* Try:
[Incubating] Problems report is available at: file:///home/runner/work/voicevox_core/voicevox_core/crates/voicevox_core_java_api/build/reports/problems/problems-report.html
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to generate a Build Scan (Powered by Develocity).
> Get more help at https://help.gradle.org.
==============================================================================

2: Task failed with an exception.
-----------
* What went wrong:
Failed to query the value of property 'buildFlowServiceProperty'.
> Could not isolate value org.jetbrains.kotlin.gradle.plugin.statistics.BuildFlowService$Parameters_Decorated@2035cbeb of type BuildFlowService.Parameters
   > Build completed with 1 failures.
      > org/gradle/api/internal/HasConvention


Deprecated Gradle features were used in this build, making it incompatible with Gradle 10.
* Try:

> Run with --stacktrace option to get the stack trace.
You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/9.0.0/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
> Run with --info or --debug option to get more log output.
> Run with --scan to generate a Build Scan (Powered by Develocity).
> Get more help at https://help.gradle.org.
==============================================================================

BUILD FAILED in 47s
```
</details>

## 関連 Issue

## その他
