### PR TITLE
build: リリース後の`download_test`ではリリースのdownloaderを使う

### DIFF
--- a/.github/workflows/download_test.yml
+++ b/.github/workflows/download_test.yml
@@ -156,9 +156,9 @@ jobs:
     name: ${{ matrix.name }}-${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
-        if: '!needs.config.outputs.use-released-downloader'
+        if: '!fromJson(needs.config.outputs.use-released-downloader)'
       - name: Set up Rust
-        if: '!needs.config.outputs.use-released-downloader'
+        if: '!fromJson(needs.config.outputs.use-released-downloader)'
         uses: ./.github/actions/rust-toolchain-from-file
       - name: Determine version
         run: |


### PR DESCRIPTION
## 内容

リリース後のテストとして強度を高めるためと、あとは時間短縮のため。

## その他

- ~~qryxip/voicevox_core/actions/runs/22031114340~~
- ~~qryxip/voicevox_core/actions/runs/22045757127~~
- ~~qryxip/voicevox_core/actions/runs/22047860863~~
- ~~qryxip/voicevox_core/actions/runs/22048935550~~
- [x] <https://github.com/qryxip/voicevox_core/actions/runs/22167831139>
