### PR TITLE
refactor: `SamplingRate`を移動

### DIFF
--- a/crates/voicevox_core/src/engine.rs
+++ b/crates/voicevox_core/src/engine.rs
@@ -2,12 +2,12 @@
 
 mod acoustic_feature_extractor;
 mod audio_file;
-mod fundamental;
 mod mora_list;
+mod sampling_rate;
 pub(crate) mod talk;
 
 pub use self::audio_file::wav_from_s16le;
 pub(crate) use self::{
     acoustic_feature_extractor::PhonemeCode, audio_file::to_s16le_pcm,
-    fundamental::DEFAULT_SAMPLING_RATE,
+    sampling_rate::DEFAULT_SAMPLING_RATE,
 };

--- a/crates/voicevox_core/src/engine/fundamental.rs
+++ b/crates/voicevox_core/src/engine/fundamental.rs
@@ -1,1 +1,0 @@
-pub(crate) const DEFAULT_SAMPLING_RATE: u32 = 24000;

--- a/crates/voicevox_core/src/engine/sampling_rate.rs
+++ b/crates/voicevox_core/src/engine/sampling_rate.rs
@@ -1,0 +1,18 @@
+use std::num::NonZero;
+
+pub(crate) const DEFAULT_SAMPLING_RATE: u32 = 24000;
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub(crate) struct SamplingRate(NonZero<u32>);
+
+impl SamplingRate {
+    pub(super) fn new(n: u32) -> Option<Self> {
+        NonZero::new(n)
+            .filter(|n| n.get() % DEFAULT_SAMPLING_RATE == 0)
+            .map(Self)
+    }
+
+    pub(crate) fn get(self) -> u32 {
+        self.0.get()
+    }
+}

--- a/crates/voicevox_core/src/engine/talk/audio_query/validated.rs
+++ b/crates/voicevox_core/src/engine/talk/audio_query/validated.rs
@@ -10,11 +10,11 @@ use tracing::warn;
 use crate::error::{ErrorRepr, InvalidQueryErrorKind};
 
 use super::{
-    super::super::{acoustic_feature_extractor::Phoneme, DEFAULT_SAMPLING_RATE},
+    super::super::{
+        acoustic_feature_extractor::Phoneme, sampling_rate::SamplingRate, DEFAULT_SAMPLING_RATE,
+    },
     AccentPhrase, AudioQuery, Mora,
 };
-
-pub(crate) use self::sampling_rate::SamplingRate;
 
 impl Mora {
     /// この構造体をバリデートする。
@@ -489,27 +489,6 @@ impl From<ValidatedAudioQuery<'_>> for AudioQuery {
             output_sampling_rate: output_sampling_rate.get(),
             output_stereo,
             kana,
-        }
-    }
-}
-
-mod sampling_rate {
-    use std::num::NonZero;
-
-    use crate::engine::DEFAULT_SAMPLING_RATE;
-
-    #[derive(Clone, Copy, PartialEq, Debug)]
-    pub(crate) struct SamplingRate(NonZero<u32>);
-
-    impl SamplingRate {
-        pub(super) fn new(n: u32) -> Option<Self> {
-            NonZero::new(n)
-                .filter(|n| n.get() % DEFAULT_SAMPLING_RATE == 0)
-                .map(Self)
-        }
-
-        pub(crate) fn get(self) -> u32 {
-            self.0.get()
         }
     }
 }


### PR DESCRIPTION
## 内容

ソング (#1073)にも必要であることに気付いたため。

#1211 と同じ場所に、モジュール名を改名する形で置く。

## 関連 Issue

## その他
