### PR TITLE
ci(benchmarks): revert #1170

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -21,7 +21,6 @@ on:
 
 jobs:
   rust-api:
-    if: false # FIXME: 一時的に無効化。詳細は #1167
     name: Rust API
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## 内容

This reverts commit 6241aa831e10e60ea80d5996d3f5105d9cc0fa79.

2日前にリリースされた[actionlint v1.7.9](https://github.com/rhysd/actionlint/releases/tag/v1.7.9)が`if: false`を咎め始めてCIが落ちたため、とりあえず今のCodSpeedなら ~~大丈夫なのかどうかを確かめる。~~ 大丈夫らしいので #1170 をリバートする。なお咎め始めた理由としてはactionlint曰く

> `if: false` should be replaced with commenting out because it is more obvious (or simply remove the step or job if not needed).

らしい。

## 関連 Issue

## その他
