### PR TITLE
ci: `build_xcframework`と`build_java_package`もmainで動かす

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -295,7 +295,7 @@ jobs:
           path: java_artifact
 
   build_xcframework:
-    if: ${{ !(github.event_name != 'release' && github.event_name != 'workflow_dispatch') }} # !env.IS_SIMPLE_TEST と同じ
+    if: ${{ !(github.ref != 'refs/heads/main' && github.event_name != 'release' && github.event_name != 'workflow_dispatch') }} # !env.IS_SIMPLE_TEST と同じ
     needs: [config, build_and_deploy]
     runs-on: macos-14
     env:
@@ -340,7 +340,7 @@ jobs:
 
   build_java_package:
     runs-on: ubuntu-latest
-    if: ${{ !(github.event_name != 'release' && github.event_name != 'workflow_dispatch') }} # !env.IS_SIMPLE_TEST と同じ
+    if: ${{ !(github.ref != 'refs/heads/main' && github.event_name != 'release' && github.event_name != 'workflow_dispatch') }} # !env.IS_SIMPLE_TEST と同じ
     needs: [config, build_and_deploy]
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## 内容

#1229 では`build_xcframework`と`build_java_package`が対象外になってしまったので、この二つも動くようにする。
(<https://github.com/VOICEVOX/voicevox_core/pull/1229#discussion_r2599583315>)

このPRでは問題箇所の修正のみに留める。

## 関連 Issue

## その他
