### PR TITLE
fix: Kotlinサンプルのタイポを修正

### DIFF
--- a/example/kotlin/README.md
+++ b/example/kotlin/README.md
@@ -60,7 +60,7 @@ Options:
 ❯ # TODO: ダウンロード物の構成が変わったため色々壊れているはず
 ❯ # Linuxの場合
 ❯ ./gradlew run --args="--vvm ../../crates/test_util/data/model/sample.vvm --onnxruntime ../../crates/test_util/data/lib/libonnxruntime.so.1.17.3"
-Inititalizing: AUTO, ../../crates/test_util/data/lib/libonnxruntime.so.1.17.3, ./open_jtalk_dic_utf_8-1.11
+Initializing: AUTO, ../../crates/test_util/data/lib/libonnxruntime.so.1.17.3, ./open_jtalk_dic_utf_8-1.11
 Loading: ../../crates/test_util/data/model/sample.vvm
 Creating an AudioQuery from the text: この音声は、ボイスボックスを使用して、出力されています。
 Synthesizing...

--- a/example/kotlin/app/src/main/kotlin/app/App.kt
+++ b/example/kotlin/app/src/main/kotlin/app/App.kt
@@ -33,7 +33,7 @@ fun main(args: Array<String>) {
 
   parser.parse(args)
 
-  println("Inititalizing: ${mode}, ${onnxruntime}, ${dictDir}")
+  println("Initializing: ${mode}, ${onnxruntime}, ${dictDir}")
   val ort = Onnxruntime.loadOnce().filename(onnxruntime).perform()
   val openJtalk = OpenJtalk(dictDir)
   val synthesizer =


### PR DESCRIPTION
## 内容

Kotlinサンプルの初期化時に表示するメッセージとREADMEの実行例にある、`Inititalizing`のタイポを修正します。
