### PR TITLE
refactor: `Validate`を移動し、`Note`と`Score`でも利用

### DIFF
--- a/crates/voicevox_core/src/__internal/interop.rs
+++ b/crates/voicevox_core/src/__internal/interop.rs
@@ -3,10 +3,8 @@ pub mod raii;
 pub use crate::{
     convert::ToJsonValue,
     core::metas::merge as merge_metas,
-    engine::talk::{
-        user_dict::{DEFAULT_PRIORITY, DEFAULT_WORD_TYPE},
-        Validate,
-    },
+    engine::talk::user_dict::{DEFAULT_PRIORITY, DEFAULT_WORD_TYPE},
+    engine::validate::Validate,
     synthesizer::{
         blocking::PerformInference, BlockingTextAnalyzerExt, NonblockingTextAnalyzerExt,
         DEFAULT_CPU_NUM_THREADS, DEFAULT_ENABLE_INTERROGATIVE_UPSPEAK,

--- a/crates/voicevox_core/src/engine.rs
+++ b/crates/voicevox_core/src/engine.rs
@@ -7,6 +7,7 @@ mod ndarray;
 mod sampling_rate;
 pub(crate) mod song;
 pub(crate) mod talk;
+pub(crate) mod validate;
 
 pub(crate) use self::{
     acoustic_feature_extractor::PhonemeCode, audio_file::to_s16le_pcm, ndarray::IteratorExt,

--- a/crates/voicevox_core/src/engine/song/validate.rs
+++ b/crates/voicevox_core/src/engine/song/validate.rs
@@ -13,6 +13,7 @@ use super::{
     super::{
         acoustic_feature_extractor::{NonPauBaseVowel, OptionalConsonant, PhonemeCode},
         sampling_rate::SamplingRate,
+        validate::Validate as _,
     },
     queries::{FrameAudioQuery, FramePhoneme, Note, NoteId, OptionalLyric, Score},
 };
@@ -181,7 +182,7 @@ impl TryFrom<&'_ Score> for ValidatedScore {
         let notes = (&*score.notes)
             .try_into()
             .map_err(|source| InvalidQueryError {
-                what: "楽譜",
+                what: Score::NAME,
                 value: None,
                 source: Some(InvalidQueryErrorSource::InvalidFields {
                     fields: "`notes`".to_owned(),
@@ -286,12 +287,12 @@ impl PauOrKeyAndLyric {
                 lyric: Lyric { phonemes: [mora] },
             }),
             (Some(_), []) => Err(InvalidQueryError {
-                what: "ノート",
+                what: Note::NAME,
                 value: None,
                 source: Some(InvalidQueryErrorSource::UnnecessaryKeyForPau),
             }),
             (None, [_]) => Err(InvalidQueryError {
-                what: "ノート",
+                what: Note::NAME,
                 value: None,
                 source: Some(InvalidQueryErrorSource::MissingKeyForNonPau),
             }),
@@ -349,7 +350,10 @@ mod tests {
         numerics::positive_finite_f32,
     };
 
-    use super::super::queries::{FrameAudioQuery, FramePhoneme, Note, Score};
+    use super::super::{
+        super::validate::Validate as _,
+        queries::{FrameAudioQuery, FramePhoneme, Note, Score},
+    };
 
     // TODO: トークの方と一緒に、`validated`に関するテストを書く
 
@@ -398,7 +402,7 @@ mod tests {
         assert!(matches!(
             err,
             crate::Error(ErrorRepr::InvalidQuery(InvalidQueryError {
-                what: "楽譜",
+                what: Score::NAME,
                 value: None,
                 source: Some(InvalidQueryErrorSource::InvalidFields { .. }),
             }))

--- a/crates/voicevox_core/src/engine/talk.rs
+++ b/crates/voicevox_core/src/engine/talk.rs
@@ -7,7 +7,7 @@ pub(crate) mod text;
 pub(crate) mod text_analyzer;
 pub(crate) mod user_dict;
 
-pub use self::audio_query::{AccentPhrase, AudioQuery, Mora, Validate};
+pub use self::audio_query::{AccentPhrase, AudioQuery, Mora};
 pub(crate) use self::audio_query::{
     LengthedPhoneme, ValidatedAccentPhrase, ValidatedAudioQuery, ValidatedMora,
 };

--- a/crates/voicevox_core/src/engine/talk/audio_query.rs
+++ b/crates/voicevox_core/src/engine/talk/audio_query.rs
@@ -6,8 +6,6 @@ pub(crate) use self::validated::{
     LengthedPhoneme, ValidatedAccentPhrase, ValidatedAudioQuery, ValidatedMora,
 };
 
-pub use self::validated::Validate;
-
 /* 各フィールドのjsonフィールド名はsnake_caseとする*/
 
 /// モーラ（子音＋母音）ごとの情報。

--- a/crates/voicevox_core/src/engine/talk/audio_query/validated.rs
+++ b/crates/voicevox_core/src/engine/talk/audio_query/validated.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use duplicate::duplicate_item;
-use serde::de::DeserializeOwned;
 use tracing::warn;
 
 use crate::error::{InvalidQueryError, InvalidQueryErrorSource};
@@ -14,6 +13,7 @@ use super::{
     super::super::{
         acoustic_feature_extractor::{Consonant, NonConsonant},
         sampling_rate::SamplingRate,
+        validate::Validate as _,
         DEFAULT_SAMPLING_RATE,
     },
     AccentPhrase, AudioQuery, Mora,
@@ -132,30 +132,6 @@ impl AudioQuery {
     // TODO: この層を破壊
     pub(crate) fn to_validated(&self) -> crate::Result<ValidatedAudioQuery<'_>> {
         ValidatedAudioQuery::new(self).map_err(Into::into)
-    }
-}
-
-pub trait Validate: DeserializeOwned {
-    const NAME: &str;
-    fn validate(&self) -> crate::Result<()>;
-
-    fn validation_error_description() -> String {
-        format!("不正な{}です", Self::NAME)
-    }
-}
-
-#[duplicate_item(
-    T S validation;
-    [ AudioQuery ] [ "AudioQuery" ] [ Self::validate ];
-    [ AccentPhrase ] [ "アクセント句" ] [ Self::validate ];
-    [ Mora ] [ "モーラ" ] [ Self::validate ];
-    [ Vec<AccentPhrase> ] [ "アクセント句の列" ] [ |this: &Self| this.iter().try_for_each(AccentPhrase::validate) ];
-)]
-impl Validate for T {
-    const NAME: &str = S;
-
-    fn validate(&self) -> crate::Result<()> {
-        (validation)(self)
     }
 }
 

--- a/crates/voicevox_core/src/engine/validate.rs
+++ b/crates/voicevox_core/src/engine/validate.rs
@@ -1,0 +1,33 @@
+use duplicate::duplicate_item;
+use serde::de::DeserializeOwned;
+
+use super::{
+    song::queries::{Note, Score},
+    talk::{AccentPhrase, AudioQuery, Mora},
+};
+
+pub trait Validate: DeserializeOwned {
+    const NAME: &str;
+    fn validate(&self) -> crate::Result<()>;
+
+    fn validation_error_description() -> String {
+        format!("不正な{}です", Self::NAME)
+    }
+}
+
+#[duplicate_item(
+    T S validation;
+    [ AudioQuery ] [ "AudioQuery" ] [ Self::validate ];
+    [ AccentPhrase ] [ "アクセント句" ] [ Self::validate ];
+    [ Mora ] [ "モーラ" ] [ Self::validate ];
+    [ Vec<AccentPhrase> ] [ "アクセント句の列" ] [ |this: &Self| this.iter().try_for_each(AccentPhrase::validate) ];
+    [ Note ] [ "ノート" ] [ Self::validate ];
+    [ Score ] [ "楽譜" ] [ Self::validate ];
+)]
+impl Validate for T {
+    const NAME: &str = S;
+
+    fn validate(&self) -> crate::Result<()> {
+        (validation)(self)
+    }
+}


### PR DESCRIPTION
## 内容

VOICEVOX SONGのPython API実装に必要。
