### PR TITLE
ci: cargo-denyをv0.18に上げる

### DIFF
--- a/.github/actions/install-cargo-deny/action.yml
+++ b/.github/actions/install-cargo-deny/action.yml
@@ -8,4 +8,4 @@ runs:
       uses: taiki-e/install-action@cargo-binstall
     - name: Install cargo-deny
       shell: bash
-      run: cargo binstall cargo-deny@^0.16 --no-confirm --log-level debug
+      run: cargo binstall cargo-deny@^0.18 --no-confirm --log-level debug


### PR DESCRIPTION
## 内容

11個あった[advisory](https://rustsec.org/advisories/)を #1265, #1266, #1268, #1269 で全部解決したので、CIで動くcargo-denyを最新版に上げることで[`audit`ワークフロー](https://github.com/VOICEVOX/voicevox_core/actions/workflows/audit.yml)を復旧させる。

およそ10ヶ月の間、毎晩欠かすことなく落ち続けて通知を飛ばしてきていたが、今晩からはadvisoryがあるとき以外静かになるはず。

## その他

動作確認:
<https://github.com/qryxip/voicevox_core/actions/runs/20692561751>
