### PR TITLE
chore: このリポジトリでのORTダウンロードは`test_util`側でやる

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,7 +3,6 @@ xtask = "run -p xtask --"
 
 [env]
 CARGO_WORKSPACE_DIR = { value = "", relative = true }
-VVCORE_BUILD_DOWNLOAD_AND_COPY_ORT = "1"
 
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -42,7 +42,7 @@ jobs:
         run: cargo check -vp test_util
 
       - name: Build
-        run: cargo codspeed build -p voicevox_core --bench simulation --features buildtime-download-onnxruntime,load-onnxruntime -m simulation
+        run: cargo codspeed build -p voicevox_core --bench simulation --features load-onnxruntime -m simulation
 
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@93bbfdc546455345ae00c6f4e100a37838b37bcf # v4.14.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -314,13 +314,9 @@ jobs:
           (cd crates/voicevox_core_python_api && poetry install --with dev)
           maturin build --manifest-path ./crates/voicevox_core_python_api/Cargo.toml --target ${{ matrix.target }} --release
           echo "whl=$(find ./target/wheels -type f)" >> "$GITHUB_OUTPUT"
-        env:
-          VVCORE_BUILD_DOWNLOAD_AND_COPY_ORT: '0'
       - name: build voicevox_core_java_api
         if: ${{ matrix.java }}
         run: cargo build -p voicevox_core_java_api -vv --target ${{ matrix.target }} --release
-        env:
-          VVCORE_BUILD_DOWNLOAD_AND_COPY_ORT: '0'
       - name: Organize artifact
         run: |
           mkdir -p artifact/${{ env.ASSET_NAME }}/{include,lib}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,8 +81,6 @@ jobs:
 
   rust-lint:
     runs-on: windows-latest
-    env:
-      VVCORE_BUILD_DOWNLOAD_AND_COPY_ORT: '0'
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - name: Extract Rust API's MSRV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -256,7 +256,7 @@ jobs:
         run: |
           # `./target/voicevox_core/downloads/onnxruntime` and `./crates/test_util/data` are created in the build time
           # shellcheck disable=SC2054
-          target_and_features=(--example talk -F load-onnxruntime,buildtime-download-onnxruntime)
+          target_and_features=(--example talk -F load-onnxruntime)
           cargo b "${target_and_features[@]}"
           onnxruntime=$(find ./target/voicevox_core/downloads/onnxruntime '(' -name onnxruntime.dll -o -name 'libonnxruntime.*' ')' -type f)
           cargo r "${target_and_features[@]}" -- \
@@ -377,7 +377,7 @@ jobs:
           poetry install --with dev --with test
       - run: cargo build -p test_util -v # build scriptにより/crates/test_util/data/の生成
       - run: poetry run maturin build --locked
-      - run: poetry run maturin develop -F voicevox_core/buildtime-download-onnxruntime --locked
+      - run: poetry run maturin develop --locked
       - name: pytestを実行
         run: poetry run pytest ./python/test/
       - name: Exampleを実行
@@ -430,7 +430,7 @@ jobs:
           # TODO: リポジトリとしてシンボリックリンクを張るか、コピーするべき
           cp ./gradle/wrapper/gradle-wrapper.jar ../../example/kotlin/gradle/wrapper/
 
-          cargo build -p voicevox_core_java_api -F voicevox_core/buildtime-download-onnxruntime -v
+          cargo build -p voicevox_core_java_api -v
           cargo build -p test_util -v # build scriptにより/crates/test_util/data/の生成
           mkdir -p "./lib/src/main/resources/dll/$TARGET_NAME"
           cp -v "../../target/debug/$DLL_NAME" "./lib/src/main/resources/dll/$TARGET_NAME/$DLL_NAME"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4364,6 +4364,7 @@ dependencies = [
  "serde_json",
  "tar",
  "tokio",
+ "voicevox_core_build_features",
  "zip",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5016,7 +5016,6 @@ dependencies = [
  "typed_floats",
  "typeshare",
  "uuid",
- "voicevox_core",
  "voicevox_core_build_features",
  "voicevox_core_macros",
  "windows",

--- a/crates/test_util/Cargo.toml
+++ b/crates/test_util/Cargo.toml
@@ -25,6 +25,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
 reqwest.workspace = true
 tar.workspace = true
+voicevox_core_build_features = { workspace = true, features = ["download"] }
 zip.workspace = true
 
 [lints.rust]

--- a/crates/test_util/build.rs
+++ b/crates/test_util/build.rs
@@ -16,8 +16,15 @@ mod typing;
 
 const DIC_DIR_NAME: &str = "open_jtalk_dic_utf_8-1.11";
 
+fn main() -> anyhow::Result<()> {
+    // Tokio内で`reqwest::blocking`を使ったらどうやら駄目らしいので、これだけTokioの外で実行
+    build_features::download::download(false)?;
+
+    run()
+}
+
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn run() -> anyhow::Result<()> {
     let out_dir = &Utf8PathBuf::from(env::var("OUT_DIR").unwrap());
     let dist = &Utf8Path::new(env!("CARGO_MANIFEST_DIR")).join("data");
 
@@ -26,8 +33,6 @@ async fn main() -> anyhow::Result<()> {
         download_open_jtalk_dict(dist.as_ref()).await?;
         ensure!(dic_dir.exists(), "`{dic_dir}` does not exist");
     }
-
-    build_features::download::download(false)?;
 
     create_sample_voice_model_file(out_dir, dist)?;
 

--- a/crates/test_util/build.rs
+++ b/crates/test_util/build.rs
@@ -27,6 +27,8 @@ async fn main() -> anyhow::Result<()> {
         ensure!(dic_dir.exists(), "`{dic_dir}` does not exist");
     }
 
+    build_features::download::download(false)?;
+
     create_sample_voice_model_file(out_dir, dist)?;
 
     generate_example_data_json(dist.as_ref())?;

--- a/crates/voicevox_core/Cargo.toml
+++ b/crates/voicevox_core/Cargo.toml
@@ -90,7 +90,6 @@ rstest.workspace = true
 rstest_reuse.workspace = true
 test_util.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
-voicevox_core = { workspace = true, features = ["buildtime-download-onnxruntime"] }
 
 [build-dependencies]
 voicevox_core_build_features.workspace = true

--- a/crates/voicevox_core_c_api/tests/e2e/main.rs
+++ b/crates/voicevox_core_c_api/tests/e2e/main.rs
@@ -22,10 +22,7 @@ fn main() -> anyhow::Result<()> {
     enum TestContext {}
 
     impl assert_cdylib::TestContext for TestContext {
-        const FEATURES: &'static [&'static str] = &[
-            "voicevox_core/buildtime-download-onnxruntime",
-            "load-onnxruntime",
-        ];
+        const FEATURES: &'static [&'static str] = &["load-onnxruntime"];
         const TARGET_DIR: &'static str = "../../target";
         const CDYLIB_NAME: &'static str = "voicevox_core";
         const RUNTIME_ENVS: &'static [(&'static str, &'static str)] =


### PR DESCRIPTION
## 内容

#1278 以前のように、`test_util`の起動で純正ONNX Runtimeがダウンロード・配置されるようにする。また、テスト目的で`voicevox_core/buildtime-download-onnxruntime`を使わないようにする。

第一の理由としては、ビルド済みwhlでpytestするといったことをやりやすくするため。

第二の理由としては今後 #1278 の方針を一部撤回し、test_util/data下にORTを置くようにしたいため。
(というのも現在はCargoのtarget directoryが固定の位置にいると仮定してしまっているため、Gitのworktreeが使い辛い。)

第三の理由としては.cargo/config.tomlで`VVCORE_BUILD_DOWNLOAD_AND_COPY_ORT=1`をするというややこしい状況を変えたいため。
