### PR TITLE
test: fixup #1153: 手元実行でのイテレーション数が一部多すぎた

### DIFF
--- a/crates/voicevox_core/benches/benches.rs
+++ b/crates/voicevox_core/benches/benches.rs
@@ -111,8 +111,8 @@ impl Config {
     fn iterations_for_light_operations(&self) -> Iterations {
         if self.iterate_more {
             Iterations {
-                sample_count: 1000,
-                sample_size: 500,
+                sample_count: 500,
+                sample_size: 100,
                 warmups: 50000,
             }
         } else {


### PR DESCRIPTION
## 内容

#1153 で作ったベンチの仕組みにおいて、手元でのベンチ実行時にはイテレーション数を増やすようにしたが、一部(CPUバウンドの軽い処理)において10倍にするつもりが誤って100倍にしてしまっていた。

## 関連 Issue

## その他
