### PR TITLE
ci: #873 は完全解決されたものとし、再発しないかの確認をやめる

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -329,18 +329,6 @@ jobs:
           for file in ../../example/python/run{,-asyncio}.py; do
             poetry run python "$file" ../test_util/data/model/sample.vvm --dict-dir ../test_util/data/open_jtalk_dic_utf_8-1.11 --onnxruntime ../test_util/data/lib/*onnxruntime*
           done
-          # https://github.com/VOICEVOX/voicevox_core/issues/873 が再発しないかの確認。
-          #
-          # Python 3.8においては、プロセスの終了までにFatal Python errorに至らなくても`StopIteration`までは達することが多い。
-          # #873の要因は依然として不明であるが、`StopIteration`が出ないことの確認をもって#873の解決とすることにする。
-          #
-          # TODO: 10回の実行におよそ60秒ほどかかるため、状況の経過を見てやめる。
-          for _ in {1..10}; do
-            poetry run python ../../example/python/run-asyncio.py ../test_util/data/model/sample.vvm --dict-dir ../test_util/data/open_jtalk_dic_utf_8-1.11 --onnxruntime ../test_util/data/lib/*onnxruntime* \
-              2> >(tee ./stderr.txt >&2)
-            # shellcheck disable=SC2059
-            ! grep -q StopIteration ./stderr.txt
-          done
   build-and-test-java-api:
     strategy:
       fail-fast: false


### PR DESCRIPTION
## 内容

#915 では #873 が再発しないかのチェック機構を入れていたが、私が記憶している限り一度も引っ掛かることはなかった。そのため#915をもって完全解決されたものとしてチェック機構を取り除く。

(あとUbuntuのShellCheck v0.8.0は何も言わないけどShellCheck v0.11.0が文句を言ってきていたので、手元で鬱陶しかったというのもある)

## 関連 Issue

## その他
