### PR TITLE
ci: actionlint ダウンロード時に SHA256 チェックサムを検証する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,10 @@ jobs:
         run: pip install 'pyflakes>3,<4'
       - name: actionlint
         run: |
-          bash <(curl -f --retry 3 --retry-delay 5 https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          curl -fLO --retry 3 --retry-delay 5 \
+              "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz"
+          echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  actionlint_1.7.12_linux_amd64.tar.gz" | sha256sum --check
+          tar -xzf actionlint_1.7.12_linux_amd64.tar.gz actionlint
           ./actionlint -color
 
   validate-cargo-lock:


### PR DESCRIPTION
## 内容

VOICEVOX/voicevox_project#94 の対応として、actionlint バイナリの取得を `download-actionlint.bash` 経由から公式リリースアセットの直接取得に変更し、SHA256 チェックサムを検証するようにしました。

参考: VOICEVOX/voicevox#2999, VOICEVOX/voicevox_engine#1855

## 関連 Issue

ref VOICEVOX/voicevox_project#94

## その他