### PR TITLE
ci: fixup: #1258: `build_and_deploy_downloader`も`main`でだけ

### DIFF
--- a/.github/workflows/build_and_deploy_downloader.yml
+++ b/.github/workflows/build_and_deploy_downloader.yml
@@ -21,11 +21,8 @@ on:
       - crates/downloader/**
       - .github/workflows/build_and_deploy_downloader.yml
   push:
-    paths:
-      - Cargo.*
-      - rust-toolchain
-      - crates/downloader/**
-      - .github/workflows/build_and_deploy_downloader.yml
+    branches:
+      - main
 
 env:
   # releaseタグ名か、workflow_dispatchでのバージョン名か、'0.0.0'が入る


### PR DESCRIPTION
## 内容

現在これだけフォークブランチで動いてしまっているため、これも`main`ブランチ限定にする。代わりに`paths`フィルターは取り除いた。定期実行は重要だと考えられるため。
