### PR TITLE
ci: `push`トリガーを`main`ブランチに限定

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -16,6 +16,8 @@ on:
       - published
   pull_request:
   push:
+    branches:
+      - main
 
 env:
   # releaseタグ名か、workflow_dispatchでのバージョン名か、'0.0.0'が入る

--- a/.github/workflows/check-shebangs-and-filemodes.yml
+++ b/.github/workflows/check-shebangs-and-filemodes.yml
@@ -3,6 +3,9 @@ name: Check shebangs and filemodes
 
 on:
   push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   check:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: test workflow
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -2,6 +2,8 @@ name: Check typos
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     branches:
       - "**"


### PR DESCRIPTION
## 内容

題の通り。

対象のworkflowは今までフォークリポジトリ上でも無条件で動いてしまっており、リソースを圧迫していた。フォーク上で動かす必要は無い認識。

本当は(もうすぐ丸三年前になる)#382 をやりたいが、とりあえず`push`トリガーの削減だけ自明なので行っておく。
