### PR TITLE
ci: mainブランチではすべてのCIを実行する

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -20,8 +20,8 @@ on:
 env:
   # releaseタグ名か、workflow_dispatchでのバージョン名か、'0.0.0'が入る
   VERSION: ${{ github.event.release.tag_name || inputs.version || '0.0.0' }}
-  # 簡易テストとするかどうか。releaseとworkflow_dispatch以外は簡易テストとする
-  IS_SIMPLE_TEST: ${{ github.event_name != 'release' && github.event_name != 'workflow_dispatch' }}
+  # 簡易テストとするかどうか。mainブランチ、release、workflow_dispatch以外は簡易テストとする
+  IS_SIMPLE_TEST: ${{ github.ref != 'refs/heads/main' && github.event_name != 'release' && github.event_name != 'workflow_dispatch' }}
 
 defaults:
   run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  # 簡易テストとするかどうか。workflow_dispatch以外は簡易テストとする
-  IS_SIMPLE_TEST: ${{ github.event_name != 'workflow_dispatch' }}
+  # 簡易テストとするかどうか。mainブランチとworkflow_dispatch以外は簡易テストとする
+  IS_SIMPLE_TEST: ${{ github.ref != 'refs/heads/main' && github.event_name != 'workflow_dispatch' }}
 
 defaults:
   run:


### PR DESCRIPTION
## 内容

0.16.2のリリースのときに[Discordでも言った](https://discord.com/channels/879570910208733277/893889888208977960/1432006190006800436)が、現状の`can_skip_in_simple_test`の考えかただと、一番壊れやすい部分がCIされずにリリース直前になって壊れていることが発覚するということが起こる。というか頻発している。

そのためmainブランチ上でのCIは"simple\_test"としないこととする。CI時間については、 #382 のようにワークフローを分割したりキャッシュを（もちらん適切に）効かせるといった方向で対処するべき。

## 関連 Issue

## その他
