### PR TITLE
ci: yqから脱却する

### DIFF
--- a/.github/workflows/check-release-target-tuples.yml
+++ b/.github/workflows/check-release-target-tuples.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           jq_r_from_yaml() {
             set -e
-            json=$(ruby -r json -r yaml -e 'print YAML.load(File.read($*[0])).to_json' "$2")
+            json=$(ruby -r json -r yaml -e 'print YAML.load_file($*[0]).to_json' "$2")
             jq -r "$1" <(cat <<< "$json")
           }
 


### PR DESCRIPTION
## 内容

先日リリースされた[v4.52.1](https://github.com/mikefarah/yq/releases/tag/v4.52.1)以降のyqが、このリポジトリのdeny.tomlを読めなくなったことへの対処。 mikefarah/yq@bdeedbd2759ee48da7ededfd674266219f78bdc2 や mikefarah/yq#2589 といったことが行われた[v4.52.2](https://github.com/mikefarah/yq/releases/tag/v4.52.2)でも解決しなかった。

```console
Error: bad file './deny.toml': unsupported type Comment
```

代わりにRubyの標準ライブラリでYAMLを、Pythonの標準ライブラリでTOMLをJSONに変換するようにする。この二つはパーサーとしての信頼性が高いはず。

YAMLの方はyqでも依然として正常に読めはするが、どうせなのでYAMLごと脱却する。
