### PR TITLE
chore: ONNX Runtimeを再びtest_util/data/にコピーするように

### DIFF
--- a/crates/test_util/build.rs
+++ b/crates/test_util/build.rs
@@ -18,13 +18,13 @@ const DIC_DIR_NAME: &str = "open_jtalk_dic_utf_8-1.11";
 
 fn main() -> anyhow::Result<()> {
     // Tokio内で`reqwest::blocking`を使ったらどうやら駄目らしいので、これだけTokioの外で実行
-    build_features::download::download(false)?;
+    let onnxruntime_path = &build_features::download::download(false)?;
 
-    run()
+    run(onnxruntime_path)
 }
 
 #[tokio::main]
-async fn run() -> anyhow::Result<()> {
+async fn run(onnxruntime_path: &Utf8Path) -> anyhow::Result<()> {
     let out_dir = &Utf8PathBuf::from(env::var("OUT_DIR").unwrap());
     let dist = &Utf8Path::new(env!("CARGO_MANIFEST_DIR")).join("data");
 
@@ -33,6 +33,8 @@ async fn run() -> anyhow::Result<()> {
         download_open_jtalk_dict(dist.as_ref()).await?;
         ensure!(dic_dir.exists(), "`{dic_dir}` does not exist");
     }
+
+    copy_onnxruntime(onnxruntime_path, out_dir.as_ref(), dist)?;
 
     create_sample_voice_model_file(out_dir, dist)?;
 
@@ -45,6 +47,14 @@ async fn run() -> anyhow::Result<()> {
     generate_c_api_rs_bindings(out_dir)?;
 
     Ok(())
+}
+
+fn copy_onnxruntime(src: &Utf8Path, out_dir: &Path, dist: &Utf8Path) -> io::Result<()> {
+    let dst_dir = &dist.join("lib");
+    let dst = &dst_dir.join(src.file_name().expect("should exist"));
+    fs_err::create_dir_all(dst_dir)?;
+    fs_err::copy(src, dst)?;
+    fs_err::write(out_dir.join("onnxruntime-dylib-path.txt"), dst.as_str())
 }
 
 fn create_sample_voice_model_file(out_dir: &Utf8Path, dist: &Utf8Path) -> anyhow::Result<()> {

--- a/crates/test_util/build.rs
+++ b/crates/test_util/build.rs
@@ -52,8 +52,16 @@ async fn run(onnxruntime_path: &Utf8Path) -> anyhow::Result<()> {
 fn copy_onnxruntime(src: &Utf8Path, out_dir: &Path, dist: &Utf8Path) -> io::Result<()> {
     let dst_dir = &dist.join("lib");
     let dst = &dst_dir.join(src.file_name().expect("should exist"));
-    fs_err::create_dir_all(dst_dir)?;
-    fs_err::copy(src, dst)?;
+    let stale = match fs_err::metadata(dst) {
+        Ok(md) => md.modified()? < fs_err::metadata(src)?.modified()?,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => true,
+        Err(e) => return Err(e),
+    };
+    if stale {
+        fs_err::create_dir_all(dst_dir)?;
+        fs_err::copy(src, dst)?;
+    }
+    println!("cargo:rerun-if-changed={dst}");
     fs_err::write(out_dir.join("onnxruntime-dylib-path.txt"), dst.as_str())
 }
 

--- a/crates/test_util/src/lib.rs
+++ b/crates/test_util/src/lib.rs
@@ -26,36 +26,8 @@ use std::sync::LazyLock;
 pub use self::typing::{
     DecodeExampleData, DurationExampleData, ExampleData, IntonationExampleData,
 };
-
-pub const ONNXRUNTIME_DYLIB_PATH: &str = {
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
-    macro_rules! version {
-        () => {
-            include_str!("../../../onnxruntime-version.txt")
-        };
-    }
-
-    cfg_select! {
-        target_os = "windows" => concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../target/voicevox_core/downloads/onnxruntime/",
-            "onnxruntime.dll",
-        ),
-        target_os = "linux" => concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../target/voicevox_core/downloads/onnxruntime/",
-            "libonnxruntime.so.",
-            version!(),
-        ),
-        target_os = "macos" => concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../target/voicevox_core/downloads/onnxruntime/",
-            "libonnxruntime.",
-            version!(),
-            ".dylib",
-        ),
-    }
-};
+pub const ONNXRUNTIME_DYLIB_PATH: &str =
+    include_str!(concat!(env!("OUT_DIR"), "/onnxruntime-dylib-path.txt"));
 
 pub const OPEN_JTALK_DIC_DIR: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),

--- a/crates/voicevox_core_build_features/src/download.rs
+++ b/crates/voicevox_core_build_features/src/download.rs
@@ -19,7 +19,7 @@ static TARGET: LazyLock<String> = LazyLock::new(|| env::var("TARGET").unwrap());
 static OUT_DIR: LazyLock<Utf8PathBuf> =
     LazyLock::new(|| env::var("OUT_DIR").expect("`$OUT_DIR` is not UTF-8").into());
 
-pub fn download(add_link_search: bool) -> anyhow::Result<()> {
+pub fn download(add_link_search: bool) -> anyhow::Result<Utf8PathBuf> {
     let up_to_date = {
         let current_exe_mtime =
             fs_err::metadata(process_path::get_executable_path().unwrap())?.modified()?;
@@ -63,7 +63,7 @@ pub fn download(add_link_search: bool) -> anyhow::Result<()> {
         .with_context(|| format!("`{}` not found in onnxruntime-libs.toml", *TARGET))?;
 
     let lib_versioned_file_name = &lib_versioned_file_name(VERSION)?;
-    let lib_path = &lib_dir.join(lib_versioned_file_name);
+    let lib_path = lib_dir.join(lib_versioned_file_name);
 
     let importlib_path = &importlib_file_name().map(|s| lib_dir.join(s));
 
@@ -71,7 +71,7 @@ pub fn download(add_link_search: bool) -> anyhow::Result<()> {
         Some(lib_unversioned_file_name()?).filter(|s| s != lib_versioned_file_name);
 
     // TODO: MSRVを1.91にしたら`std::iter::chain`にする
-    if !itertools::chain([lib_path], importlib_path)
+    if !itertools::chain([&lib_path], importlib_path)
         .map(|p| up_to_date(p.as_ref()))
         .collect::<Result<Vec<_>, _>>()?
         .into_iter()
@@ -88,7 +88,7 @@ pub fn download(add_link_search: bool) -> anyhow::Result<()> {
 
         let lib_content = &extract_lib(tgz, lib_versioned_file_name)?;
         verify(lib_content, lib_sha256)?;
-        fs_err::write(lib_path, lib_content)?;
+        fs_err::write(&lib_path, lib_content)?;
 
         if let Some(importlib_path) = importlib_path {
             let importlib_sha256 =
@@ -109,7 +109,7 @@ pub fn download(add_link_search: bool) -> anyhow::Result<()> {
         if dst.is_symlink() {
             fs_err::remove_file(dst)?;
         }
-        symlink_or_copy(lib_path, dst)?;
+        symlink_or_copy(&lib_path, dst)?;
         println!("cargo::rerun-if-changed={dst}");
     }
 
@@ -126,12 +126,12 @@ pub fn download(add_link_search: bool) -> anyhow::Result<()> {
                 if dst.is_symlink() {
                     fs_err::remove_file(dst)?;
                 }
-                symlink_or_copy(lib_path, dst)?;
+                symlink_or_copy(&lib_path, dst)?;
             }
             println!("cargo::rerun-if-changed={dst}");
         }
     }
-    Ok(())
+    Ok(lib_path)
 }
 
 fn lib_versioned_file_name(version: &str) -> anyhow::Result<String> {

--- a/crates/voicevox_core_java_api/lib/src/test/java/jp/hiroshiba/voicevoxcore/TestUtils.java
+++ b/crates/voicevox_core_java_api/lib/src/test/java/jp/hiroshiba/voicevoxcore/TestUtils.java
@@ -20,7 +20,7 @@ public class TestUtils {
 
   protected Onnxruntime loadOnnxruntime() {
     final String FILENAME =
-        "../../../target/voicevox_core/downloads/onnxruntime/"
+        "../../test_util/data/lib/"
             + Onnxruntime.LIB_VERSIONED_FILENAME.replace("voicevox_onnxruntime", "onnxruntime");
 
     try {

--- a/crates/voicevox_core_python_api/python/benches/test_tts.py
+++ b/crates/voicevox_core_python_api/python/benches/test_tts.py
@@ -10,11 +10,10 @@ from pytest_codspeed import BenchmarkFixture
 from voicevox_core import StyleId
 
 ONNXRUNTIME_FILENAME = str(
-    Path(__file__).parent.parent.parent.parent.parent
-    / "target"
-    / "voicevox_core"
-    / "downloads"
-    / "onnxruntime"
+    Path(__file__).parent.parent.parent.parent
+    / "test_util"
+    / "data"
+    / "lib"
     / voicevox_core.blocking.Onnxruntime.LIB_VERSIONED_FILENAME.replace(
         "voicevox_onnxruntime", "onnxruntime"
     )

--- a/crates/voicevox_core_python_api/python/test/conftest.py
+++ b/crates/voicevox_core_python_api/python/test/conftest.py
@@ -9,11 +9,10 @@ import voicevox_core
 root_dir = Path(os.path.dirname(os.path.abspath(__file__)))
 
 onnxruntime_filename = str(
-    root_dir.parent.parent.parent.parent
-    / "target"
-    / "voicevox_core"
-    / "downloads"
-    / "onnxruntime"
+    Path(__file__).parent.parent.parent.parent
+    / "test_util"
+    / "data"
+    / "lib"
     / voicevox_core.blocking.Onnxruntime.LIB_VERSIONED_FILENAME.replace(
         "voicevox_onnxruntime", "onnxruntime"
     )

--- a/crates/voicevox_core_python_api/python/test/conftest.py
+++ b/crates/voicevox_core_python_api/python/test/conftest.py
@@ -9,7 +9,7 @@ import voicevox_core
 root_dir = Path(os.path.dirname(os.path.abspath(__file__)))
 
 onnxruntime_filename = str(
-    Path(__file__).parent.parent.parent.parent
+    root_dir.parent.parent.parent
     / "test_util"
     / "data"
     / "lib"


### PR DESCRIPTION
## 内容

#1372 でやったことに一貫性を持たせるため。

#1278 以前のようにコピーする形だが、`cargo metadata`は不要になったので呼ばない。

このPRにより #1361 はC APIのみの変更になる予定。
