### PR TITLE
fix: `aws-lc-rs`, `rustls-webpki`, `tar`をアップデート

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,19 @@
     - \[追加\]: `git+https://github.com/pykeio/ort.git?rev=94417081c47f47f5a7d6a92ce94bb38fda10019f#ort@2.0.0-rc.12`
     - \[変更\]: `indexmap@2`: `^2.6.0` → `^2.13.0`
 
+### Security
+
+- \[Rust,ダウンローダー\] 以下の脆弱性登録の影響を受けないようになります ([#1349])。
+    - [RUSTSEC-2026-0044](https://rustsec.org/advisories/RUSTSEC-2026-0044)
+    - [RUSTSEC-2026-0045](https://rustsec.org/advisories/RUSTSEC-2026-0045)
+    - [RUSTSEC-2026-0046](https://rustsec.org/advisories/RUSTSEC-2026-0046)
+    - [RUSTSEC-2026-0047](https://rustsec.org/advisories/RUSTSEC-2026-0047)
+    - [RUSTSEC-2026-0048](https://rustsec.org/advisories/RUSTSEC-2026-0048)
+    - [RUSTSEC-2026-0049](https://rustsec.org/advisories/RUSTSEC-2026-0049)
+    - [RUSTSEC-2026-0098](https://rustsec.org/advisories/RUSTSEC-2026-0098)
+    - [RUSTSEC-2026-0099](https://rustsec.org/advisories/RUSTSEC-2026-0099)
+    - [RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104)
+
 ## [0.16.4] - 2026-02-19 (+09:00)
 
 主な変更点とその解説については、[GitHub Releaseの本文](https://github.com/VOICEVOX/voicevox_core/releases/tag/0.16.4)をご覧ください。
@@ -1496,6 +1509,7 @@ Windows版ダウンローダーのビルドに失敗しています。
 [#1315]: https://github.com/VOICEVOX/voicevox_core/pull/1315
 [#1323]: https://github.com/VOICEVOX/voicevox_core/pull/1323
 [#1331]: https://github.com/VOICEVOX/voicevox_core/pull/1331
+[#1349]: https://github.com/VOICEVOX/voicevox_core/pull/1349
 
 [VOICEVOX/onnxruntime-builder#25]: https://github.com/VOICEVOX/onnxruntime-builder/pull/25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,9 +261,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88aab2464f1f25453baa7a07c84c5b7684e274054ba06817f382357f77a288"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -271,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.35.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45afffdee1e7c9126814751f88dddc747f41d91da16c9551a0f1e8a11e788a1"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -3709,9 +3709,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4295,9 +4295,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.42"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ff6c40d3aedb5e06b57c6f669ad17ab063dd1e63d977c6a88e7f4dfa4f04020"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ smallvec = "1.13.2"
 smol_str = "0.3.2"
 strum = "0.24.1"
 syn = "2.0.87"
-tar = "0.4.42"
+tar = "0.4.45"
 tempfile = "3.13.0"
 test_util = { path = "crates/test_util" }
 thiserror = "1.0.64"

--- a/deny.toml
+++ b/deny.toml
@@ -29,17 +29,17 @@ allow-build-scripts = [
     # SHA256: b4dd86261a70df757efa53f06ce7543a4dc9c51178b9b023c92069fddee97a29
     { name = "typenum", version = "1" }, # https://docs.rs/crate/typenum/1.15.0/source/build/main.rs
 
-    # https://docs.rs/crate/aws-lc-sys/0.35.0/source/builder/main.rs
-    # SHA256: 180047fd086dc17c9a9491ebfb39123a0dab29edfa21bfc8c1d6c3cff385a9c3
+    # https://docs.rs/crate/aws-lc-sys/0.40.0/source/builder/main.rs
+    # SHA256: f13e021619f64da72ffab37bf54216b30a721e481bde86d9aebda10e004efc2d
     #
-    # aws-lc-sys inherits the license of aws-lc: https://docs.rs/crate/aws-lc-sys/0.35.0/source/LICENSE
-    { name = "aws-lc-sys", version = "0.35" },
+    # aws-lc-sys inherits the license of aws-lc: https://docs.rs/crate/aws-lc-sys/0.40.0/source/LICENSE
+    { name = "aws-lc-sys", version = "0.40" },
 ]
 bypass = [
     { name = "anyhow", version = "1", build-script = "2cd2c3a980dcecdf1b0e0f1fff31b440d8ddcab9340434d4f678ed807a9d7cdd" }, # https://docs.rs/crate/anyhow/1.0.99/source/build.rs
     { name = "assert_cmd", version = "2", build-script = "367a36318cd9bb47aeb730f8a8ddad39c10b926175465393f0d5b01cbd993d44" }, # https://docs.rs/crate/assert_cmd/2.0.16/source/build.rs
     { name = "async-trait", version = "0.1", build-script = "b45aa3a5c177cbeaeb4847163088924491ac27b79534f8ea4c53ed3e10c163ea" }, # https://docs.rs/crate/async-trait/0.1.57/source/build.rs
-    { name = "aws-lc-rs", version = "1", build-script = "84ca0d8a8a61487e0c36215b23b144239ffc9af760dd7e7bcde6a76aa68bc3c5" }, # https://docs.rs/crate/aws-lc-rs/1.15.2/source/build.rs
+    { name = "aws-lc-rs", version = "1", build-script = "791f97e6abdb685bcc722342d49f2646b3146b209f68753669c178716f6cee01" }, # https://docs.rs/crate/aws-lc-rs/1.16.3/source/build.rs
     { name = "bindgen", version = "0.70", build-script = "4a9c4ac3759572e17de312a9d3f4ced3b6fd3c71811729e5a8d06bfbd1ac8f82" }, # https://docs.rs/crate/bindgen/0.70.1/source/build.rs
     { name = "bindgen", version = "0.71", build-script = "f7a10af0a21662e104e0058da7e3471a20be328eef6c7c41988525be90fdfe92" }, # https://docs.rs/crate/bindgen/0.71.1/source/build.rs
     { name = "camino", version = "1", build-script = "cbdfaa56ff8e211896e75fc7867e3230aa8aa09fdda901111db957c65306f1d8" }, # https://docs.rs/crate/camino/1.1.9/source/build.rs
@@ -172,7 +172,6 @@ allow = [
     "ISC",
     "MIT",
     "MPL-2.0",
-    "OpenSSL",
     "Unicode-3.0",
     "Zlib",
 ]


### PR DESCRIPTION
## 内容

- `pkg:cargo/aws-lc-rs`: `1.15.2` → `1.16.3`
    - `pkg:cargo/aws-lc-sys`: `0.35.0` → `0.40.0`
- `pkg:cargo/rustls-webpki`: `0.103.8` → `0.103.13`
- `pkg:cargo/tar`: `0.4.42` → `0.4.45`

以下の脆弱性登録に対応。

- [RUSTSEC-2026-0044](https://rustsec.org/advisories/RUSTSEC-2026-0044)
- [RUSTSEC-2026-0045](https://rustsec.org/advisories/RUSTSEC-2026-0045)
- [RUSTSEC-2026-0046](https://rustsec.org/advisories/RUSTSEC-2026-0046)
- [RUSTSEC-2026-0047](https://rustsec.org/advisories/RUSTSEC-2026-0047)
- [RUSTSEC-2026-0048](https://rustsec.org/advisories/RUSTSEC-2026-0048)
- [RUSTSEC-2026-0049](https://rustsec.org/advisories/RUSTSEC-2026-0049)
- [RUSTSEC-2026-0067](https://rustsec.org/advisories/RUSTSEC-2026-0067)
- [RUSTSEC-2026-0068](https://rustsec.org/advisories/RUSTSEC-2026-0068)
- [RUSTSEC-2026-0098](https://rustsec.org/advisories/RUSTSEC-2026-0098)
- [RUSTSEC-2026-0099](https://rustsec.org/advisories/RUSTSEC-2026-0099)
- [RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104)
