### PR TITLE
chore: リリース作成とアセットアップロードに contents: write を明示する

### DIFF
--- a/.github/workflows/build-downloader.yml
+++ b/.github/workflows/build-downloader.yml
@@ -45,6 +45,8 @@ jobs:
   build-downloader:
     needs: config
     environment: ${{ inputs.code_signing && 'code_signing' || '' }} # コード署名用のenvironment
+    permissions:
+      contents: write
     strategy:
       matrix:
         include:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,6 +184,8 @@ jobs:
   create_draft_release:
     needs: config
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       # `draft-release`がtrueなら、GitHub REST APIの`Release`オブジェクトの一部。falseならnull。
       release: ${{ steps.create-draft-release.outputs.release || 'null' }}
@@ -229,6 +231,8 @@ jobs:
   build:
     needs: [config, create_draft_release]
     environment: ${{ inputs.code_signing && 'code_signing' || '' }} # コード署名用のenvironment
+    permissions:
+      contents: write
     strategy:
       matrix:
         include: ${{ fromJson(needs.config.outputs.includes) }}
@@ -377,6 +381,8 @@ jobs:
     if: ${{ needs.config.outputs.mode == 'draft-release' || needs.config.outputs.mode == 'full-test' }}
     needs: [config, create_draft_release, build]
     runs-on: macos-14
+    permissions:
+      contents: write
     env:
       IOS_X86_64_PATH: artifact/voicevox_core-x86_64-apple-ios
       IOS_AARCH64_SIM_PATH: artifact/voicevox_core-aarch64-apple-ios-sim
@@ -416,6 +422,8 @@ jobs:
 
   build_java_package:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: ${{ needs.config.outputs.mode == 'draft-release' || needs.config.outputs.mode == 'full-test' }}
     needs: [config, create_draft_release, build]
     steps:
@@ -504,6 +512,8 @@ jobs:
   build_downloader:
     needs: [config, create_draft_release]
     if: needs.config.outputs.mode == 'draft-release'
+    permissions:
+      contents: write
     uses: ./.github/workflows/build-downloader.yml
     with:
       upload_url: ${{ fromJson(needs.create_draft_release.outputs.release).upload_url }}
@@ -515,6 +525,8 @@ jobs:
     needs: [config, create_draft_release, build, build_xcframework, build_java_package, build_downloader]
     if: needs.config.outputs.mode == 'draft-release'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Set the tag name
         run: |


### PR DESCRIPTION
## 内容

GITHUB_TOKEN のデフォルト権限を read-only にする準備として、write が必要な job に permissions を明示します。

- release 作成や release asset upload を行う job に `contents: write` を明示します。
- reusable workflow の caller と called の両方に必要な `contents: write` を明示します。
- public resource の read 用 permissions は追加していません。

## 関連 Issue

ref VOICEVOX/voicevox_project#93
