### PR TITLE
refactor: コア領域関係のndarray操作ユーティリティを移動

### DIFF
--- a/crates/voicevox_core/src/core.rs
+++ b/crates/voicevox_core/src/core.rs
@@ -8,4 +8,7 @@ pub(crate) mod metas;
 pub(crate) mod status;
 pub(crate) mod voice_model;
 
-pub(crate) use self::adjust::{ensure_minimum_phoneme_length, pad_decoder_feature, ArrayExt};
+pub(crate) use self::adjust::{
+    ensure_minimum_phoneme_length, pad_decoder_feature, Array1ExtForPostProcess,
+    Array1ExtForPreProcess, ArrayExt,
+};

--- a/crates/voicevox_core/src/core/adjust.rs
+++ b/crates/voicevox_core/src/core/adjust.rs
@@ -4,6 +4,6 @@ mod post;
 mod pre;
 
 pub(crate) use self::{
-    post::{ensure_minimum_phoneme_length, ArrayExt},
-    pre::pad_decoder_feature,
+    post::{ensure_minimum_phoneme_length, Array1ExtForPostProcess, ArrayExt},
+    pre::{pad_decoder_feature, Array1ExtForPreProcess},
 };

--- a/crates/voicevox_core/src/core/adjust/post.rs
+++ b/crates/voicevox_core/src/core/adjust/post.rs
@@ -17,6 +17,20 @@ pub(crate) fn ensure_minimum_phoneme_length(mut output: Vec<f32>) -> Vec<f32> {
     output
 }
 
+#[ext(Array1ExtForPostProcess)]
+impl<T> Array1<T> {
+    pub(crate) fn into_vec(self) -> Vec<T> {
+        let (vec, offset) = self.into_raw_vec_and_offset();
+        // TODO: Rust 2024にしたらlet chainにする
+        if let Some(offset) = offset {
+            if offset != 0 {
+                unimplemented!("offset = {offset}");
+            }
+        }
+        vec
+    }
+}
+
 #[ext(ArrayExt)]
 impl<T, const N: usize> Array<T, Dim<[Ix; N]>>
 where

--- a/crates/voicevox_core/src/core/adjust/pre.rs
+++ b/crates/voicevox_core/src/core/adjust/pre.rs
@@ -1,5 +1,8 @@
 //! 推論の入力の前処理。
 
+use easy_ext::ext;
+use ndarray::{Array1, Array2};
+
 /// 音が途切れてしまうのを避けるworkaround処理。
 // TODO: 改善したらここのpadding処理を取り除く
 pub(crate) fn pad_decoder_feature<const PADDING_FRAME_LENGTH: usize>(
@@ -33,5 +36,13 @@ pub(crate) fn pad_decoder_feature<const PADDING_FRAME_LENGTH: usize>(
             .slice_mut(ndarray::s![.., 0])
             .assign(&ndarray::arr0(1.0));
         ndarray::concatenate![ndarray::Axis(0), padding, phoneme_slice, padding]
+    }
+}
+
+#[ext(Array1ExtForPreProcess)]
+impl<T> Array1<T> {
+    pub(crate) fn into_one_row(self) -> Array2<T> {
+        let n = self.len();
+        self.into_shape_with_order([1, n]).expect("should be ok")
     }
 }

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -36,7 +36,7 @@ use crate::{
         },
         pad_decoder_feature,
         status::Status,
-        voice_model, ArrayExt as _,
+        voice_model, Array1ExtForPostProcess as _, Array1ExtForPreProcess as _, ArrayExt as _,
     },
     engine::{
         talk::{
@@ -1204,25 +1204,6 @@ impl<R: InferenceRuntime> Status<R> {
             .await?;
 
         wav.squeeze_into_1d()
-    }
-}
-
-#[ext]
-impl<T> ndarray::Array1<T> {
-    fn into_one_row(self) -> ndarray::Array2<T> {
-        let n = self.len();
-        self.into_shape_with_order([1, n]).expect("should be ok")
-    }
-
-    fn into_vec(self) -> Vec<T> {
-        let (vec, offset) = self.into_raw_vec_and_offset();
-        // TODO: Rust 2024にしたらlet chainにする
-        if let Some(offset) = offset {
-            if offset != 0 {
-                unimplemented!("offset = {offset}");
-            }
-        }
-        vec
     }
 }
 


### PR DESCRIPTION
## 内容

#1217 に追従する形でコード移動を行う。

## 関連 Issue

## その他
