### PR TITLE
refactor: 半角→全角変換処理とモーラ数カウント処理を移動

### DIFF
--- a/crates/voicevox_core/src/__internal.rs
+++ b/crates/voicevox_core/src/__internal.rs
@@ -1,13 +1,13 @@
 pub mod doctest_fixtures;
 pub mod interop;
 
-use crate::engine::talk::user_dict;
+use crate::engine::talk::{text::hankaku_zenkaku, user_dict};
 
 // VOICEVOX CORE内のラッパー向けの実装
 // FIXME: 要議論: https://github.com/VOICEVOX/voicevox_core/issues/595
 
 pub fn to_zenkaku(surface: &str) -> String {
-    user_dict::to_zenkaku(surface)
+    hankaku_zenkaku::to_zenkaku(surface)
 }
 
 pub fn validate_pronunciation(pronunciation: &str) -> crate::Result<()> {

--- a/crates/voicevox_core/src/engine/talk.rs
+++ b/crates/voicevox_core/src/engine/talk.rs
@@ -3,6 +3,7 @@ mod interpret_query;
 mod kana_parser;
 mod model;
 pub(crate) mod open_jtalk;
+pub(crate) mod text;
 pub(crate) mod text_analyzer;
 pub(crate) mod user_dict;
 

--- a/crates/voicevox_core/src/engine/talk/text.rs
+++ b/crates/voicevox_core/src/engine/talk/text.rs
@@ -1,0 +1,2 @@
+pub(crate) mod hankaku_zenkaku;
+pub(super) mod katakana;

--- a/crates/voicevox_core/src/engine/talk/text/hankaku_zenkaku.rs
+++ b/crates/voicevox_core/src/engine/talk/text/hankaku_zenkaku.rs
@@ -1,0 +1,40 @@
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+/// 一部の種類の文字を、全角文字に置き換える。
+///
+/// 具体的には
+///
+/// - "!"から"~"までの範囲の文字(数字やアルファベット)は、対応する全角文字に
+/// - " "などの目に見えない文字は、まとめて全角スペース(0x3000)に
+///
+/// 変換する。
+pub(crate) fn to_zenkaku(s: &str) -> String {
+    // 元実装：https://github.com/VOICEVOX/voicevox/blob/69898f5dd001d28d4de355a25766acb0e0833ec2/src/components/DictionaryManageDialog.vue#L379-L387
+
+    static SPACE_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\p{Z}").unwrap());
+
+    SPACE_REGEX
+        .replace_all(s, "\u{3000}")
+        .chars()
+        .map(|c| match u32::from(c) {
+            i @ 0x21..=0x7e => char::from_u32(0xfee0 + i).unwrap_or(c),
+            _ => c,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("abcdefg", "ａｂｃｄｅｆｇ")]
+    #[case("あいうえお", "あいうえお")]
+    #[case("a_b_c_d_e_f_g", "ａ＿ｂ＿ｃ＿ｄ＿ｅ＿ｆ＿ｇ")]
+    #[case("a b c d e f g", "ａ　ｂ　ｃ　ｄ　ｅ　ｆ　ｇ")]
+    fn to_zenkaku_works(#[case] before: &str, #[case] after: &str) {
+        assert_eq!(super::to_zenkaku(before), after);
+    }
+}

--- a/crates/voicevox_core/src/engine/talk/text/katakana.rs
+++ b/crates/voicevox_core/src/engine/talk/text/katakana.rs
@@ -1,0 +1,25 @@
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+pub(in super::super) fn count_moras(pron: &str) -> usize {
+    // 元実装：https://github.com/VOICEVOX/voicevox_engine/blob/39747666aa0895699e188f3fd03a0f448c9cf746/voicevox_engine/model.py#L219-L228
+
+    static MORA_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+        // TODO: Rust 2024にしたら`any()`を`false`に
+        #[cfg_attr(any(), rustfmt::skip)] // `rule_one_mora`の行が100文字を超過してしまうため
+        Regex::new(concat!(
+            "(?:",
+            "[イ][ェ]|[ヴ][ャュョ]|[トド][ゥ]|[テデ][ィャュョ]|[デ][ェ]|[クグ][ヮ]|", // rule_others
+            "[キシチニヒミリギジビピ][ェャュョ]|",                                    // rule_line_i
+            "[ツフヴ][ァ]|[ウスツフヴズ][ィ]|[ウツフヴ][ェォ]|",                      // rule_line_u
+            "[ァ-ヴー]",                                                              // rule_one_mora
+            ")",
+        ))
+        .unwrap()
+    });
+
+    MORA_REGEX.find_iter(pron).count()
+}
+
+// TODO: ENGINEのテストを持ってくる。

--- a/crates/voicevox_core/src/engine/talk/user_dict.rs
+++ b/crates/voicevox_core/src/engine/talk/user_dict.rs
@@ -2,7 +2,7 @@ pub(crate) mod dict;
 mod part_of_speech_data;
 mod word;
 
-pub(crate) use self::word::{to_zenkaku, validate_pronunciation, InvalidWordError};
+pub(crate) use self::word::{validate_pronunciation, InvalidWordError};
 pub use self::word::{
     UserDictWord, UserDictWordBuilder, UserDictWordType, DEFAULT_PRIORITY, DEFAULT_WORD_TYPE,
 };

--- a/crates/voicevox_core/src/engine/talk/user_dict/word.rs
+++ b/crates/voicevox_core/src/engine/talk/user_dict/word.rs
@@ -5,8 +5,11 @@ use serde::{de::Error as _, Deserialize, Serialize, Serializer};
 
 use crate::{error::ErrorRepr, result::Result};
 
-use super::part_of_speech_data::{
-    priority2cost, PartOfSpeechDetail, MAX_PRIORITY, MIN_PRIORITY, PART_OF_SPEECH_DETAIL,
+use super::{
+    super::text::{hankaku_zenkaku, katakana},
+    part_of_speech_data::{
+        priority2cost, PartOfSpeechDetail, MAX_PRIORITY, MIN_PRIORITY, PART_OF_SPEECH_DETAIL,
+    },
 };
 
 /// ユーザー辞書の単語。
@@ -179,18 +182,6 @@ pub const DEFAULT_PRIORITY: u32 = 5;
 
 static PRONUNCIATION_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[ァ-ヴー]+$").unwrap());
-static MORA_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(concat!(
-        "(?:",
-        "[イ][ェ]|[ヴ][ャュョ]|[トド][ゥ]|[テデ][ィャュョ]|[デ][ェ]|[クグ][ヮ]|", // rule_others
-        "[キシチニヒミリギジビピ][ェャュョ]|",                                    // rule_line_i
-        "[ツフヴ][ァ]|[ウスツフヴズ][ィ]|[ウツフヴ][ェォ]|",                      // rule_line_u
-        "[ァ-ヴー]",                                                              // rule_one_mora
-        ")",
-    ))
-    .unwrap()
-});
-static SPACE_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\p{Z}").unwrap());
 
 impl UserDictWord {
     #[cfg_attr(doc, doc(alias = "voicevox_user_dict_word_make"))]
@@ -211,7 +202,7 @@ impl UserDictWord {
         validate_pronunciation(&pronunciation)?;
         let mora_count = calculate_mora_count(&pronunciation, accent_type)?;
         Ok(Self {
-            surface: to_zenkaku(surface),
+            surface: hankaku_zenkaku::to_zenkaku(surface),
             pronunciation,
             accent_type,
             word_type,
@@ -290,7 +281,7 @@ pub(crate) fn validate_pronunciation(pronunciation: &str) -> InvalidWordResult<(
 /// カタカナの発音からモーラ数を計算する。
 fn calculate_mora_count(pronunciation: &str, accent_type: usize) -> InvalidWordResult<usize> {
     // 元実装：https://github.com/VOICEVOX/voicevox_engine/blob/39747666aa0895699e188f3fd03a0f448c9cf746/voicevox_engine/model.py#L212-L236
-    let mora_count = MORA_REGEX.find_iter(pronunciation).count();
+    let mora_count = katakana::count_moras(pronunciation);
 
     if accent_type > mora_count {
         return Err(InvalidWordError::InvalidAccentType(
@@ -300,26 +291,6 @@ fn calculate_mora_count(pronunciation: &str, accent_type: usize) -> InvalidWordR
     }
 
     Ok(mora_count)
-}
-
-/// 一部の種類の文字を、全角文字に置き換える。
-///
-/// 具体的には
-///
-/// - "!"から"~"までの範囲の文字(数字やアルファベット)は、対応する全角文字に
-/// - " "などの目に見えない文字は、まとめて全角スペース(0x3000)に
-///
-/// 変換する。
-pub(crate) fn to_zenkaku(surface: &str) -> String {
-    // 元実装：https://github.com/VOICEVOX/voicevox/blob/69898f5dd001d28d4de355a25766acb0e0833ec2/src/components/DictionaryManageDialog.vue#L379-L387
-    SPACE_REGEX
-        .replace_all(surface, "\u{3000}")
-        .chars()
-        .map(|c| match u32::from(c) {
-            i @ 0x21..=0x7e => char::from_u32(0xfee0 + i).unwrap_or(c),
-            _ => c,
-        })
-        .collect()
 }
 
 impl UserDictWordBuilder {
@@ -433,15 +404,6 @@ mod tests {
     use serde_json::json;
 
     use super::{InvalidWordError, UserDictWord, UserDictWordType};
-
-    #[rstest]
-    #[case("abcdefg", "ａｂｃｄｅｆｇ")]
-    #[case("あいうえお", "あいうえお")]
-    #[case("a_b_c_d_e_f_g", "ａ＿ｂ＿ｃ＿ｄ＿ｅ＿ｆ＿ｇ")]
-    #[case("a b c d e f g", "ａ　ｂ　ｃ　ｄ　ｅ　ｆ　ｇ")]
-    fn to_zenkaku_works(#[case] before: &str, #[case] after: &str) {
-        assert_eq!(super::to_zenkaku(before), after);
-    }
 
     #[rstest]
     fn to_mecab_format_works() {


### PR DESCRIPTION
## 内容

VOICEVOX/voicevox_engine#1679 および VOICEVOX/voicevox_engine#1695 と同じようにコードの移動を行う。モーラ数のカウントについては ~~1166~~ #1161 に必要でもある。

移動先のモジュールはENGINEでは`voicevox_engine.utility.text_utility`だったが、COREには"utility"のような名前の置き場は無いため別の名前を考えた。

上記の通り`text_utility`という名前を直接使ってもおらず、ENGINEの著作権が及ぶかはかなり微妙ではあるが一応、以下の1名の許諾のもと #874 にのっとりMITライセンスとしてライセンスする。

- @tarepan

(VOICEVOX/voicevox_engine#1695 については、code suggestionの分は本PRとは無関係)

## 関連 Issue

## その他
