### PR TITLE
docs: `load-onnxruntime`フラグのmuslターゲットに関する警告を追加

### DIFF
--- a/crates/voicevox_core/build.rs
+++ b/crates/voicevox_core/build.rs
@@ -4,6 +4,7 @@ use std::{env, sync::LazyLock};
 compile_error!("either `load-onnxruntime` or `link-onnxruntime` must be enabled");
 
 const ENV_DOWNLOAD_AND_COPY_ORT: &str = "VVCORE_BUILD_DOWNLOAD_AND_COPY_ORT";
+const ENV_TARGET_ENV: &str = "CARGO_CFG_TARGET_ENV";
 static DOWNLOAD_AND_COPY_ORT: LazyLock<bool> = LazyLock::new(|| is_true(ENV_DOWNLOAD_AND_COPY_ORT));
 
 fn main() -> Result<(), build_features::Error> {
@@ -12,6 +13,13 @@ fn main() -> Result<(), build_features::Error> {
     }
 
     println!("cargo::rerun-if-changed=build.rs");
+    println!("cargo::rerun-if-env-changed={ENV_TARGET_ENV}");
+
+    if cfg!(feature = "load-onnxruntime") && env::var(ENV_TARGET_ENV).is_ok_and(|s| s == "musl") {
+        println!(
+            "cargo::warning=`load-onnxruntime` is unavailable on musl targets because `dlopen` is unsupported; use `link-onnxruntime` instead",
+        );
+    }
 
     if cfg!(feature = "buildtime-download-onnxruntime") {
         println!("cargo::rerun-if-env-changed={ENV_DOWNLOAD_AND_COPY_ORT}");

--- a/crates/voicevox_core/src/lib.rs
+++ b/crates/voicevox_core/src/lib.rs
@@ -6,6 +6,7 @@
 //!   Runtimeのバイナリをダウンロードしてtarget
 //!   directory内の複数箇所に配置する。`VVCORE_BUILD_DOWNLOAD_AND_COPY_ORT`が`1`ではないなら警告を出して何もしない。後述の`link-onnxruntime`フィーチャと合わせると、システムにONNX Runtimeが無くてもビルドが可能になる。
 //! - **`load-onnxruntime`**: ONNX Runtimeを`dlopen`/`LoadLibraryExW`で開く。[CUDA]と[DirectML]が利用可能。
+//!   またmuslをターゲットとしたビルドでは`dlopen`をサポートしないため、このフラグは利用不可であるため、`link-onnxruntime`を利用する必要がある。
 //! - **`link-onnxruntime`**: ONNX Runtimeをロード時動的リンクする。そのためビルドするためにはシステムにONNX
 //!   Runtimeがインストールされているか、`buildtime-download-onnxruntime`によるダウンロードを行う必要がある。iOSのような`dlopen`の利用が困難な環境でのみこちらを利用するべきである。_Note_:
 //!   [動的リンク対象のライブラリ名]は`onnxruntime`で固定。変更は`patchelf(1)`や`install_name_tool(1)`で行うこと。また、[ONNX RuntimeのGPU機能]を使うことは不可。


### PR DESCRIPTION
## 内容

`load-onnxruntime` が dlopen に依存しているため、musl ベースの静的リンク環境（例: x86_64-unknown-linux-musl）では動作しないことをドキュメントに明記しました。

また、該当環境でビルドした際に気づきやすくするため、build.rs に警告表示を追加しました。

## 関連 Issue

ref #1340

## その他

関連 Issue では、link-onnxruntime による対応についての議論も行われていますが、一応問題だった docs 追加について build.rs と lib.rs について説明と警告表示をまず追加しました。
