### PR TITLE
refactor: 不要な`workspace.dependencies`を削除

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ boxcar = "0.2.6"
 bytemuck = "1.24.0"
 bytes = "1.11.1"
 camino = "1.1.9"
-cargo_metadata = "0.18.1"
 cbindgen = "0.28.0"
 chrono = { version = "0.4.38", default-features = false }
 clap = { version = "4.5.19", features = ["cargo"] }


### PR DESCRIPTION
## 内容

#1278 で消し忘れていた。
