### PR TITLE
ci(codspeed): `open_and_close_vvm`を再び対象外にする

### DIFF
--- a/crates/voicevox_core/benches/simulation.rs
+++ b/crates/voicevox_core/benches/simulation.rs
@@ -71,15 +71,6 @@ mod blocking {
         bencher.bench_local(|| ojt.analyze(input.value).unwrap());
     }
 
-    #[divan::bench(sample_count = 300, sample_size = 10)]
-    fn open_and_close_vvm(bencher: Bencher<'_, '_>) {
-        bencher.bench_local(|| {
-            divan::black_box_drop(
-                VoiceModelFile::open(test_util::SAMPLE_VOICE_MODEL_FILE_PATH).unwrap(),
-            );
-        });
-    }
-
     #[divan::bench(args = InputText::ALL, sample_count = 300, sample_size = 10)]
     fn replace_mora_pitch(bencher: Bencher<'_, '_>, input: InputText) {
         let (synth, _) = &*FIXTURE;


### PR DESCRIPTION
## 内容

#1356 でベンチマークをかなり絞ったが、`open_and_close_vvm`がどうやら駄目っぽいのでこれも外す。`simulation`ではI/Oが主なやつは完全にやめておいた方がよさげ。

GHA上で無理矢理`walltime`を実行していたときにやっていた #1169 と同じ対応（`git commit -am`の履歴補完に出るまで完全に忘れていた）。あちらは単純に実行時間のブレが凄まじかったという理由であるが。

