### PR TITLE
feat(c): fixup #1208: C APIの`validate`関数でRust APIに言及

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@
 
 ### Changed
 
-- `AudioQuery`/`AccentPhrase`/`Mora`において不正な状態というものが定義され、不正な`AudioQuery`もしくは`accent_phrases`が明示的にエラーを引き起こすようになります ([#1203], [#1208], [#1222], [#1221])。
+- `AudioQuery`/`AccentPhrase`/`Mora`において不正な状態というものが定義され、不正な`AudioQuery`もしくは`accent_phrases`が明示的にエラーを引き起こすようになります ([#1203], [#1208], [#1222], [#1221], [#1224])。
     - \[Rust,Python,Java\] エラーの種類として`InvalidQuery`が追加されます。
     - \[C\] エラーの種類として`VOICEVOX_RESULT_INVALID_MORA_ERROR`が追加されます。
     - メソッドとして`{AudioQuery,AccentPhrase,Mora}::validate`が追加されます。
@@ -1387,6 +1387,7 @@ Windows版ダウンローダーのビルドに失敗しています。
 [#1221]: https://github.com/VOICEVOX/voicevox_core/pull/1221
 [#1222]: https://github.com/VOICEVOX/voicevox_core/pull/1222
 [#1223]: https://github.com/VOICEVOX/voicevox_core/pull/1223
+[#1224]: https://github.com/VOICEVOX/voicevox_core/pull/1224
 
 [VOICEVOX/onnxruntime-builder#25]: https://github.com/VOICEVOX/onnxruntime-builder/pull/25
 

--- a/crates/voicevox_core_c_api/include/voicevox_core.h
+++ b/crates/voicevox_core_c_api/include/voicevox_core.h
@@ -707,15 +707,15 @@ VoicevoxResultCode voicevox_audio_query_create_from_accent_phrases(const char *a
                                                                    char **output_audio_query_json);
 
 /**
- * JSONを[`AudioQuery`型]としてバリデートする。
- *
- * [`AudioQuery`型]: ../rust_api/voicevox_core/struct.AudioQuery.html
+ * JSONを`AudioQuery`型としてバリデートする。
  *
  * 次のうちどれかを満たすならエラーを返す。
  *
+ * - [Rust APIの`AudioQuery`型]としてデシリアライズ不可、もしくはJSONとして不正。
  * - `accent_phrases`の要素のうちいずれかが、 ::voicevox_accent_phrase_validate でエラーになる。
  * - `outputSamplingRate`が`24000`の倍数ではない、もしくは`0` (将来的に解消予定。cf. [#762])。
  *
+ * [Rust APIの`AudioQuery`型]: ../rust_api/voicevox_core/struct.AudioQuery.html
  * [#762]: https://github.com/VOICEVOX/voicevox_core/issues/762
  *
  * 次の状態に対しては警告のログを出す。将来的にはエラーになる予定。
@@ -743,14 +743,15 @@ __declspec(dllimport)
 VoicevoxResultCode voicevox_audio_query_validate(const char *audio_query_json);
 
 /**
- * JSONを[`AccentPhrase`型]としてバリデートする。
- *
- * [`AccentPhrase`型]: ../rust_api/voicevox_core/struct.AccentPhrase.html
+ * JSONを`AccentPhrase`型としてバリデートする。
  *
  * 次のうちどれかを満たすならエラーを返す。
  *
+ * - [Rust APIの`AccentPhrase`型]としてデシリアライズ不可、もしくはJSONとして不正。
  * - `moras`もしくは`pause_mora`の要素のうちいずれかが、 ::voicevox_mora_validate でエラーになる。
  * - `accent`が`0`。
+ *
+ * [Rust APIの`AccentPhrase`型]: ../rust_api/voicevox_core/struct.AccentPhrase.html
  *
  * 次の状態に対しては警告のログを出す。将来的にはエラーになる予定。
  *
@@ -773,15 +774,16 @@ __declspec(dllimport)
 VoicevoxResultCode voicevox_accent_phrase_validate(const char *accent_phrase_json);
 
 /**
- * JSONを[`Mora`型]としてバリデートする。
- *
- * [`Mora`型]: ../rust_api/voicevox_core/struct.Mora.html
+ * JSONを`Mora`型としてバリデートする。
  *
  * 次のうちどれかを満たすならエラーを返す。
  *
+ * - [Rust APIの`Mora`型]としてデシリアライズ不可、もしくはJSONとして不正。
  * - `consonant`と`consonant_length`の有無が不一致。
  * - `consonant`が子音以外の音素であるか、もしくは音素として不正。
  * - `vowel`が子音であるか、もしくは音素として不正。
+ *
+ * [Rust APIの`Mora`型]: ../rust_api/voicevox_core/struct.Mora.html
  *
  * 次の状態に対しては警告のログを出す。将来的にはエラーになる予定。
  *

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -511,15 +511,15 @@ pub unsafe extern "C" fn voicevox_audio_query_create_from_accent_phrases(
 }
 
 // SAFETY: voicevox_core_c_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
-/// JSONを[`AudioQuery`型]としてバリデートする。
-///
-/// [`AudioQuery`型]: ../rust_api/voicevox_core/struct.AudioQuery.html
+/// JSONを`AudioQuery`型としてバリデートする。
 ///
 /// 次のうちどれかを満たすならエラーを返す。
 ///
+/// - [Rust APIの`AudioQuery`型]としてデシリアライズ不可、もしくはJSONとして不正。
 /// - `accent_phrases`の要素のうちいずれかが、 ::voicevox_accent_phrase_validate でエラーになる。
 /// - `outputSamplingRate`が`24000`の倍数ではない、もしくは`0` (将来的に解消予定。cf. [#762])。
 ///
+/// [Rust APIの`AudioQuery`型]: ../rust_api/voicevox_core/struct.AudioQuery.html
 /// [#762]: https://github.com/VOICEVOX/voicevox_core/issues/762
 ///
 /// 次の状態に対しては警告のログを出す。将来的にはエラーになる予定。
@@ -551,14 +551,15 @@ pub unsafe extern "C" fn voicevox_audio_query_validate(
 }
 
 // SAFETY: voicevox_core_c_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
-/// JSONを[`AccentPhrase`型]としてバリデートする。
-///
-/// [`AccentPhrase`型]: ../rust_api/voicevox_core/struct.AccentPhrase.html
+/// JSONを`AccentPhrase`型としてバリデートする。
 ///
 /// 次のうちどれかを満たすならエラーを返す。
 ///
+/// - [Rust APIの`AccentPhrase`型]としてデシリアライズ不可、もしくはJSONとして不正。
 /// - `moras`もしくは`pause_mora`の要素のうちいずれかが、 ::voicevox_mora_validate でエラーになる。
 /// - `accent`が`0`。
+///
+/// [Rust APIの`AccentPhrase`型]: ../rust_api/voicevox_core/struct.AccentPhrase.html
 ///
 /// 次の状態に対しては警告のログを出す。将来的にはエラーになる予定。
 ///
@@ -585,15 +586,16 @@ pub unsafe extern "C" fn voicevox_accent_phrase_validate(
 }
 
 // SAFETY: voicevox_core_c_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
-/// JSONを[`Mora`型]としてバリデートする。
-///
-/// [`Mora`型]: ../rust_api/voicevox_core/struct.Mora.html
+/// JSONを`Mora`型としてバリデートする。
 ///
 /// 次のうちどれかを満たすならエラーを返す。
 ///
+/// - [Rust APIの`Mora`型]としてデシリアライズ不可、もしくはJSONとして不正。
 /// - `consonant`と`consonant_length`の有無が不一致。
 /// - `consonant`が子音以外の音素であるか、もしくは音素として不正。
 /// - `vowel`が子音であるか、もしくは音素として不正。
+///
+/// [Rust APIの`Mora`型]: ../rust_api/voicevox_core/struct.Mora.html
 ///
 /// 次の状態に対しては警告のログを出す。将来的にはエラーになる予定。
 ///


### PR DESCRIPTION
## 内容

C APIの不正な状態の定義として、「Rust APIの`…`型としてデシリアライズ不可、もしくはJSONとして不正」というのを加える。

#1223 をやった目的の一つ。

## 関連 Issue

## その他
