### PR TITLE
ci(benchmarks): ワークアラウンドとして`rust-api`を一時的に無効化

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   rust-api:
-    if: false # 現在performance reportのファイルが数十GB単位に膨れ上がってアップロードに失敗する(あとその前にランナーのディスク容量が足りなくなる)という問題(#1167)があるため。ベンチマークを分割するというワークアラウンドがあるにはあるが、job単位で5分割しなければならないことからCodSpeed側での根本的な対応を待つ。幸い、事が事だけにCodSpeed側の対応も期待していいはず。
+    if: false # FIXME: 一時的に無効化。詳細は #1167
     name: Rust API
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## 内容

~~大体変更内容内のコメントの通り。~~

ベンチマークを分割するというワークアラウンドがあるにはあるが、ベンチマーク一つ一つをjobに分割するしかないためCI時間の観点からCodSpeed側での根本的な対応を待つ。幸い、事が事だけにCodSpeed側の対応も期待していいはず。

経緯: <https://discord.com/channels/1065233827569598464/1426800221068853431/1426800221068853431>

## 関連 Issue

Resolves: #1167

## その他

できればセルフマージしたい気持ちもあります。
