### PR TITLE
docs(rust): exampleと（見かけだけ）doctestに`tracing_subscriber`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,9 @@
 ### Added
 
 - `Synthesizer::load_voice_model`にオプション`on_existing`が追加されます ([#1331], [#1337])。
-- \[Rust\] \[Linux\] APIドキュメントが改善されます ([#1343])。
-    - muslターゲットでは`load-onnxruntime`が事実上利用不可であることが明記されます。
+- \[Rust\] APIドキュメントが改善されます ([#1343], [#1381])。
+    - トップページのコード例で`tracing_subscriber::fmt().init();`が行われるようになります。
+    - \[Linux\] muslターゲットでは`load-onnxruntime`が事実上利用不可であることが明記されます。
 - \[C\] \[macOS\] :tada: macOS向けのXCFrameworkがvoicevox\_core-xcframework-cpu-{バージョン}.zipという名前でリリースされるようになります ([#1056] helped by [@nekomimimi], [#1114], [#1362])。
 - \[C,ダウンローダー\] \[macOS\] リリースがコード署名されるようになります ([#1326])。
 - \[ダウンローダー\] `--os`オプションで`android`と`ios`を指定できるようになります。ただしiOSの`c-api`をダウンロードすることはできません ([#1313])。
@@ -1516,6 +1517,7 @@ Windows版ダウンローダーのビルドに失敗しています。
 [#1350]: https://github.com/VOICEVOX/voicevox_core/pull/1350
 [#1359]: https://github.com/VOICEVOX/voicevox_core/pull/1359
 [#1362]: https://github.com/VOICEVOX/voicevox_core/pull/1362
+[#1381]: https://github.com/VOICEVOX/voicevox_core/pull/1381
 
 [VOICEVOX/onnxruntime-builder#25]: https://github.com/VOICEVOX/onnxruntime-builder/pull/25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5042,6 +5042,7 @@ dependencies = [
  "thiserror 1.0.64",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "typed_floats",
  "typeshare",
  "uuid",

--- a/crates/voicevox_core/Cargo.toml
+++ b/crates/voicevox_core/Cargo.toml
@@ -90,6 +90,7 @@ rstest.workspace = true
 rstest_reuse.workspace = true
 test_util.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tracing-subscriber.workspace = true
 
 [build-dependencies]
 voicevox_core_build_features.workspace = true

--- a/crates/voicevox_core/examples/talk.rs
+++ b/crates/voicevox_core/examples/talk.rs
@@ -52,7 +52,7 @@ struct Args {
 }
 
 fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt().init(); // `voicevox_core`や(VOICEVOX) ONNX Runtimeが出すログを標準出力に出力する。
+    tracing_subscriber::fmt().init(); // `voicevox_core`や(VOICEVOX) ONNX Runtimeの情報表示や警告は、`tracing`に出力される。
 
     let args = Args::parse();
 

--- a/crates/voicevox_core/examples/talk.rs
+++ b/crates/voicevox_core/examples/talk.rs
@@ -52,6 +52,9 @@ struct Args {
 }
 
 fn main() -> anyhow::Result<()> {
+    #[cfg(false)]
+    tracing_subscriber::fmt().init();
+
     let args = Args::parse();
 
     // ONNX Runtimeのロード

--- a/crates/voicevox_core/examples/talk.rs
+++ b/crates/voicevox_core/examples/talk.rs
@@ -52,8 +52,7 @@ struct Args {
 }
 
 fn main() -> anyhow::Result<()> {
-    #[cfg(false)]
-    tracing_subscriber::fmt().init();
+    tracing_subscriber::fmt().init(); // `voicevox_core`や(VOICEVOX) ONNX Runtimeが出すログを標準出力に出力する。
 
     let args = Args::parse();
 

--- a/crates/voicevox_core/src/lib.rs
+++ b/crates/voicevox_core/src/lib.rs
@@ -70,6 +70,9 @@
 //! #
 //! const TEXT: &str = "こんにちは";
 //!
+//! # #[cfg(false)]
+//! tracing_subscriber::fmt().init(); // `voicevox_core`や(VOICEVOX) ONNX Runtimeが出すログを標準出力に出力する。
+//!
 //! let synth = {
 //!     let ort = Onnxruntime::load_once().filename(VVORT).perform()?;
 //!     let ojt = OpenJtalk::new(OJT_DIC)?;
@@ -153,6 +156,9 @@
 //! # #[cfg(false)]
 //! const SINGER_STYLE_NAME: &str = "ノーマル";
 //! # const SINGER_STYLE_NAME: &str = "style4-1";
+//!
+//! # #[cfg(false)]
+//! tracing_subscriber::fmt().init(); // `voicevox_core`や(VOICEVOX) ONNX Runtimeが出すログを標準出力に出力する。
 //!
 //! let synth = {
 //!     let ort = Onnxruntime::load_once().filename(VVORT).perform()?;

--- a/crates/voicevox_core/src/lib.rs
+++ b/crates/voicevox_core/src/lib.rs
@@ -71,7 +71,7 @@
 //! const TEXT: &str = "こんにちは";
 //!
 //! # #[cfg(false)]
-//! tracing_subscriber::fmt().init(); // `voicevox_core`や(VOICEVOX) ONNX Runtimeが出すログを標準出力に出力する。
+//! tracing_subscriber::fmt().init(); // `voicevox_core`や(VOICEVOX) ONNX Runtimeの情報表示や警告は、`tracing`に出力される。
 //!
 //! let synth = {
 //!     let ort = Onnxruntime::load_once().filename(VVORT).perform()?;
@@ -158,7 +158,7 @@
 //! # const SINGER_STYLE_NAME: &str = "style4-1";
 //!
 //! # #[cfg(false)]
-//! tracing_subscriber::fmt().init(); // `voicevox_core`や(VOICEVOX) ONNX Runtimeが出すログを標準出力に出力する。
+//! tracing_subscriber::fmt().init(); // `voicevox_core`や(VOICEVOX) ONNX Runtimeの情報表示や警告は、`tracing`に出力される。
 //!
 //! let synth = {
 //!     let ort = Onnxruntime::load_once().filename(VVORT).perform()?;


### PR DESCRIPTION
## 内容

`voicevox_core`本体やONNX Runtimeのinfo/warning/errorが見えないのは不便なので、exampleに`tracing_subscriber::fmt().init()`を入れるようにする。さらにrustdocのトップページのコードブロックにも、案内を兼ねて書くようにする。

経緯: <https://github.com/VOICEVOX/onnxruntime-builder/issues/110#issuecomment-4823871668>
