### PR TITLE
feat(rust): `voicevox_core_macros`が内部クレートであることを明記

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@
 [@phenylshima]: https://github.com/phenylshima
 -->
 
+### Changed
+
+- \[Rust\] `voicevox_core_macros`は内部クレートであり、SemVerに従わないということが明記されます。`substitute_type!`と`pyproject_project_version!`に関してはバージョン0.16の間は保持しますが、バージョン0.17以降の保証はしません ([#1149])。
+
 ## [0.16.1] - 2025-08-14 (+09:00)
 
 ### Added
@@ -1410,6 +1414,7 @@ Windows版ダウンローダーのビルドに失敗しています。
 [#1140]: https://github.com/VOICEVOX/voicevox_core/pull/1140
 [#1143]: https://github.com/VOICEVOX/voicevox_core/pull/1143
 [#1144]: https://github.com/VOICEVOX/voicevox_core/pull/1144
+[#1149]: https://github.com/VOICEVOX/voicevox_core/pull/1149
 
 [VOICEVOX/onnxruntime-builder#25]: https://github.com/VOICEVOX/onnxruntime-builder/pull/25
 

--- a/crates/voicevox_core_macros/README.md
+++ b/crates/voicevox_core_macros/README.md
@@ -1,0 +1,5 @@
+# voicevox_core_macros
+
+`voicevox_core`用の内部クレート。
+
+SemVerに従わない。

--- a/crates/voicevox_core_macros/src/lib.rs
+++ b/crates/voicevox_core_macros/src/lib.rs
@@ -1,4 +1,7 @@
 #![warn(rust_2018_idioms)]
+//! `voicevox_core`用の内部クレート。
+//!
+//! SemVerに従わない。
 
 mod extract;
 mod inference_domain;


### PR DESCRIPTION
## 内容

crates/voicevox\_core\_macrosは内部クレート (_internal crate_)であり、SemVerに従わないということを明記する。

なお`voicevox_core_macros`のうち大半は`voicevox_core`以外では使えそうにないものであるが、`substitute_type!`と`pyproject_project_version!`だけは汎用的に利用できてしまう可能性がある。そのためこの二つのproc-macroに限り、バージョン0.16の間だけは保証することにする。

## 関連 Issue

## その他

駄目押しとして、Rust APIをcrates.ioに上げるときが来たら`voicevox_core_macros`のバージョンを`0.0.0-0.16.2`のようにすることも考えています。