### PR TITLE
docs: song.mdに音域調整の章を追加

### DIFF
--- a/docs/guide/user/song.md
+++ b/docs/guide/user/song.md
@@ -108,7 +108,7 @@ wav = synthesizer.frame_synthesis(frame_audio_query, SINGER)
 
 ## 音域調整
 
-`frame_decode`側のスタイルと`singing_teacher`側のスタイルでは得意な音域が異なることがあります。そのため場合によってはうまく歌わせるために、[VOICEVOXエディタの音域調整機能]と同じことを行う必要があります。
+`singing_teacher`のスタイルと`frame_decode`のスタイルでは得意な音域が異なることがあります。その場合はうまく歌うために音域を調整します。この調整は[VOICEVOXエディタの音域調整機能]と同じ。
 
 ```py
 KEY_RANGE_ADJUSTMENT = -4  # "四国めたん（あまあま）"の場合


### PR DESCRIPTION
## 内容

APIドキュメント側にも書こうと思ったが、`Note::key`に書くか`FrameAudioQuery::f0`に書くか`Synthesizer::create_sing_frame_audio_query`に書くかが明らかではなかったため保留。
