### PR TITLE
build: fixup #1262: Windows署名付きダウンローダーのビルドを直す

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -495,6 +495,7 @@ jobs:
       upload_url: ${{ fromJson(needs.create_draft_release.outputs.release).upload_url }}
       version: ${{ needs.config.outputs.version }}
       code_signing: ${{ inputs.code_signing }}
+    secrets: inherit
 
   prerelease:
     needs: [config, create_draft_release, build_and_deploy, build_xcframework, build_java_package, build_and_deploy_downloader]


### PR DESCRIPTION
## 内容

以下の実験により、`secrets: inherit`を入れればいいらしいことがわかったため入れる。
<https://github.com/qryxip/poc-gha-secrets-via-workflow-call/tree/1711afc86f1896c4d843f2fd34de9fc40d5a755b>

一応参考にしたもの: actions/runner#1490
