### PR TITLE
ci: `build_java_package`でJava API artifactをアップロードするよう修正

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -288,7 +288,7 @@ jobs:
             ${{ steps.build-voicevox-core-python-api.outputs.whl }}
           target_commitish: ${{ github.sha }}
       - name: Upload voicevox_core_java_api artifact
-        if: fromJson(needs.config.outputs.deploy) && matrix.java
+        if: matrix.java
         uses: actions/upload-artifact@v4
         with:
           name: voicevox_core_java_api-${{ matrix.artifact_name }}


### PR DESCRIPTION
## 内容

#1230 で`build_java_package`ジョブをmainブランチでも実行するようにしたが、Java API artifactのアップロード条件に`deploy`チェックが残っていたため、mainブランチへのpushでartifactがアップロードされず、ジョブが失敗していた。

`build_xcframework`のartifactアップロードと同様に、`deploy`条件を削除。

## 関連 Issue

ref https://github.com/VOICEVOX/voicevox_core/actions/runs/20080403427

## スクリーンショット・動画など

なし

## その他

なし