### PR TITLE
fix(java): 利用不可だった`cpuNumThreads`を直す

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 
 - 一部のケースにおける`RunModel`エラーのメッセージが改善されます ([#1385])。
 - \[Python\] `Synthesizer.load_voice_model`のdocstringにおける"Parameters"の説明が誤っていたのが修正されます ([#1359])。
+- \[Java\] Java APIの実装当初から事実上利用不可だった`Synthesizer.Builder#cpuNumThreads`が利用可能になります ([#1394])。
 
 ### Security
 
@@ -1520,6 +1521,7 @@ Windows版ダウンローダーのビルドに失敗しています。
 [#1362]: https://github.com/VOICEVOX/voicevox_core/pull/1362
 [#1381]: https://github.com/VOICEVOX/voicevox_core/pull/1381
 [#1385]: https://github.com/VOICEVOX/voicevox_core/pull/1385
+[#1394]: https://github.com/VOICEVOX/voicevox_core/pull/1394
 
 [VOICEVOX/onnxruntime-builder#25]: https://github.com/VOICEVOX/onnxruntime-builder/pull/25
 

--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/blocking/Synthesizer.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/blocking/Synthesizer.java
@@ -547,7 +547,7 @@ public class Synthesizer {
      * @return ビルダー。
      */
     public Builder cpuNumThreads(int cpuNumThreads) {
-      if (Utils.isU16(cpuNumThreads)) {
+      if (!Utils.isU16(cpuNumThreads)) {
         throw new IllegalArgumentException("cpuNumThreads");
       }
       this.cpuNumThreads = cpuNumThreads;

--- a/crates/voicevox_core_java_api/lib/src/test/java/jp/hiroshiba/voicevoxcore/blocking/SynthesizerTest.java
+++ b/crates/voicevox_core_java_api/lib/src/test/java/jp/hiroshiba/voicevoxcore/blocking/SynthesizerTest.java
@@ -7,6 +7,7 @@ package jp.hiroshiba.voicevoxcore.blocking;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
@@ -36,6 +37,34 @@ class SynthesizerTest extends TestUtils {
     Synthesizer synthesizer =
         Synthesizer.builder(onnxruntime, openJtalk).accelerationMode(AccelerationMode.CPU).build();
     assertFalse(synthesizer.isGpuMode());
+  }
+
+  @Test
+  void checkCpuNumThreadsAcceptsUint16() {
+    Onnxruntime onnxruntime = loadOnnxruntime();
+    OpenJtalk openJtalk = loadOpenJtalk();
+    for (int cpuNumThreads : Arrays.asList(0, 1, 2, 4, 0xffff)) {
+      Synthesizer.builder(onnxruntime, openJtalk)
+          .accelerationMode(AccelerationMode.CPU)
+          .cpuNumThreads(cpuNumThreads)
+          .build();
+    }
+  }
+
+  @Test
+  void checkCpuNumThreadsDeniesNonUint16() {
+    Onnxruntime onnxruntime = loadOnnxruntime();
+    OpenJtalk openJtalk = loadOpenJtalk();
+    IllegalArgumentException e =
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> {
+              Synthesizer.builder(onnxruntime, openJtalk)
+                  .accelerationMode(AccelerationMode.CPU)
+                  .cpuNumThreads(0x10000)
+                  .build();
+            });
+    assertEquals("cpuNumThreads", e.getMessage());
   }
 
   boolean checkAllMoras(


### PR DESCRIPTION
## 内容

Java API実装当初（#558）からずっと利用不可になっていた`Synthesizer.Builder#cpuNumThreads`を使えるようにする。

Reported-by: @higuchi-shu (`TOW_樋口収一 <s.higuchi@ko-tatsu.jp>`)

## 関連 Issue

Fixes: #1390
