### PR TITLE
feat: OpenVINO Execution Provider 対応（Intel Arc / Xe 向け）

### DIFF
--- a/crates/voicevox_core/src/core/devices.rs
+++ b/crates/voicevox_core/src/core/devices.rs
@@ -86,6 +86,12 @@ pub struct SupportedDevices {
     ///
     /// [DirectML Execution Provider]: https://onnxruntime.ai/docs/execution-providers/DirectML-ExecutionProvider.html
     pub dml: bool,
+    /// OpenVINOが利用可能。
+    ///
+    /// ONNX Runtimeの[OpenVINO Execution Provider] (`OpenVINOExecutionProvider`)に対応する。必要な環境についてはそちらを参照。
+    ///
+    /// [OpenVINO Execution Provider]: https://onnxruntime.ai/docs/execution-providers/OpenVINO-ExecutionProvider.html
+    pub openvino: bool,
 }
 
 impl SupportedDevices {
@@ -98,6 +104,7 @@ impl SupportedDevices {
     /// # use voicevox_core::SupportedDevices;
     /// assert!(SupportedDevices::THIS.cuda);
     /// assert!(SupportedDevices::THIS.dml);
+    /// assert!(SupportedDevices::THIS.openvino);
     /// ```
     ///
     /// `link-onnxruntime`のフィーチャが有効化されているときは`cpu`を除き`false`となる。
@@ -107,18 +114,21 @@ impl SupportedDevices {
     /// # use voicevox_core::SupportedDevices;
     /// assert!(!SupportedDevices::THIS.cuda);
     /// assert!(!SupportedDevices::THIS.dml);
+    /// assert!(!SupportedDevices::THIS.openvino);
     /// ```
     pub const THIS: Self = if cfg!(feature = "load-onnxruntime") {
         Self {
             cpu: true,
             cuda: true,
             dml: true,
+            openvino: true,
         }
     } else if cfg!(feature = "link-onnxruntime") {
         Self {
             cpu: true,
             cuda: false,
             dml: false,
+            openvino: false,
         }
     } else {
         panic!("either `load-onnxruntime` or `link-onnxruntime` must be enabled");
@@ -190,13 +200,16 @@ pub(crate) enum GpuSpec {
     #[display("CUDA (device_id=0)")]
     Cuda,
 
+    #[display("OpenVINO")]
+    OpenVino,
+
     #[display("DirectML (device_id=0)")]
     Dml,
 }
 
 impl GpuSpec {
     pub(crate) fn defaults() -> Vec<Self> {
-        vec![Self::Cuda, Self::Dml]
+        vec![Self::Cuda, Self::OpenVino, Self::Dml]
     }
 }
 
@@ -206,6 +219,7 @@ impl Index<GpuSpec> for SupportedDevices {
     fn index(&self, gpu: GpuSpec) -> &Self::Output {
         match gpu {
             GpuSpec::Cuda => &self.cuda,
+            GpuSpec::OpenVino => &self.openvino,
             GpuSpec::Dml => &self.dml,
         }
     }
@@ -227,8 +241,13 @@ mod tests {
                     unused_variables,
                     reason = "比較対象としてここは網羅されてなければなりません"
                 )]
-                let SupportedDevices { cpu: _, cuda, dml } = &SUPPORTED_DEVICES;
-                [&raw const *cuda, &raw const *dml]
+                let SupportedDevices {
+                    cpu: _,
+                    cuda,
+                    dml,
+                    openvino,
+                } = &SUPPORTED_DEVICES;
+                [&raw const *cuda, &raw const *openvino, &raw const *dml]
             },
             *GpuSpec::defaults()
                 .into_iter()

--- a/crates/voicevox_core/src/core/infer/runtimes/onnxruntime.rs
+++ b/crates/voicevox_core/src/core/infer/runtimes/onnxruntime.rs
@@ -27,7 +27,7 @@ use ort::{
     environment::Environment,
     ep::{
         CPUExecutionProvider, CUDAExecutionProvider, DirectMLExecutionProvider,
-        ExecutionProvider as _, cuda::ConvAlgorithmSearch,
+        ExecutionProvider as _, OpenVINOExecutionProvider, cuda::ConvAlgorithmSearch,
     },
     session::{RunOptions, builder::GraphOptimizationLevel},
     value::{PrimitiveTensorElementType, TensorElementType, ValueType},
@@ -254,6 +254,7 @@ impl InferenceRuntime for self::blocking::Onnxruntime {
             let cpu = CPUExecutionProvider::default().is_available()?;
             let cuda = CUDAExecutionProvider::default().is_available()?;
             let dml = DirectMLExecutionProvider::default().is_available()?;
+            let openvino = OpenVINOExecutionProvider::default().is_available()?;
 
             ensure!(cpu, "missing `CPUExecutionProvider`");
 
@@ -261,6 +262,7 @@ impl InferenceRuntime for self::blocking::Onnxruntime {
                 cpu: true,
                 cuda,
                 dml,
+                openvino,
             })
         })()
         .map_err(ErrorRepr::GetSupportedDevices)
@@ -273,6 +275,7 @@ impl InferenceRuntime for self::blocking::Onnxruntime {
             GpuSpec::Cuda => CUDAExecutionProvider::default()
                 .with_conv_algorithm_search(ConvAlgorithmSearch::Default)
                 .register(sess_builder),
+            GpuSpec::OpenVino => openvino_gpu_execution_provider().register(sess_builder),
             GpuSpec::Dml => DirectMLExecutionProvider::default().register(sess_builder),
         }
         .map_err(Into::into)
@@ -302,6 +305,9 @@ impl InferenceRuntime for self::blocking::Onnxruntime {
                 CUDAExecutionProvider::default()
                     .with_conv_algorithm_search(ConvAlgorithmSearch::Default)
                     .register(&mut builder)?;
+            }
+            DeviceSpec::Gpu(GpuSpec::OpenVino) => {
+                openvino_gpu_execution_provider().register(&mut builder)?;
             }
             DeviceSpec::Gpu(GpuSpec::Dml) => {
                 builder = builder
@@ -477,6 +483,30 @@ impl InferenceRuntime for self::blocking::Onnxruntime {
             ::blocking::unblock(move || extract_outputs(&sess.lock_blocking().run(inputs)?)).await
         }
     }
+}
+
+fn openvino_gpu_execution_provider() -> OpenVINOExecutionProvider {
+    // Defaults tuned for Intel Arc (Xe / Battlemage), all overridable by env var:
+    // - `AUTO:GPU,CPU` serves the first inferences on CPU while the GPU graph
+    //   compiles in the background, then moves to the GPU — this hides OpenVINO's
+    //   multi-second GPU compile instead of blocking the first synthesis on it.
+    // - `FP16` engages the Xe matrix engines (XMX) for a large decode speedup.
+    // - `cache_dir` persists the compiled GPU blob across process restarts.
+    let device_type =
+        std::env::var("VV_OPENVINO_DEVICE_TYPE").unwrap_or_else(|_| "AUTO:GPU,CPU".to_owned());
+    let precision = std::env::var("VV_OPENVINO_PRECISION").unwrap_or_else(|_| "FP16".to_owned());
+    let cache_dir = std::env::var("VV_OPENVINO_CACHE_DIR").unwrap_or_else(|_| {
+        std::env::temp_dir()
+            .join("voicevox-openvino-cache")
+            .to_string_lossy()
+            .into_owned()
+    });
+    let _ = std::fs::create_dir_all(&cache_dir);
+
+    OpenVINOExecutionProvider::default()
+        .with_device_type(device_type)
+        .with_precision(precision)
+        .with_cache_dir(cache_dir)
 }
 
 pub(crate) struct OnnxruntimeRunContext {

--- a/crates/voicevox_core/src/lib.rs
+++ b/crates/voicevox_core/src/lib.rs
@@ -5,7 +5,7 @@
 //! - **`buildtime-download-onnxruntime`**: ビルド時に後述する環境変数`VVCORE_BUILD_DOWNLOAD_AND_COPY_ORT`が`1`なら、ONNX
 //!   Runtimeのバイナリをダウンロードしてtarget
 //!   directory内の複数箇所に配置する。`VVCORE_BUILD_DOWNLOAD_AND_COPY_ORT`が`1`ではないなら警告を出して何もしない。後述の`link-onnxruntime`フィーチャと合わせると、システムにONNX Runtimeが無くてもビルドが可能になる。
-//! - **`load-onnxruntime`**: ONNX Runtimeを`dlopen`/`LoadLibraryExW`で開く。[CUDA]と[DirectML]が利用可能。
+//! - **`load-onnxruntime`**: ONNX Runtimeを`dlopen`/`LoadLibraryExW`で開く。[CUDA]、[DirectML]、[OpenVINO]が利用可能。
 //!   またmuslをターゲットとしたビルドでは`dlopen`をサポートしないため、このフラグは利用不可であるため、`link-onnxruntime`を利用する必要がある。
 //! - **`link-onnxruntime`**: ONNX Runtimeをロード時動的リンクする。そのためビルドするためにはシステムにONNX
 //!   Runtimeがインストールされているか、`buildtime-download-onnxruntime`によるダウンロードを行う必要がある。iOSのような`dlopen`の利用が困難な環境でのみこちらを利用するべきである。_Note_:
@@ -22,6 +22,7 @@
 //! [Cargoフィーチャ]: https://doc.rust-lang.org/stable/cargo/reference/features.html
 //! [CUDA]: https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html
 //! [DirectML]: https://onnxruntime.ai/docs/execution-providers/DirectML-ExecutionProvider.html
+//! [OpenVINO]: https://onnxruntime.ai/docs/execution-providers/OpenVINO-ExecutionProvider.html
 //! [動的リンク対象のライブラリ名]:
 //! https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-link-lib
 //! [`Onnxruntime`]: blocking::Onnxruntime

--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/SupportedDevices.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/SupportedDevices.java
@@ -7,7 +7,7 @@ import jakarta.annotation.Nonnull;
 /**
  * ONNX Runtime利用可能なデバイスの情報。
  *
- * <p>あくまでONNX Runtimeが対応しているデバイスの情報であることに注意。GPUが使える環境ではなかったとしても {@link #cuda} や {@link #dml} は
+ * <p>あくまでONNX Runtimeが対応しているデバイスの情報であることに注意。GPUが使える環境ではなかったとしても {@link #cuda} や {@link #dml} や {@link #openvino} は
  * {@code true} を示しうる。
  *
  * <p>現在この型はGSONに対応しているが、将来的には <a href="https://github.com/VOICEVOX/voicevox_core/issues/984"
@@ -50,14 +50,27 @@ public class SupportedDevices implements Cloneable {
   @Nonnull
   public final boolean dml;
 
+  /**
+   * OpenVINOが利用可能。
+   *
+   * <p>ONNX Runtimeの <a href=
+   * "https://onnxruntime.ai/docs/execution-providers/OpenVINO-ExecutionProvider.html"
+   * target="_blank">OpenVINOExecutionProvider</a>に対応する。 必要な環境についてはそちらを参照。
+   */
+  @SerializedName("openvino")
+  @Expose
+  @Nonnull
+  public final boolean openvino;
+
   private SupportedDevices() {
     throw new UnsupportedOperationException("You cannot deserialize `SupportedDevices`");
   }
 
-  private SupportedDevices(boolean cpu, boolean cuda, boolean dml) {
+  private SupportedDevices(boolean cpu, boolean cuda, boolean dml, boolean openvino) {
     this.cpu = cpu;
     this.cuda = cuda;
     this.dml = dml;
+    this.openvino = openvino;
   }
 
   @Override
@@ -66,11 +79,11 @@ public class SupportedDevices implements Cloneable {
       return false;
     }
     SupportedDevices other = (SupportedDevices) obj;
-    return cpu == other.cpu && cuda == other.cuda && dml == other.dml;
+    return cpu == other.cpu && cuda == other.cuda && dml == other.dml && openvino == other.openvino;
   }
 
   @Override
   public SupportedDevices clone() {
-    return new SupportedDevices(cpu, cuda, dml);
+    return new SupportedDevices(cpu, cuda, dml, openvino);
   }
 }

--- a/crates/voicevox_core_java_api/src/onnxruntime.rs
+++ b/crates/voicevox_core_java_api/src/onnxruntime.rs
@@ -68,14 +68,19 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_blocking_Onnxruntime_rs
         let devices = this.supported_devices()?;
 
         assert!(match devices.to_json_value() {
-            serde_json::Value::Object(o) => o.len() == 3, // `cpu`, `cuda`, `dml`
+            serde_json::Value::Object(o) => o.len() == 4, // `cpu`, `cuda`, `dml`, `openvino`
             _ => false,
         });
 
         let devices = env.new_object(
             object!("SupportedDevices"),
-            "(ZZZ)V",
-            &[devices.cpu.into(), devices.cuda.into(), devices.dml.into()],
+            "(ZZZZ)V",
+            &[
+                devices.cpu.into(),
+                devices.cuda.into(),
+                devices.dml.into(),
+                devices.openvino.into(),
+            ],
         )?;
         Ok(devices.into_raw())
     })

--- a/crates/voicevox_core_python_api/python/voicevox_core/_python/__init__.py
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_python/__init__.py
@@ -183,7 +183,7 @@ class SupportedDevices:
     ONNX Runtimeとして利用可能なデバイスの情報。
 
     あくまでONNX Runtimeが対応しているデバイスの情報であることに注意。GPUが使える環境ではなかったとしても
-    ``cuda`` や ``dml`` は ``True`` を示しうる。
+    ``cuda`` や ``dml`` や ``openvino`` は ``True`` を示しうる。
 
     VOICEVOX CORE以外が作ることはできない。作ろうとした場合 ``TypeError`` となる。
     """
@@ -209,6 +209,14 @@ class SupportedDevices:
 
     ONNX Runtimeの `DirectML Execution Provider <https://onnxruntime.ai/docs/execution-providers/DirectML-ExecutionProvider.html>`_
     (``DmlExecutionProvider``)に対応する。必要な環境についてはそちらを参照。
+    """
+
+    openvino: bool
+    """
+    OpenVINOが利用可能。
+
+    ONNX Runtimeの `OpenVINO Execution Provider <https://onnxruntime.ai/docs/execution-providers/OpenVINO-ExecutionProvider.html>`_
+    (``OpenVINOExecutionProvider``)に対応する。必要な環境についてはそちらを参照。
     """
 
     _reserved: InitVar[Never]

--- a/crates/voicevox_core_python_api/src/convert.rs
+++ b/crates/voicevox_core_python_api/src/convert.rs
@@ -459,7 +459,7 @@ pub(crate) impl<T> voicevox_core::Result<T> {
 impl SupportedDevices {
     fn to_py(self, py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {
         assert!(match self.to_json_value() {
-            serde_json::Value::Object(o) => o.len() == 3, // `cpu`, `cuda`, `dml`
+            serde_json::Value::Object(o) => o.len() == 4, // `cpu`, `cuda`, `dml`, `openvino`
             _ => false,
         });
 


### PR DESCRIPTION
## 内容

Intel Arc / Xe GPU 向けに **OpenVINO Execution Provider** 対応を入れたく、まず Draft で出して方針を相談させてください （新しい EP なので、正式に PR 化する前に意見をうかがいたいです）

現状 Intel GPU だと実質 DirectML 一択ですが、OpenVINO だと XMX(FP16) が効いて速いです。手元の **Intel Arc B570** で試したところ、`voicevox_bench` で RTX 4070 の CUDA と同等以上が出ました:

| 文字数 | RTX 4070 (CUDA・製品エンジン) | Arc B570 (OpenVINO・試作) |
|---|---|---|
| 10 | 0.0229 | 0.0485 |
| 50 | 0.0618 | 0.0541 |
| 100 | 0.1088 | 0.0603 |
| 平均 | **0.0645** | **0.0543** |

※ CUDA は製品モデル / OpenVINO はサンプル(平文ONNX)モデルなので厳密な同条件ではないですが、実用速度域には十分入りそう、という目安です。

このブランチでやってること（core 中心・最小限）:
- `SupportedDevices` に `openvino` を追加
- `GpuSpec::OpenVino` を追加し、`onnxruntime.rs` の EP 登録に分岐を追加（`ort` の `openvino` feature、`OpenVINOExecutionProvider` の `device_type`/`precision`/`cache_dir`）
- `AccelerationMode::Auto` の探索に OpenVINO を追加
- Python / Java バインディング追従（C API は JSON 返却なので ABI 影響なし）

## 関連 Issue

- 新規提案（既存 Issue なし）

## その他（相談したいこと）

- **製品版モデル（vv_bin）の扱い**: 公開 onnxruntime-builder がビルドする ONNX Runtime の OpenVINO EP だと、製品版 vv_bin は直接読めなさそうで、製品版へ適用するには `voicevox_onnxruntime` 側に `--use_openvino` が要りそう…と理解しています。この辺どう考えてますか？（まずは公開/平文ONNX対応から、でもアリかなと）
- **ビルド**: 動かす実体として onnxruntime-builder に `--use_openvino` 版の追加が要ります。これは別 PR でやるつもりです（#363 同様、ビルドは分けます）。
- **engine 側**: `use_gpu` 経由で core(`AccelerationMode`)任せに動くので、変更は最小限の想定です。
- **形状ごとコンパイル**: OpenVINO GPU は入力形状ごとにコンパイルするので、可変長文だと毎回走ります。手元では decode 長を少数の固定形状に丸めて回避しました。上流に入れる形は要相談です。

