### PR TITLE
fix: ストリーミング非対応VVMでのパニックをちゃんとしたエラーに

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,11 +33,13 @@
 - fix compat breaking: revive workaround padding in decode() ([#867])
 - feat!: `render`の引数の範囲指定部分を各言語の慣習に合わせる ([#879])
 - feat!: decode.onnxを復活させる ([#918])
+- [#1319]
 
 [#854]: https://github.com/VOICEVOX/voicevox_core/pull/854
 [#864]: https://github.com/VOICEVOX/voicevox_core/pull/864
 [#867]: https://github.com/VOICEVOX/voicevox_core/pull/867
 [#879]: https://github.com/VOICEVOX/voicevox_core/pull/879
+[#1319]: https://github.com/VOICEVOX/voicevox_core/pull/1319
 
 ### もし`TextAnalyzer`機能を充実させた場合
 

--- a/crates/voicevox_core/src/core/status.rs
+++ b/crates/voicevox_core/src/core/status.rs
@@ -176,6 +176,15 @@ impl<R: InferenceRuntime> LoadedModels<R> {
         ) = self
             .0
             .iter()
+            .filter(
+                |(
+                    _,
+                    LoadedModel {
+                        session_sets_with_inner_ids,
+                        ..
+                    },
+                )| D::visit(session_sets_with_inner_ids).is_some(),
+            )
             .find(|(_, LoadedModel { metas, .. })| {
                 metas
                     .iter()


### PR DESCRIPTION
## 内容

#1206 を修正する。

#1207 の後では不要になりそうな気もするが、`vvm_format_version=1`のVVMを読む機能も残したいのでバグはバグとして直した方がよさそうと思った次第。

## 関連 Issue

Fixes: #1206

## その他
