### PR TITLE
docs: 0.16.4のchangelogとkey changesを訂正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,9 @@
 [@phenylshima]: https://github.com/phenylshima
 -->
 
-## [0.16.4] - 2026-02-20 (+09:00)
+## [0.16.4] - 2026-02-19 (+09:00)
+
+主な変更点とその解説については、[GitHub Releaseの本文](https://github.com/VOICEVOX/voicevox_core/releases/tag/0.16.4)をご覧ください。
 
 ### Added
 

--- a/docs/guide/user/key-changes/0.16.4.md
+++ b/docs/guide/user/key-changes/0.16.4.md
@@ -33,11 +33,7 @@ wav = synthesizer.frame_synthesis(frame_audio_query, SINGER)
 
 リリースされるバイナリが16KBページサイズのデバイスに対応し、[Google Playの要件]を満たすようになります。
 
-ただし、現在の VOICEVOX ONNX Runtime バージョン1.17.3は16KBアライメントに対応していません。近日中に対応済みの[VOICEVOX ONNX Runtime バージョン1.23.2]がリリースされます。このバージョンは、ダウンローダーで`--onnxruntime-version voicevox_onnxruntime-1.23.2`を指定することでダウンロードできるようになる予定です。
-
-```console
-❯ ./download --only onnxruntime --onnxruntime-version voicevox_onnxruntime-1.23.2
-```
+ただし、現在の VOICEVOX ONNX Runtime バージョン1.17.3は16KBアライメントに対応していません。近日中に対応済みの[VOICEVOX ONNX Runtime バージョン1.23.2]がリリースされます。
 
 ## 謝辞
 
@@ -45,7 +41,7 @@ wav = synthesizer.frame_synthesis(frame_audio_query, SINGER)
 
 - [@k-yamada]さん（[#1152]の報告）
 
-[CHANGELOG.md]: https://github.com/VOICEVOX/voicevox_core/blob/main/CHANGELOG.md#0164---2026-02-20-0900
+[CHANGELOG.md]: https://github.com/VOICEVOX/voicevox_core/blob/main/CHANGELOG.md#0164---2026-02-19-0900
 [VOICEVOX Song]: https://voicevox.hiroshiba.jp/song/
 [歌唱音声合成]: https://github.com/VOICEVOX/voicevox_core/blob/0.16.4/docs/guide/user/song.md
 [Google Playの要件]: https://developer.android.com/guide/practices/page-sizes


### PR DESCRIPTION
## 内容

changelogについては、 #1310 に対してClaude Codeが指摘したもの。リリース日は「タグの日付」にすることになっているため、2026-02-19が正しい。

key changesについては私が気付いたもの。ダウンローダーには`--os android`のオプションが無いので (cf. #1312)、不可能なことを提示してしまっているということで記述を削除。
