### PR TITLE
refactor: `setup-python`の`architecture`の指定方法を改善

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -165,7 +165,7 @@ jobs:
       ASSET_NAME: voicevox_core-${{ matrix.artifact_name }}-${{ needs.config.outputs.version }}
     steps:
       - uses: actions/checkout@v5
-      # PyO3とMaturinはクロスコンパイルをサポートしているが、RustのターゲットとPythonインタプリタとでポインタ幅だけは同じである必要がある。
+      # NOTE: PyO3の制約で、RustのターゲットとPythonのビット数を一致させる必要がある。
       # https://github.com/PyO3/pyo3/blob/v0.27.1/pyo3-ffi/build.rs#L138-L143
       - name: Determine Python interpreter architecture
         if: matrix.python_whl


### PR DESCRIPTION
## 内容

従来の`contains(matrix.artifact_name,'x86') && 'x86' || 'x64'`という形のままだと、 #1174 のようにホストOSがARM化したときに困るため。

## 関連 Issue

## その他
