### PR TITLE
chore: `xtask`の未使用依存を削除

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5795,7 +5795,6 @@ dependencies = [
  "clap",
  "color-eyre",
  "eyre",
- "fs-err",
 ]
 
 [[package]]

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -9,7 +9,6 @@ cbindgen.workspace = true
 clap = { workspace = true, features = ["derive"] }
 color-eyre.workspace = true
 eyre.workspace = true
-fs-err.workspace = true
 
 [lints.rust]
 unsafe_code = "forbid"


### PR DESCRIPTION
## その他

[cargo-udeps](https://crates.io/crates/cargo-udeps)で発見。
