### PR TITLE
chore: deny.tomlの`licenses.clarify`を直す

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -172,9 +172,10 @@ allow = [
     "ISC",
     "MIT",
     "MPL-2.0",
+    "OpenSSL",
     "Unicode-3.0",
     "Zlib",
 ]
 clarify = [
-    { name = "ring", version = "0.17", expression = "MIT AND ISC AND OpenSSL", license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }] },
+    { name = "ring", version = "0.17", expression = "MIT AND ISC AND OpenSSL", license-files = [{ path = "LICENSE", hash = 0x0d99693a }] },
 ]


### PR DESCRIPTION
## 内容

#1186 内でdeny.tomlを更新するときに発見。どうやら`hash`が間違っていると宣言自体がサイレントに読み飛ばされるらしい。

> Note: your premise is off — that `ring-0.17.11/LICENSE` (and the `0.17.14` one cargo-deny actually consumes; Cargo.lock pins `ring 0.17.14`) hashes to `0x0d99693a` under the current cargo-deny algorithm, not `0xbd0eed23`. The `0xbd0eed23` value in `deny.toml:182` was originally written for `ring 0.16` (see `git log -S 0xbd0eed23 -- deny.toml`) and was carried forward to the 0.17 entry without re-checking. cargo-deny silently ignores a clarify entry whose `hash` doesn't match (it just falls back to askalono detection), so the stale value hasn't been noticed.

(注: `182`行目というのは #1186 での話)

なおそもそも`hash`というのは何なのかというと、

> `twox_hash::XxHash32` over the file content with `\r\n` → `\n` normalization, see `gather.rs::get_file_source` and `lib.rs::hash`

らしい（私の知る限りundocumented）。
