### PR TITLE
chore: bump `backtrace` to v0.3.66 and `color-eyre` to v0.6.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,12 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.17.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "adler2"
@@ -289,17 +283,17 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.66"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.5.4",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-link",
 ]
 
 [[package]]
@@ -748,9 +742,9 @@ dependencies = [
 
 [[package]]
 name = "color-eyre"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55146f5e46f237f7423d74111267d4597b59b0dad0ffaf7303bce9945d843ad5"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
 dependencies = [
  "backtrace",
  "color-spantrace",
@@ -784,9 +778,9 @@ dependencies = [
 
 [[package]]
 name = "color-spantrace"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba75b3d9449ecdccb27ecbc479fdc0b87fa2dd43d2f8298f9bf0e59aacc8dce"
+checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
 dependencies = [
  "once_cell",
  "owo-colors",
@@ -1564,7 +1558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.0",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1788,9 +1782,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.26.2"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
@@ -2544,15 +2538,6 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
@@ -2764,9 +2749,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.29.0"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -2951,9 +2936,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
-version = "3.5.0"
+version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
 name = "parking"
@@ -3749,9 +3734,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.21"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ cargo_metadata = "0.18.1"
 cbindgen = "0.28.0"
 chrono = { version = "0.4.38", default-features = false }
 clap = { version = "4.5.19", features = ["cargo"] }
-color-eyre = "0.6.3"
+color-eyre = "0.6.5"
 color-print = "0.3.7"
 colorchoice = "1.0.2"
 comrak = { version = "0.26.0", default-features = false }

--- a/deny.toml
+++ b/deny.toml
@@ -35,13 +35,13 @@ bypass = [
     { name = "assert_cmd", version = "2", build-script = "367a36318cd9bb47aeb730f8a8ddad39c10b926175465393f0d5b01cbd993d44" }, # https://docs.rs/crate/assert_cmd/2.0.16/source/build.rs
     { name = "async-trait", version = "0.1", build-script = "b45aa3a5c177cbeaeb4847163088924491ac27b79534f8ea4c53ed3e10c163ea" }, # https://docs.rs/crate/async-trait/0.1.57/source/build.rs
     { name = "aws-lc-rs", version = "1", build-script = "84ca0d8a8a61487e0c36215b23b144239ffc9af760dd7e7bcde6a76aa68bc3c5" }, # https://docs.rs/crate/aws-lc-rs/1.15.2/source/build.rs
-    { name = "backtrace", version = "0.3", build-script = "8d5e860da109f86c67596b10b5613ff6d19f9d24c2970f491a55261fb1973692" }, # https://docs.rs/crate/backtrace/0.3.66/source/build.rs
     { name = "bindgen", version = "0.70", build-script = "4a9c4ac3759572e17de312a9d3f4ced3b6fd3c71811729e5a8d06bfbd1ac8f82" }, # https://docs.rs/crate/bindgen/0.70.1/source/build.rs
     { name = "bindgen", version = "0.71", build-script = "f7a10af0a21662e104e0058da7e3471a20be328eef6c7c41988525be90fdfe92" }, # https://docs.rs/crate/bindgen/0.71.1/source/build.rs
     { name = "camino", version = "1", build-script = "cbdfaa56ff8e211896e75fc7867e3230aa8aa09fdda901111db957c65306f1d8" }, # https://docs.rs/crate/camino/1.1.9/source/build.rs
     { name = "caseless", version = "0.2", build-script = "8ab1dc9ef269f28202fe1156c5c655f286cbc03b6dd4fb20a2f9f9e00763b6f5" }, # https://docs.rs/crate/caseless/0.2.1/source/src/build.rs
     { name = "cbindgen", version = "0.28", build-script = "f0fa57ad2c0dca5855cc2636a2e95acbadb52fa887609216022bdf71ed996dec" }, # https://docs.rs/crate/cbindgen/0.28.0/source/build.rs
     { name = "codspeed-divan-compat", version = "3", build-script = "c389c9c87396d2966977c9fa5933073e3eba788dfeb3e9dc1e99313d0d9085bf" }, # https://docs.rs/crate/codspeed-divan-compat/3.0.5/source/build.rs
+    { name = "color-spantrace", version = "0.3", build-script = "3cdfaf5da596d96e9fd23a05b4f634ff7c98fd8f97f1a1558585e9f018ba5f5c" }, # https://docs.rs/crate/color-spantrace/0.3.0/source/build.rs
     { name = "const_fn", version = "0.4", build-script = "8de9d55780370383bbb0c5e816d03e343796fafe4e9ce9f3f8905a441823dae7" }, # https://docs.rs/crate/const_fn/0.4.11/source/build.rs
     { name = "crc32fast", version = "1", build-script = "4ccc50c3da67eb27f0b622440d2b7aee2f73fa9c71884571f3c041122231d105" }, # https://docs.rs/crate/crc32fast/1.3.2/source/build.rs
     { name = "crossbeam-epoch", version = "0.9", build-script = "901be3c21843440be5c456ff049f57f72ee5ec365918a772ad2a4751e52f69c5" }, # https://docs.rs/crate/crossbeam-epoch/0.9.13/source/build.rs
@@ -62,6 +62,8 @@ bypass = [
     { name = "num-bigint", version = "0.4", build-script = "4955639b370d3636b8c44cb7743e6c5fb129077b069d78becbc135eba37e1ece" }, # https://docs.rs/crate/num-bigint/0.4.3/source/build.rs
     { name = "num-integer", version = "0.1", build-script = "575b157527243fe355a7c8d7d874a1f790c3fb0177beba9032076a7803c5b9dd" }, # https://docs.rs/crate/num-integer/0.1.45/source/build.rs
     { name = "num-traits", version = "0.2", build-script = "cf682b2322303196e241048cb56d873597b78a3b4e3f275f6f761dadb33a65f5" }, # https://docs.rs/crate/num-traits/0.2.15/source/build.rs
+    { name = "object", version = "0.37", build-script = "ba7ab1735d3642c53562d1223a6eb54c2392e619ade3005e0deee3fc4229feea" }, # https://docs.rs/crate/object/0.37.3/source/build.rs
+    { name = "owo-colors", version = "4", build-script = "afffaf4540849a8daf1e5a2efbb7eba25ede31c77060ca4f14dc43f8b7aadbeb" }, # https://docs.rs/crate/owo-colors/4.2.3/source/build.rs
     { name = "parking_lot_core", version = "0.9", build-script = "29e629057144d1238dcd8ea70ad6cbb6ec14ca742797af3fa9335710ff5cbaaa" }, # https://docs.rs/crate/parking_lot_core/0.9.3/source/build.rs
     { name = "prettyplease", version = "0.2", build-script = "fdf8aa9b5441b298c72ae23645e227adc52ac69d2decc1bda04e1a91f70ff87d" }, # https://docs.rs/crate/prettyplease/0.2.17/source/build.rs
     { name = "portable-atomic", version = "1", build-script = "0d5e11d1d1376259bbd99269b52728a5a7e3f93403d82fa4ee1cfbd11ed892dd" }, # https://docs.rs/crate/portable-atomic/1.9.0/source/build.rs


### PR DESCRIPTION
## 内容

cargo-denyが[RUSTSEC-2025-0056](https://rustsec.org/advisories/RUSTSEC-2025-0056)（カテゴリは"Unmaintained"）に反応しないようにするため。
