### PR TITLE
refactor: `"a" | "i" | "u" | "e" | "o" | "N" | "cl"`を表す型

### DIFF
--- a/crates/voicevox_core/src/engine/acoustic_feature_extractor.rs
+++ b/crates/voicevox_core/src/engine/acoustic_feature_extractor.rs
@@ -2,7 +2,7 @@ pub(super) mod convert;
 
 use bytemuck::{CheckedBitPattern, Contiguous, NoUninit};
 use serde_with::SerializeDisplay;
-use strum::EnumCount;
+use strum::{EnumCount, EnumIter};
 
 pub use self::sil::Sil;
 
@@ -490,7 +490,7 @@ pub(crate) enum OptionalConsonant {
     ConsonantZ = 44,
 }
 
-#[expect(dead_code, reason = "we use `bytemuck` to construct `MorablePau`")]
+#[expect(dead_code, reason = "we use `bytemuck` to construct values")]
 #[derive(Clone, Copy, CheckedBitPattern, NoUninit, EnumCount)]
 #[repr(i64)]
 pub(crate) enum MoraTail {
@@ -542,10 +542,62 @@ pub(crate) enum MoraTail {
     //ConsonantZ = 44,
 }
 
+#[derive(Clone, Copy, NoUninit, EnumCount, EnumIter)]
+#[repr(i64)]
+pub(crate) enum NonPauBaseVowel {
+    //None = -1,
+    //MorablePau = 0,
+    //UnvoicedVowelA = 1,
+    //UnvoicedVowelE = 2,
+    //UnvoicedVowelI = 3,
+    MorableN = 4,
+    //UnvoicedVowelO = 5,
+    //UnvoicedVowelU = 6,
+    VoicedVowelA = 7,
+    //ConsonantB = 8,
+    //ConsonantBy = 9,
+    //ConsonantCh = 10,
+    MorableCl = 11,
+    //ConsonantD = 12,
+    //ConsonantDy = 13,
+    VoicedVowelE = 14,
+    //ConsonantF = 15,
+    //ConsonantG = 16,
+    //ConsonantGw = 17,
+    //ConsonantGy = 18,
+    //ConsonantH = 19,
+    //ConsonantHy = 20,
+    VoicedVowelI = 21,
+    //ConsonantJ = 22,
+    //ConsonantK = 23,
+    //ConsonantKw = 24,
+    //ConsonantKy = 25,
+    //ConsonantM = 26,
+    //ConsonantMy = 27,
+    //ConsonantN = 28,
+    //ConsonantNy = 29,
+    VoicedVowelO = 30,
+    //ConsonantP = 31,
+    //ConsonantPy = 32,
+    //ConsonantR = 33,
+    //ConsonantRy = 34,
+    //ConsonantS = 35,
+    //ConsonantSh = 36,
+    //ConsonantT = 37,
+    //ConsonantTs = 38,
+    //ConsonantTy = 39,
+    VoicedVowelU = 40,
+    //ConsonantV = 41,
+    //ConsonantW = 42,
+    //ConsonantY = 43,
+    //ConsonantZ = 44,
+}
+
 const _: () = assert!(PhonemeCode::MIN_VALUE == 0);
 const _: () = assert!(PhonemeCode::MAX_VALUE == 44);
 const _: () = assert!(PhonemeCode::COUNT == 45);
 const _: () = assert!(MoraTail::COUNT == 13);
+const _: () = assert!(NonPauBaseVowel::COUNT == 7);
 const _: () = assert!(OptionalConsonant::COUNT == PhonemeCode::COUNT - MoraTail::COUNT + 1);
 
 mod sil {

--- a/crates/voicevox_core/src/engine/mora_mappings.rs
+++ b/crates/voicevox_core/src/engine/mora_mappings.rs
@@ -44,7 +44,7 @@ use enum_map::{Enum, EnumMap};
 use macros::MoraMappings;
 use strum::{EnumCount, IntoStaticStr};
 
-use super::acoustic_feature_extractor::{MoraTail, OptionalConsonant};
+use super::acoustic_feature_extractor::{NonPauBaseVowel, OptionalConsonant};
 
 #[derive(Clone, Copy, PartialEq, Debug, Enum, EnumCount, IntoStaticStr, MoraMappings)]
 #[mora_mappings(
@@ -54,7 +54,7 @@ use super::acoustic_feature_extractor::{MoraTail, OptionalConsonant};
     mora_kana_to_mora_phonemes {
         pub(super) static MORA_KANA_TO_MORA_PHONEMES: EnumMap<
             MoraKana,
-            (OptionalConsonant, MoraTail),
+            (OptionalConsonant, NonPauBaseVowel),
         > = _;
     }
 )]

--- a/crates/voicevox_core_macros/src/mora_mappings.rs
+++ b/crates/voicevox_core_macros/src/mora_mappings.rs
@@ -53,7 +53,7 @@ pub(crate) fn derive_mora_mappings(input: &DeriveInput) -> syn::Result<proc_macr
             quote! {
                 (
                     crate::engine::acoustic_feature_extractor::convert::optional_consonant!(#consonant),
-                    crate::engine::acoustic_feature_extractor::convert::mora_tail!(#vowel)
+                    crate::engine::acoustic_feature_extractor::convert::non_pau_base_vowel!(#vowel)
                 )
             }
         });


### PR DESCRIPTION
## 内容

#1073 をやってて欲しくなったため。

## 関連 Issue

## その他
