### PR TITLE
ci: cargo-codspeed v4に適応する

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -38,7 +38,7 @@ jobs:
         run: cargo check -vp test_util
 
       - name: Build
-        run: cargo codspeed build -p voicevox_core --features load-onnxruntime -m walltime benches
+        run: cargo codspeed build -p voicevox_core --bench benches --features load-onnxruntime -m walltime
 
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@v4

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -55,6 +55,11 @@ jobs:
     name: Python API
     runs-on: ubuntu-latest
     steps:
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          large-packages: false
+
       - name: Checkout
         uses: actions/checkout@v5
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -55,11 +55,6 @@ jobs:
     name: Python API
     runs-on: ubuntu-latest
     steps:
-      - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          large-packages: false
-
       - name: Checkout
         uses: actions/checkout@v5
 


### PR DESCRIPTION
## 内容

CodSpeedHQ/codspeed-rust#122 が入ったcargo-codspeed v4がリリースされてCIが落ちたので、v4の方式に適応する。

## 関連 Issue

## その他
