### PR TITLE
ci: CodSpeedHQ/actionを最新コミットにしてCodSpeed v4.14.0を利用

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -46,7 +46,8 @@ jobs:
         run: cargo codspeed build -p voicevox_core --bench benches --features buildtime-download-onnxruntime,load-onnxruntime -m walltime
 
       - name: Run the benchmarks
-        uses: CodSpeedHQ/action@v4
+        # FIXME: CodSpeed v4.14.0を使いたいが、CodSpeedHQ/actionのv4.14.0だけ何故かまだ出ていないため。出たらpinact式の固定にする
+        uses: CodSpeedHQ/action@1d42668155453040f69e1ce27b17d23fe82963c2
         with:
           run: cargo codspeed run -m walltime
           mode: walltime
@@ -87,7 +88,8 @@ jobs:
           poetry run maturin develop --locked --profile release -F voicevox_core/buildtime-download-onnxruntime -v
 
       - name: Run the benchmarks
-        uses: CodSpeedHQ/action@v4
+        # FIXME: CodSpeed v4.14.0を使いたいが、CodSpeedHQ/actionのv4.14.0だけ何故かまだ出ていないため。出たらpinact式の固定にする
+        uses: CodSpeedHQ/action@1d42668155453040f69e1ce27b17d23fe82963c2
         with:
           run: poetry run pytest ./python/benches/ --codspeed --codspeed-mode walltime
           mode: walltime


### PR DESCRIPTION
## 内容

pytest-codspeedでのベンチマークがベンチマークレポートの破損（?）でクラッシュするということが起きているのでとりあえず、CodSpeedHQ/codspeed#298（破損したやつを無視する変更）が入ったCodSpeedの最新版v4.14.0を利用する。ベンチマークレポートの破損自体についてはよくわかっておらず調査中。

何故mainブランチの最新コミットを使うのかについてはdiffのFIXMEを参照。