### PR TITLE
chore: C API以外の開発にClangを要求しないようにする

### DIFF
--- a/crates/test_util/Cargo.toml
+++ b/crates/test_util/Cargo.toml
@@ -4,6 +4,10 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 
+[features]
+default = []
+c-api = ["dep:bindgen"]
+
 [dependencies]
 libloading.workspace = true
 serde = { workspace = true, features = ["derive"] }
@@ -12,7 +16,7 @@ serde_json.workspace = true
 [build-dependencies]
 anyhow.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-bindgen.workspace = true
+bindgen = { workspace = true, optional = true }
 camino.workspace = true
 flate2.workspace = true
 fs-err.workspace = true

--- a/crates/test_util/build.rs
+++ b/crates/test_util/build.rs
@@ -34,7 +34,10 @@ async fn main() -> anyhow::Result<()> {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=src/typing.rs");
 
-    generate_c_api_rs_bindings(out_dir)
+    #[cfg(feature = "c-api")]
+    generate_c_api_rs_bindings(out_dir)?;
+
+    Ok(())
 }
 
 fn create_sample_voice_model_file(out_dir: &Utf8Path, dist: &Utf8Path) -> anyhow::Result<()> {
@@ -83,7 +86,9 @@ fn create_sample_voice_model_file(out_dir: &Utf8Path, dist: &Utf8Path) -> anyhow
         formatdoc! {"
             pub const SAMPLE_VOICE_MODEL_FILE_PATH: &::std::primitive::str = {output_file:?};
 
+            #[cfg(feature = \"c-api\")]
             const SAMPLE_VOICE_MODEL_FILE_C_PATH: &::std::ffi::CStr = c{output_file:?};
+            #[cfg(feature = \"c-api\")]
             const VV_MODELS_ROOT_DIR: &::std::primitive::str = {output_dir:?};
             ",
         },
@@ -209,6 +214,7 @@ fn generate_example_data_json(dist: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "c-api")]
 fn generate_c_api_rs_bindings(out_dir: &Utf8Path) -> anyhow::Result<()> {
     static C_BINDINGS_PATH: &str = "../voicevox_core_c_api/include/voicevox_core.h";
     static ADDITIONAL_C_BINDINGS_PATH: &str = "./compatible_engine.h";

--- a/crates/test_util/src/lib.rs
+++ b/crates/test_util/src/lib.rs
@@ -13,6 +13,7 @@ include!(concat!(env!("OUT_DIR"), "/sample_voice_model_file.rs"));
     reason = "bindgenが生成するコードのため。`#[expect]`ではなく`#[allow]`なのは、bindgenが生成\
               するコードがOSにより変わるため"
 )]
+#[cfg(feature = "c-api")]
 pub mod c_api {
     include!(concat!(env!("OUT_DIR"), "/c_api.rs"));
 

--- a/crates/voicevox_core_c_api/Cargo.toml
+++ b/crates/voicevox_core_c_api/Cargo.toml
@@ -61,7 +61,7 @@ regex.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_with.workspace = true
 tempfile.workspace = true
-test_util.workspace = true
+test_util = { workspace = true, features = ["c-api"] }
 toml.workspace = true
 typetag.workspace = true
 


### PR DESCRIPTION
## 内容

現在C APIのテストにはClangが必要。経路としては`voicevox_core_c_api` → `test_util` → `bindgen` → Clang。しかしC API以外にも使われる`test_util`がClangを要求するという形になってしまっており、Rust APIやPython APIのテストを動かすのにもClangが必要という状態になっていた。
(cf. #1353, https://github.com/VOICEVOX/voicevox_core/pull/1363#issuecomment-4623421288)

そのため`test_util` → `bindgen`の経路をfeature-gateし、C APIの開発でのみClangを要求するようにする。

厳密に言えばiOSのRust APIビルドでは`xcrun clang --print-resource-dir`ということがされているが、前述の方の「Clangが必要」とは違うはず。
