### PR TITLE
chore(rust): fixup #1352

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -253,13 +253,13 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           key: ${{ matrix.os }}
-      - name: Exampleを実行
+      - name: Run the example
         run: |
           # `./target/voicevox_core/downloads/onnxruntime` and `./crates/test_util/data` are created in the build time
           # shellcheck disable=SC2054
           target_and_features=(--example talk -F load-onnxruntime,buildtime-download-onnxruntime)
           cargo b "${target_and_features[@]}"
-          onnxruntime=$(find ../../target/voicevox_core/downloads/onnxruntime '(' -name onnxruntime.dll -o -name 'libonnxruntime.*' ')' -type f)
+          onnxruntime=$(find ./target/voicevox_core/downloads/onnxruntime '(' -name onnxruntime.dll -o -name 'libonnxruntime.*' ')' -type f)
           cargo r "${target_and_features[@]}" -- \
             --vvm ./crates/test_util/data/model/sample.vvm \
             --onnxruntime "$onnxruntime" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,16 +113,16 @@ jobs:
       - run: cargo clippy -vp voicevox_core_build_features -F download
       - run: cargo clippy -vp voicevox_core_build_features -F link
       - run: cargo clippy -vp voicevox_core_build_features -F download,link
-      - run: cargo clippy -v --features load-onnxruntime --tests -- -D clippy::all -D warnings --no-deps
+      - run: cargo clippy -v --features load-onnxruntime --all-targets -- -D clippy::all -D warnings --no-deps
       - run: cargo clippy -v --features load-onnxruntime -- -D clippy::all -D warnings --no-deps
-      - run: cargo clippy -v -p voicevox_core -p voicevox_core_c_api --features link-onnxruntime --tests -- -D clippy::all -D warnings --no-deps
+      - run: cargo clippy -v -p voicevox_core -p voicevox_core_c_api --features link-onnxruntime --all-targets -- -D clippy::all -D warnings --no-deps
       - run: cargo clippy -v -p voicevox_core -p voicevox_core_c_api --features link-onnxruntime -- -D clippy::all -D warnings --no-deps
       - run: cargo +${{ steps.msrv-for-rust-api.outputs.rust-version }} check -vp voicevox_core_build_features
       - run: cargo +${{ steps.msrv-for-rust-api.outputs.rust-version }} check -vp voicevox_core_build_features -F download
       - run: cargo +${{ steps.msrv-for-rust-api.outputs.rust-version }} check -vp voicevox_core_build_features -F link
       - run: cargo +${{ steps.msrv-for-rust-api.outputs.rust-version }} check -vp voicevox_core_build_features -F download,link
-      - run: cargo +${{ steps.msrv-for-rust-api.outputs.rust-version }} check -vp voicevox_core --features load-onnxruntime
-      - run: cargo +${{ steps.msrv-for-rust-api.outputs.rust-version }} check -vp voicevox_core --features link-onnxruntime
+      - run: cargo +${{ steps.msrv-for-rust-api.outputs.rust-version }} check -vp voicevox_core --features load-onnxruntime --lib --examples
+      - run: cargo +${{ steps.msrv-for-rust-api.outputs.rust-version }} check -vp voicevox_core --features link-onnxruntime --lib --examples
       - run: cargo fmt -- --check
 
   rust-unit-test:
@@ -231,6 +231,41 @@ jobs:
         run: |
           cargo xtask update-c-header --verify
           git diff
+
+  build-and-test-rust-example:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+          - os: macos-latest
+          - os: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - name: Set up Rust
+        uses: ./.github/actions/rust-toolchain-from-file
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: ${{ matrix.os }}
+      - name: Exampleを実行
+        run: |
+          # `./target/voicevox_core/downloads/onnxruntime` and `./crates/test_util/data` are created in the build time
+          # shellcheck disable=SC2054
+          target_and_features=(--example talk -F load-onnxruntime,buildtime-download-onnxruntime)
+          cargo b "${target_and_features[@]}"
+          onnxruntime=$(find ../../target/voicevox_core/downloads/onnxruntime '(' -name onnxruntime.dll -o -name 'libonnxruntime.*' ')' -type f)
+          cargo r "${target_and_features[@]}" -- \
+            --vvm ./crates/test_util/data/model/sample.vvm \
+            --onnxruntime "$onnxruntime" \
+            --dict-dir ./crates/test_util/data/open_jtalk_dic_utf_8-1.11 \
+            --character dummy1 \
+            --style style1
 
   # TODO: "build-and-test-…"にする
   build-unix-cpp-example:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,8 +121,8 @@ jobs:
       - run: cargo +${{ steps.msrv-for-rust-api.outputs.rust-version }} check -vp voicevox_core_build_features -F download
       - run: cargo +${{ steps.msrv-for-rust-api.outputs.rust-version }} check -vp voicevox_core_build_features -F link
       - run: cargo +${{ steps.msrv-for-rust-api.outputs.rust-version }} check -vp voicevox_core_build_features -F download,link
-      - run: cargo +${{ steps.msrv-for-rust-api.outputs.rust-version }} check -vp voicevox_core --features load-onnxruntime --lib --examples
-      - run: cargo +${{ steps.msrv-for-rust-api.outputs.rust-version }} check -vp voicevox_core --features link-onnxruntime --lib --examples
+      - run: cargo +${{ steps.msrv-for-rust-api.outputs.rust-version }} check -vp voicevox_core --features load-onnxruntime
+      - run: cargo +${{ steps.msrv-for-rust-api.outputs.rust-version }} check -vp voicevox_core --features link-onnxruntime
       - run: cargo fmt -- --check
 
   rust-unit-test:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4967,6 +4967,7 @@ dependencies = [
  "blocking",
  "bytemuck",
  "camino",
+ "clap",
  "codspeed-divan-compat",
  "const_format",
  "derive-getters",

--- a/crates/voicevox_core/Cargo.toml
+++ b/crates/voicevox_core/Cargo.toml
@@ -10,6 +10,10 @@ license.workspace = true
 features = ["load-onnxruntime", "link-onnxruntime"]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[[example]]
+name = "talk"
+required-features = ["load-onnxruntime"] # TODO: 将来的には`link-onnxruntime`でも動くようにする
+
 [[bench]]
 name = "simulation"
 harness = false
@@ -77,6 +81,7 @@ uuid = { workspace = true, features = ["v4", "serde"] }
 voicevox_core_macros.workspace = true
 
 [dev-dependencies]
+clap = { workspace = true, features = ["derive"] }
 divan.workspace = true
 open.workspace = true
 pollster = { workspace = true, features = ["macro"] }

--- a/crates/voicevox_core/examples/talk.rs
+++ b/crates/voicevox_core/examples/talk.rs
@@ -3,17 +3,16 @@ use std::fs;
 use anyhow::Context as _;
 use camino::Utf8PathBuf;
 use clap::Parser;
+use const_format::formatcp;
 use voicevox_core::blocking::{Onnxruntime, OpenJtalk, Synthesizer, VoiceModelFile};
 
-use const_format::formatcp;
-
-const VOICEXVOX_CORE_DIR: &str = "./voicevox_core";
+const VOICEVOX_CORE_DIR: &str = "./voicevox_core";
 const DEFAULT_ONNXRUNTIME: &str = formatcp!(
-    "{VOICEXVOX_CORE_DIR}/onnxruntime/lib/{}",
+    "{VOICEVOX_CORE_DIR}/onnxruntime/lib/{}",
     Onnxruntime::LIB_VERSIONED_FILENAME,
 );
-const DEFAULT_MODEL: &str = formatcp!("{VOICEXVOX_CORE_DIR}/models/vvms/0.vvm");
-const DEFAULT_DICT: &str = formatcp!("{VOICEXVOX_CORE_DIR}/dict/open_jtalk_dic_utf_8-1.11");
+const DEFAULT_MODEL: &str = formatcp!("{VOICEVOX_CORE_DIR}/models/vvms/0.vvm");
+const DEFAULT_DICT: &str = formatcp!("{VOICEVOX_CORE_DIR}/dict/open_jtalk_dic_utf_8-1.11");
 
 /// テキスト音声合成を行うサンプルコードです。
 ///


### PR DESCRIPTION
## 内容

#1352 で入れたexampleに対して次の対応を行う。

1. `dev-dependencies`の不足によりコンパイルすらできなかった状態を解決
2. `required-features`を設定
3. <https://github.com/VOICEVOX/voicevox_core/pull/1352#pullrequestreview-4302902354>で宣言した通りCI (`test.yml`)を更新
4. typoを直す

## その他

上記のすべては前もって気づけたはずなので、#1352のマージ前にせめてAIレビューすればよかったかも。
