### PR TITLE
feat(python,java): 例外発生に対するドキュメンテーションを改める

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,10 @@
 [@phenylshima]: https://github.com/phenylshima
 -->
 
+### Added
+
+- \[Python,Java\] 一部のドキュメントの文体が改善されます ([#1238])。
+
 ### Changed
 
 - \[Python,Java\] `AudioQuery`（もしくはその一部）がRustのオブジェクトとして表現できなかったときのエラーが、`InvalidQuery`エラーに包まれるようになります。これまでは`OverflowError`や`RuntimeError`がそのままraiseされていました ([#1237])。
@@ -1409,6 +1413,7 @@ Windows版ダウンローダーのビルドに失敗しています。
 [#1224]: https://github.com/VOICEVOX/voicevox_core/pull/1224
 [#1227]: https://github.com/VOICEVOX/voicevox_core/pull/1227
 [#1237]: https://github.com/VOICEVOX/voicevox_core/pull/1237
+[#1238]: https://github.com/VOICEVOX/voicevox_core/pull/1238
 
 [VOICEVOX/onnxruntime-builder#25]: https://github.com/VOICEVOX/onnxruntime-builder/pull/25
 

--- a/crates/voicevox_core/src/core/voice_model.rs
+++ b/crates/voicevox_core/src/core/voice_model.rs
@@ -565,7 +565,7 @@ impl ModelBytes {
 }
 
 impl InferenceDomainMap<ManifestDomains> {
-    /// manifestとして対応していない`StyleType`に対してエラーを発する。
+    /// manifestとして対応していない`StyleType`に対してエラーを返す。
     ///
     /// `Status`はこのバリデーションを信頼し、`InferenceDomain`の不足時にパニックする。
     fn check_acceptable(&self, metas: &[CharacterMeta]) -> std::result::Result<(), StyleType> {

--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/AccentPhrase.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/AccentPhrase.java
@@ -11,7 +11,7 @@ import jp.hiroshiba.voicevoxcore.exceptions.InvalidQueryException;
 /**
  * AccentPhrase (アクセント句ごとの情報)。
  *
- * <p>この構造体の状態によっては、{@code Synthesizer}の各メソッドは{@link InvalidQueryException}を発する。詳細は{@link
+ * <p>この構造体の状態によっては、{@code Synthesizer}の各メソッドは{@link InvalidQueryException}をスローする。詳細は{@link
  * #validate}にて。
  *
  * <p>Gsonにおいてはフィールド名はsnake_caseとなる。<a
@@ -54,25 +54,24 @@ public class AccentPhrase {
   /**
    * このインスタンスをバリデートする。
    *
-   * <p>次のうちどれかを満たすなら{@link InvalidQueryException}を発する。
-   *
-   * <ul>
-   *   <li><a
-   *       href="https://voicevox.github.io/voicevox_core/apis/rust_api/voicevox_core/struct.AccentPhrase.html">Rust
-   *       APIの{@code AccentPhrase}型</a>としてデシリアライズ不可。
-   *       <ul>
-   *         <li>{@link #accent}が負であるか、もしくは32ビットプラットフォームの場合2<sup>32</sup>-1を超過する。
-   *       </ul>
-   *   <li>{@link #moras}もしくは{@link #pauseMora}の要素のいずれかが不正。
-   *   <li>{@link #accent}が{@code 0}。
-   * </ul>
-   *
-   * <p>また次の状態に対してはログで警告を出す。将来的にはエラーになる予定。
+   * <p>次の状態に対してはログで警告を出す。将来的にはエラーになる予定。
    *
    * <ul>
    *   <li>{@link #moras}もしくは{@link #pauseMora}の要素のいずれかが、警告が出る状態。
    *   <li>{@link #accent}が{@link #moras}の数を超過している。
    * </ul>
+   *
+   * @throws InvalidQueryException 次のうちどれかを満たす場合
+   *     <ul>
+   *       <li><a
+   *           href="https://voicevox.github.io/voicevox_core/apis/rust_api/voicevox_core/struct.AccentPhrase.html">Rust
+   *           APIの{@code AccentPhrase}型</a>としてデシリアライズ不可。
+   *           <ul>
+   *             <li>{@link #accent}が負であるか、もしくは32ビットプラットフォームの場合2<sup>32</sup>-1を超過する。
+   *           </ul>
+   *       <li>{@link #moras}もしくは{@link #pauseMora}の要素のいずれかが不正。
+   *       <li>{@link #accent}が{@code 0}。
+   *     </ul>
    */
   public void validate() {
     rsValidate();

--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/AudioQuery.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/AudioQuery.java
@@ -14,7 +14,7 @@ import jp.hiroshiba.voicevoxcore.internal.Dll;
 /**
  * AudioQuery（音声合成用のクエリ）。
  *
- * <p>この構造体の状態によっては、{@code Synthesizer}の各メソッドは{@link InvalidQueryException}を発する。詳細は{@link
+ * <p>この構造体の状態によっては、{@code Synthesizer}の各メソッドは{@link InvalidQueryException}をスローする。詳細は{@link
  * #validate}にて。
  *
  * <p>GsonにおいてはVOICEVOX ENGINEに合わせる形で、フィールド名は{@link
@@ -83,30 +83,7 @@ public class AudioQuery {
   /**
    * このインスタンスをバリデートする。
    *
-   * <p>次のうちどれかを満たすなら{@link InvalidQueryException}を発する。
-   *
-   * <ul>
-   *   <li>JSONへのシリアライズが不可。
-   *       <ul>
-   *         <li>{@link #speedScale}がNaNもしくは±infinity。
-   *         <li>{@link #pitchScale}がNaNもしくは±infinity。
-   *         <li>{@link #intonationScale}がNaNもしくは±infinity。
-   *         <li>{@link #volumeScale}がNaNもしくは±infinity。
-   *         <li>{@link #prePhonemeLength}がNaNもしくは±infinity。
-   *         <li>{@link #postPhonemeLength}がNaNもしくは±infinity。
-   *       </ul>
-   *   <li><a
-   *       href="https://voicevox.github.io/voicevox_core/apis/rust_api/voicevox_core/struct.AudioQuery.html">Rust
-   *       APIの{@code AudioQuery}型</a>としてデシリアライズ不可。
-   *       <ul>
-   *         <li>{@link #outputSamplingRate}が負であるか、もしくは2<sup>32</sup>-1を超過する。
-   *       </ul>
-   *   <li>{@link #accentPhrases}の要素のうちいずれかが不正。
-   *   <li>{@link #outputSamplingRate}が{@code 24000}の倍数ではない、もしくは{@code 0} (将来的に解消予定。cf. <a
-   *       href="https://github.com/VOICEVOX/voicevox_core/issues/762">#762</a>)
-   * </ul>
-   *
-   * <p>また次の状態に対してはログで警告を出す。将来的にはエラーになる予定。
+   * <p>次の状態に対してはログで警告を出す。将来的にはエラーになる予定。
    *
    * <ul>
    *   <li>{@link #accentPhrases}の要素のうちいずれかが警告が出る状態。
@@ -116,6 +93,28 @@ public class AudioQuery {
    *   <li>{@link #postPhonemeLength}が負。
    *   <li>{@link #outputSamplingRate}が{@code 24000}以外の値（エラーと同様将来的に解消予定）。
    * </ul>
+   *
+   * @throws InvalidQueryException 次のうちどれかを満たす場合
+   *     <ul>
+   *       <li>JSONへのシリアライズが不可。
+   *           <ul>
+   *             <li>{@link #speedScale}がNaNもしくは±infinity。
+   *             <li>{@link #pitchScale}がNaNもしくは±infinity。
+   *             <li>{@link #intonationScale}がNaNもしくは±infinity。
+   *             <li>{@link #volumeScale}がNaNもしくは±infinity。
+   *             <li>{@link #prePhonemeLength}がNaNもしくは±infinity。
+   *             <li>{@link #postPhonemeLength}がNaNもしくは±infinity。
+   *           </ul>
+   *       <li><a
+   *           href="https://voicevox.github.io/voicevox_core/apis/rust_api/voicevox_core/struct.AudioQuery.html">Rust
+   *           APIの{@code AudioQuery}型</a>としてデシリアライズ不可。
+   *           <ul>
+   *             <li>{@link #outputSamplingRate}が負であるか、もしくは2<sup>32</sup>-1を超過する。
+   *           </ul>
+   *       <li>{@link #accentPhrases}の要素のうちいずれかが不正。
+   *       <li>{@link #outputSamplingRate}が{@code 24000}の倍数ではない、もしくは{@code 0} (将来的に解消予定。cf. <a
+   *           href="https://github.com/VOICEVOX/voicevox_core/issues/762">#762</a>)
+   *     </ul>
    */
   public void validate() {
     rsValidate();

--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/Mora.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/Mora.java
@@ -9,7 +9,7 @@ import jp.hiroshiba.voicevoxcore.exceptions.InvalidQueryException;
 /**
  * モーラ（子音＋母音）ごとの情報。
  *
- * <p>この構造体の状態によっては、{@code Synthesizer}の各メソッドは{@link InvalidQueryException}を発する。詳細は{@link
+ * <p>この構造体の状態によっては、{@code Synthesizer}の各メソッドは{@link InvalidQueryException}をスローする。詳細は{@link
  * #validate}にて。
  *
  * <p>Gsonにおいてはフィールド名はsnake_caseとなる。<a
@@ -67,26 +67,25 @@ public class Mora implements Cloneable {
   /**
    * このインスタンスをバリデートする。
    *
-   * <p>次のうちどれかを満たすなら{@link InvalidQueryException}を発する。
-   *
-   * <ul>
-   *   <li>JSONへのシリアライズが不可。
-   *       <ul>
-   *         <li>{@link #consonantLength}がNaN、infinity、もしくは負。
-   *         <li>{@link #vowelLength}がNaN、infinity、もしくは負。
-   *         <li>{@link #pitch}がNaNもしくは±infinity。
-   *       </ul>
-   *   <li>{@link #consonant}と{@link #consonantLength}の有無が不一致。
-   *   <li>{@link #consonant}が子音以外の音素であるか、もしくは音素として不正。
-   *   <li>{@link #vowel}が子音であるか、もしくは音素として不正。
-   * </ul>
-   *
-   * <p>また次の状態に対してはログで警告を出す。将来的にはエラーになる予定。
+   * <p>次の状態に対してはログで警告を出す。将来的にはエラーになる予定。
    *
    * <ul>
    *   <li>{@link #consonantLength}が負。
    *   <li>{@link #vowelLength}が負。
    * </ul>
+   *
+   * @throws InvalidQueryException 次のうちどれかを満たす場合
+   *     <ul>
+   *       <li>JSONへのシリアライズが不可。
+   *           <ul>
+   *             <li>{@link #consonantLength}がNaN、infinity、もしくは負。
+   *             <li>{@link #vowelLength}がNaN、infinity、もしくは負。
+   *             <li>{@link #pitch}がNaNもしくは±infinity。
+   *           </ul>
+   *       <li>{@link #consonant}と{@link #consonantLength}の有無が不一致。
+   *       <li>{@link #consonant}が子音以外の音素であるか、もしくは音素として不正。
+   *       <li>{@link #vowel}が子音であるか、もしくは音素として不正。
+   *     </ul>
    */
   public void validate() {
     rsValidate();

--- a/crates/voicevox_core_python_api/python/voicevox_core/_python/__init__.py
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_python/__init__.py
@@ -260,7 +260,7 @@ class Mora:
     モーラ（子音＋母音）ごとの情報。
 
     この構造体の状態によっては、 ``Synthesizer`` の各メソッドは
-    |mora-invalid-query-error|_ を発する。詳細は :func:`validate` にて。
+    |mora-invalid-query-error|_ を送出する。詳細は :func:`validate` にて。
 
     .. |mora-invalid-query-error| replace:: ``InvalidQueryError``
     .. _mora-invalid-query-error: #voicevox_core.InvalidQueryError
@@ -288,7 +288,7 @@ class Mora:
         """
         このインスタンスをバリデートする。
 
-        次のうちどれかを満たすなら |mora-validate-invalid-query-error|_ を発する。
+        次のうちどれかを満たすなら |mora-validate-invalid-query-error|_ を送出する。
 
         - :attr:`consonant` と :attr:`consonant_length` の有無が不一致。
         - :attr:`consonant` が子音以外の音素であるか、もしくは音素として不正。
@@ -315,7 +315,7 @@ class AccentPhrase:
     AccentPhrase (アクセント句ごとの情報)。
 
     この構造体の状態によっては、 ``Synthesizer`` の各メソッドは
-    |accent-phrase-invalid-query-error|_ を発する。詳細は :func:`validate` にて。
+    |accent-phrase-invalid-query-error|_ を送出する。詳細は :func:`validate` にて。
 
     .. |accent-phrase-invalid-query-error| replace:: ``InvalidQueryError``
     .. _accent-phrase-invalid-query-error: #voicevox_core.InvalidQueryError
@@ -337,7 +337,7 @@ class AccentPhrase:
         """
         このインスタンスをバリデートする。
 
-        次のうちどれかを満たすなら |accent-phrase-validate-invalid-query-error|_ を発する。
+        次のうちどれかを満たすなら |accent-phrase-validate-invalid-query-error|_ を送出する。
 
         - |accent-phrase-rust-ty|_ としてデシリアライズ不可。
             - :attr:`accent` が負であるか、もしくは :math:`2^{64}-1` (32ビットプラットフォームの場合 :math:`2^{32}-1`)を超過する。
@@ -368,7 +368,7 @@ class AudioQuery:
     AudioQuery (音声合成用のクエリ)。
 
     この構造体の状態によっては、 ``Synthesizer`` の各メソッドは
-    |audio-query-invalid-query-error|_ を発する。詳細は :func:`validate` にて。
+    |audio-query-invalid-query-error|_ を送出する。詳細は :func:`validate` にて。
 
     .. |audio-query-invalid-query-error| replace:: ``InvalidQueryError``
     .. _audio-query-invalid-query-error: #voicevox_core.InvalidQueryError
@@ -422,7 +422,7 @@ class AudioQuery:
         """
         このインスタンスをバリデートする。
 
-        次のうちどれかを満たすなら |audio-query-validate-invalid-query-error|_ を発する。
+        次のうちどれかを満たすなら |audio-query-validate-invalid-query-error|_ を送出する。
 
         - |audio-query-rust-ty|_ としてデシリアライズ不可。
             - :attr:`output_sampling_rate` が負であるか、もしくは :math:`2^{32}-1` を超過する。


### PR DESCRIPTION
## 内容

#1234 の議論より。

エラーの発生に対する表現を以下の通りとすることにする。

| 言語   | 表現             |
| :----- | :--------------- |
| Rust   | エラーを返す     |
| C      | 〃               |
| Python | 例外を送出する   |
| Java   | 例外をスローする |

またJava APIについては、`InvalidQueryException`についての説明を`@throws`に押し込めてしまう。複数行を押し込んでよいのかどうかは正直わかっていないが、大丈夫な気がする。
