### PR TITLE
feat!: VVMマニフェストの"experimental_talk"を"streaming_talk"に

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [#1363]
 - [#1364]
 - [#1376]
+- [#1400]
 
 [#854]: https://github.com/VOICEVOX/voicevox_core/pull/854
 [#864]: https://github.com/VOICEVOX/voicevox_core/pull/864
@@ -26,6 +27,7 @@
 [#1363]: https://github.com/VOICEVOX/voicevox_core/pull/1363
 [#1364]: https://github.com/VOICEVOX/voicevox_core/pull/1364
 [#1376]: https://github.com/VOICEVOX/voicevox_core/pull/1376
+[#1400]: https://github.com/VOICEVOX/voicevox_core/pull/1400
 
 ### もし`TextAnalyzer`機能を充実させた場合
 

--- a/crates/voicevox_core/src/core/infer/domains.rs
+++ b/crates/voicevox_core/src/core/infer/domains.rs
@@ -1,6 +1,6 @@
-pub(crate) mod experimental_talk;
 mod frame_decode;
 mod singing_teacher;
+pub(crate) mod streaming_talk;
 pub(crate) mod talk;
 
 use std::fmt::Debug;
@@ -9,15 +9,15 @@ use educe::Educe;
 use serde::{Deserialize, Deserializer};
 
 pub(crate) use self::{
-    experimental_talk::{
-        ExperimentalTalkDomain, ExperimentalTalkOperation, GenerateFullIntermediateInput,
-        GenerateFullIntermediateOutput, RenderAudioSegmentInput, RenderAudioSegmentOutput,
-    },
     frame_decode::{FrameDecodeDomain, FrameDecodeOperation, SfDecodeInput, SfDecodeOutput},
     singing_teacher::{
         PredictSingConsonantLengthInput, PredictSingConsonantLengthOutput, PredictSingF0Input,
         PredictSingF0Output, PredictSingVolumeInput, PredictSingVolumeOutput, SingingTeacherDomain,
         SingingTeacherOperation,
+    },
+    streaming_talk::{
+        GenerateFullIntermediateInput, GenerateFullIntermediateOutput, RenderAudioSegmentInput,
+        RenderAudioSegmentOutput, StreamingTalkDomain, StreamingTalkOperation,
     },
     talk::{DecodeInput, DecodeOutput, TalkDomain, TalkOperation},
 };
@@ -27,15 +27,15 @@ pub(crate) use self::{
 // でもそうなのか？また最新版でも駄目だとしたら、弾いている理由は何なのか？
 #[educe(
     Clone(
-        bound = "V: InferenceDomainMapValues, V::Talk: Clone, V::ExperimentalTalk: Clone, V::SingingTeacher: Clone, V::FrameDecode: Clone"
+        bound = "V: InferenceDomainMapValues, V::Talk: Clone, V::StreamingTalk: Clone, V::SingingTeacher: Clone, V::FrameDecode: Clone"
     ),
     Debug(
-        bound = "V: InferenceDomainMapValues, V::Talk: Debug, V::ExperimentalTalk: Debug, V::SingingTeacher: Debug, V::FrameDecode: Debug"
+        bound = "V: InferenceDomainMapValues, V::Talk: Debug, V::StreamingTalk: Debug, V::SingingTeacher: Debug, V::FrameDecode: Debug"
     )
 )]
 pub(crate) struct InferenceDomainMap<V: InferenceDomainMapValues + ?Sized> {
     pub(crate) talk: V::Talk,
-    pub(crate) experimental_talk: V::ExperimentalTalk,
+    pub(crate) streaming_talk: V::StreamingTalk,
     pub(crate) singing_teacher: V::SingingTeacher,
     pub(crate) frame_decode: V::FrameDecode,
 }
@@ -43,12 +43,12 @@ pub(crate) struct InferenceDomainMap<V: InferenceDomainMapValues + ?Sized> {
 impl<T, X, S, F> InferenceDomainMap<(T, X, S, F)> {
     pub(in super::super) fn each_ref(&self) -> InferenceDomainMap<(&T, &X, &S, &F)> {
         let talk = &self.talk;
-        let experimental_talk = &self.experimental_talk;
+        let streaming_talk = &self.streaming_talk;
         let singing_teacher = &self.singing_teacher;
         let frame_decode = &self.frame_decode;
         InferenceDomainMap {
             talk,
-            experimental_talk,
+            streaming_talk,
             singing_teacher,
             frame_decode,
         }
@@ -68,12 +68,12 @@ impl<T, X, S, F> InferenceDomainMap<(T, X, S, F)> {
         fs: InferenceDomainMap<(Ft, Fx, Fs, Ff)>,
     ) -> InferenceDomainMap<(T2, X2, S2, F2)> {
         let talk = (fs.talk)(self.talk);
-        let experimental_talk = (fs.experimental_talk)(self.experimental_talk);
+        let streaming_talk = (fs.streaming_talk)(self.streaming_talk);
         let singing_teacher = (fs.singing_teacher)(self.singing_teacher);
         let frame_decode = (fs.frame_decode)(self.frame_decode);
         InferenceDomainMap {
             talk,
-            experimental_talk,
+            streaming_talk,
             singing_teacher,
             frame_decode,
         }
@@ -83,12 +83,12 @@ impl<T, X, S, F> InferenceDomainMap<(T, X, S, F)> {
 impl<T, X, S, F, E> InferenceDomainMap<(Result<T, E>, Result<X, E>, Result<S, E>, Result<F, E>)> {
     pub(in super::super) fn collect(self) -> Result<InferenceDomainMap<(T, X, S, F)>, E> {
         let talk = self.talk?;
-        let experimental_talk = self.experimental_talk?;
+        let streaming_talk = self.streaming_talk?;
         let singing_teacher = self.singing_teacher?;
         let frame_decode = self.frame_decode?;
         Ok(InferenceDomainMap {
             talk,
-            experimental_talk,
+            streaming_talk,
             singing_teacher,
             frame_decode,
         })
@@ -98,7 +98,7 @@ impl<T, X, S, F, E> InferenceDomainMap<(Result<T, E>, Result<X, E>, Result<S, E>
 impl<'de, V: InferenceDomainMapValues + ?Sized> Deserialize<'de> for InferenceDomainMap<V>
 where
     V::Talk: Deserialize<'de>,
-    V::ExperimentalTalk: Deserialize<'de>,
+    V::StreamingTalk: Deserialize<'de>,
     V::SingingTeacher: Deserialize<'de>,
     V::FrameDecode: Deserialize<'de>,
 {
@@ -108,13 +108,13 @@ where
     {
         let Repr {
             talk,
-            experimental_talk,
+            streaming_talk,
             singing_teacher,
             frame_decode,
         } = Repr::deserialize(deserializer)?;
         return Ok(Self {
             talk,
-            experimental_talk,
+            streaming_talk,
             singing_teacher,
             frame_decode,
         });
@@ -122,7 +122,7 @@ where
         #[derive(Deserialize)]
         struct Repr<T, E, S, F> {
             talk: T,
-            experimental_talk: E,
+            streaming_talk: E,
             singing_teacher: S,
             frame_decode: F,
         }
@@ -133,7 +133,7 @@ macro_rules! inference_domain_map {
     ($elem:expr $(,)?) => {
         crate::core::infer::domains::InferenceDomainMap {
             talk: $elem,
-            experimental_talk: $elem,
+            streaming_talk: $elem,
             singing_teacher: $elem,
             frame_decode: $elem,
         }
@@ -143,14 +143,14 @@ pub(crate) use inference_domain_map;
 
 pub(crate) trait InferenceDomainMapValues {
     type Talk;
-    type ExperimentalTalk;
+    type StreamingTalk;
     type SingingTeacher;
     type FrameDecode;
 }
 
 impl<T, X, S, F> InferenceDomainMapValues for (T, X, S, F) {
     type Talk = T;
-    type ExperimentalTalk = X;
+    type StreamingTalk = X;
     type SingingTeacher = S;
     type FrameDecode = F;
 }
@@ -164,7 +164,7 @@ macro_rules! inference_domain_map_values {
             ),
             ::macros::substitute_type!(
                 $body
-                where $arg = crate::core::infer::domains::ExperimentalTalkDomain as crate::core::infer::InferenceDomain
+                where $arg = crate::core::infer::domains::StreamingTalkDomain as crate::core::infer::InferenceDomain
             ),
             ::macros::substitute_type!(
                 $body

--- a/crates/voicevox_core/src/core/infer/domains/streaming_talk.rs
+++ b/crates/voicevox_core/src/core/infer/domains/streaming_talk.rs
@@ -11,10 +11,10 @@ use super::super::{
     InferenceDomain, InferenceInputSignature as _, InferenceOutputSignature as _, OutputTensor,
 };
 
-pub(crate) enum ExperimentalTalkDomain {}
+pub(crate) enum StreamingTalkDomain {}
 
-impl InferenceDomain for ExperimentalTalkDomain {
-    type Operation = ExperimentalTalkOperation;
+impl InferenceDomain for StreamingTalkDomain {
+    type Operation = StreamingTalkOperation;
 
     fn style_types() -> &'static BTreeSet<StyleType> {
         static STYLE_TYPES: LazyLock<BTreeSet<StyleType>> =
@@ -26,9 +26,9 @@ impl InferenceDomain for ExperimentalTalkDomain {
 #[derive(Clone, Copy, Debug, Deserialize, Enum, InferenceOperation)]
 #[serde(rename_all = "snake_case")]
 #[inference_operation(
-    type Domain = ExperimentalTalkDomain;
+    type Domain = StreamingTalkDomain;
 )]
-pub(crate) enum ExperimentalTalkOperation {
+pub(crate) enum StreamingTalkOperation {
     #[inference_operation(
         type Input = PredictDurationInput;
         type Output = PredictDurationOutput;

--- a/crates/voicevox_core/src/core/status.rs
+++ b/crates/voicevox_core/src/core/status.rs
@@ -19,7 +19,7 @@ use super::{
         self, InferenceDomain, InferenceInputSignature, InferenceRuntime, InferenceSessionOptions,
         InferenceSignature,
         domains::{
-            ExperimentalTalkDomain, FrameDecodeDomain, InferenceDomainMap, SingingTeacherDomain,
+            FrameDecodeDomain, InferenceDomainMap, SingingTeacherDomain, StreamingTalkDomain,
             TalkDomain, inference_domain_map_values,
         },
         session_set::{InferenceSessionCell, InferenceSessionSet},
@@ -402,7 +402,7 @@ pub(crate) trait InferenceDomainExt: InferenceDomain {
 #[duplicate_item(
     T                        field;
     [ TalkDomain ]           [ talk ];
-    [ ExperimentalTalkDomain ] [ experimental_talk ];
+    [ StreamingTalkDomain ] [ streaming_talk ];
     [ SingingTeacherDomain ] [ singing_teacher ];
     [ FrameDecodeDomain ]    [ frame_decode ];
 )]
@@ -432,7 +432,7 @@ impl InferenceDomainMap<ModelBytesWithInnerVoiceIdsByDomain> {
             [
                 field;
                 [ talk ];
-                [ experimental_talk ];
+                [ streaming_talk ];
                 [ singing_teacher ];
                 [ frame_decode ];
             ]
@@ -448,7 +448,7 @@ impl InferenceDomainMap<ModelBytesWithInnerVoiceIdsByDomain> {
 
         Ok(InferenceDomainMap {
             talk,
-            experimental_talk,
+            streaming_talk,
             singing_teacher,
             frame_decode,
         })
@@ -484,8 +484,8 @@ mod tests {
                 InferenceOperation, InferenceRuntime, InferenceSessionOptions, InputScalarKind,
                 OutputScalarKind, OutputTensor, ParamInfo, PushInputTensor,
                 domains::{
-                    ExperimentalTalkOperation, FrameDecodeOperation, InferenceDomainMap,
-                    SingingTeacherOperation, TalkOperation, inference_domain_map,
+                    FrameDecodeOperation, InferenceDomainMap, SingingTeacherOperation,
+                    StreamingTalkOperation, TalkOperation, inference_domain_map,
                 },
             },
             voice_model::{ModelBytes, ModelBytesWithInnerVoiceIdsByDomain, VoiceModelHeader},
@@ -511,11 +511,11 @@ mod tests {
                 }
                 TalkOperation::Decode => heavy_session_options,
             },
-            experimental_talk: enum_map! {
-                ExperimentalTalkOperation::PredictDuration
-                | ExperimentalTalkOperation::PredictIntonation
-                | ExperimentalTalkOperation::GenerateFullIntermediate => light_session_options,
-                ExperimentalTalkOperation::RenderAudioSegment => heavy_session_options,
+            streaming_talk: enum_map! {
+                StreamingTalkOperation::PredictDuration
+                | StreamingTalkOperation::PredictIntonation
+                | StreamingTalkOperation::GenerateFullIntermediate => light_session_options,
+                StreamingTalkOperation::RenderAudioSegment => heavy_session_options,
             },
             singing_teacher: enum_map! {
                 SingingTeacherOperation::PredictSingConsonantLength
@@ -530,20 +530,19 @@ mod tests {
 
         assert_eq!(
             light_session_options,
-            status.session_options.experimental_talk[ExperimentalTalkOperation::PredictDuration],
+            status.session_options.streaming_talk[StreamingTalkOperation::PredictDuration],
         );
         assert_eq!(
             light_session_options,
-            status.session_options.experimental_talk[ExperimentalTalkOperation::PredictIntonation],
+            status.session_options.streaming_talk[StreamingTalkOperation::PredictIntonation],
         );
         assert_eq!(
             light_session_options,
-            status.session_options.experimental_talk
-                [ExperimentalTalkOperation::GenerateFullIntermediate],
+            status.session_options.streaming_talk[StreamingTalkOperation::GenerateFullIntermediate],
         );
         assert_eq!(
             heavy_session_options,
-            status.session_options.experimental_talk[ExperimentalTalkOperation::RenderAudioSegment],
+            status.session_options.streaming_talk[StreamingTalkOperation::RenderAudioSegment],
         );
 
         assert!(status.loaded_models.lock().unwrap().0.is_empty());
@@ -698,7 +697,7 @@ mod tests {
                 Default::default(),
                 EnumMap::from_fn(|op: TalkOperation| ModelBytes::Onnx(vec![op.into_usize() as u8])),
             )),
-            experimental_talk: None,
+            streaming_talk: None,
             singing_teacher: None,
             frame_decode: None,
         });

--- a/crates/voicevox_core/src/core/voice_model.rs
+++ b/crates/voicevox_core/src/core/voice_model.rs
@@ -30,7 +30,7 @@ use super::{
     infer::{
         InferenceDomain,
         domains::{
-            ExperimentalTalkDomain, FrameDecodeDomain, InferenceDomainMap, SingingTeacherDomain,
+            FrameDecodeDomain, InferenceDomainMap, SingingTeacherDomain, StreamingTalkDomain,
             TalkDomain, inference_domain_map, inference_domain_map_values,
         },
     },
@@ -247,7 +247,7 @@ impl<A: Async> Inner<A> {
 
         let InferenceDomainMap {
             talk,
-            experimental_talk,
+            streaming_talk,
             singing_teacher,
             frame_decode,
         } = self.with_inference_model_entries(|inference_model_entries| {
@@ -270,7 +270,7 @@ impl<A: Async> Inner<A> {
         .await
         .transpose()?;
 
-        let experimental_talk = OptionFuture::from(experimental_talk.map(
+        let streaming_talk = OptionFuture::from(streaming_talk.map(
             async |(entries, style_id_to_inner_voice_id)| {
                 let [
                     predict_duration,
@@ -337,7 +337,7 @@ impl<A: Async> Inner<A> {
 
         Ok(InferenceDomainMap {
             talk,
-            experimental_talk,
+            streaming_talk,
             singing_teacher,
             frame_decode,
         })
@@ -523,14 +523,13 @@ impl InferenceDomainMap<ManifestDomains> {
     fn accepts(&self, style_type: StyleType) -> bool {
         let Self {
             talk,
-            experimental_talk,
+            streaming_talk,
             singing_teacher,
             frame_decode,
         } = self;
 
         return TalkDomain::contains(style_type).implies(|| talk.is_some())
-            && ExperimentalTalkDomain::contains(style_type)
-                .implies(|| experimental_talk.is_some())
+            && StreamingTalkDomain::contains(style_type).implies(|| streaming_talk.is_some())
             && SingingTeacherDomain::contains(style_type).implies(|| singing_teacher.is_some())
             && FrameDecodeDomain::contains(style_type).implies(|| frame_decode.is_some());
 

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -27,14 +27,14 @@ use crate::{
         infer::{
             self, InferenceRuntime, InferenceSessionOptions,
             domains::{
-                DecodeInput, DecodeOutput, ExperimentalTalkDomain, ExperimentalTalkOperation,
-                FrameDecodeDomain, FrameDecodeOperation, GenerateFullIntermediateInput,
-                GenerateFullIntermediateOutput, InferenceDomainMap,
+                DecodeInput, DecodeOutput, FrameDecodeDomain, FrameDecodeOperation,
+                GenerateFullIntermediateInput, GenerateFullIntermediateOutput, InferenceDomainMap,
                 PredictSingConsonantLengthInput, PredictSingConsonantLengthOutput,
                 PredictSingF0Input, PredictSingF0Output, PredictSingVolumeInput,
                 PredictSingVolumeOutput, RenderAudioSegmentInput, RenderAudioSegmentOutput,
                 SfDecodeInput, SfDecodeOutput, SingingTeacherDomain, SingingTeacherOperation,
-                TalkDomain, TalkOperation, experimental_talk, talk,
+                StreamingTalkDomain, StreamingTalkOperation, TalkDomain, TalkOperation,
+                streaming_talk, talk,
             },
         },
         pad_decoder_feature,
@@ -335,11 +335,11 @@ impl<T, A: AsyncExt> Inner<T, A> {
                     }
                     TalkOperation::Decode => heavy_session_options,
                 },
-                experimental_talk: enum_map! {
-                    ExperimentalTalkOperation::PredictDuration
-                    | ExperimentalTalkOperation::PredictIntonation
-                    | ExperimentalTalkOperation::GenerateFullIntermediate => light_session_options,
-                    ExperimentalTalkOperation::RenderAudioSegment => heavy_session_options,
+                streaming_talk: enum_map! {
+                    StreamingTalkOperation::PredictDuration
+                    | StreamingTalkOperation::PredictIntonation
+                    | StreamingTalkOperation::GenerateFullIntermediate => light_session_options,
+                    StreamingTalkOperation::RenderAudioSegment => heavy_session_options,
                 },
                 singing_teacher: enum_map! {
                     SingingTeacherOperation::PredictSingConsonantLength
@@ -1185,7 +1185,7 @@ impl<R: InferenceRuntime> Status<R> {
         phoneme_vector: ndarray::Array1<i64>,
         style_id: StyleId,
     ) -> Result<Vec<PositiveFinite<f32>>> {
-        // `TalkDomain`と`ExperimentalTalkDomain`の両方がある場合、`TalkDomain`を優先
+        // `TalkDomain`と`StreamingTalkDomain`の両方がある場合、`TalkDomain`を優先
         if self.contains_domain::<TalkDomain>(style_id) {
             let (model_id, inner_voice_id) = self.ids_for::<TalkDomain>(style_id)?;
             let talk::PredictDurationOutput {
@@ -1205,14 +1205,14 @@ impl<R: InferenceRuntime> Status<R> {
             })?;
             return Ok(ensure_minimum_phoneme_length(output));
         }
-        let (model_id, inner_voice_id) = self.ids_for::<ExperimentalTalkDomain>(style_id)?;
+        let (model_id, inner_voice_id) = self.ids_for::<StreamingTalkDomain>(style_id)?;
 
-        let experimental_talk::PredictDurationOutput {
+        let streaming_talk::PredictDurationOutput {
             phoneme_length: output,
         } = self
             .run_session::<A, _>(
                 model_id,
-                experimental_talk::PredictDurationInput {
+                streaming_talk::PredictDurationInput {
                     phoneme_list: phoneme_vector,
                     speaker_id: ndarray::arr1(&[inner_voice_id.raw_id().into()]),
                 },
@@ -1241,7 +1241,7 @@ impl<R: InferenceRuntime> Status<R> {
         end_accent_phrase_vector: ndarray::Array1<i64>,
         style_id: StyleId,
     ) -> Result<Vec<NonNaNFinite<f32>>> {
-        // `TalkDomain`と`ExperimentalTalkDomain`の両方がある場合、`TalkDomain`を優先
+        // `TalkDomain`と`StreamingTalkDomain`の両方がある場合、`TalkDomain`を優先
         if self.contains_domain::<TalkDomain>(style_id) {
             let (model_id, inner_voice_id) = self.ids_for::<TalkDomain>(style_id)?;
             let talk::PredictIntonationOutput { f0_list: output } = self
@@ -1264,12 +1264,12 @@ impl<R: InferenceRuntime> Status<R> {
                 anyhow!("`predict_intonation` returned an array that contains: {invalid}")
             });
         }
-        let (model_id, inner_voice_id) = self.ids_for::<ExperimentalTalkDomain>(style_id)?;
+        let (model_id, inner_voice_id) = self.ids_for::<StreamingTalkDomain>(style_id)?;
 
-        let experimental_talk::PredictIntonationOutput { f0_list: output } = self
+        let streaming_talk::PredictIntonationOutput { f0_list: output } = self
             .run_session::<A, _>(
                 model_id,
-                experimental_talk::PredictIntonationInput {
+                streaming_talk::PredictIntonationInput {
                     length: ndarray::arr0(length as i64),
                     vowel_phoneme_list: vowel_phoneme_vector,
                     consonant_phoneme_list: consonant_phoneme_vector,
@@ -1299,7 +1299,7 @@ impl<R: InferenceRuntime> Status<R> {
         phoneme_vector: ndarray::Array1<f32>,
         style_id: StyleId,
     ) -> Result<ndarray::Array2<f32>> {
-        let (model_id, inner_voice_id) = self.ids_for::<ExperimentalTalkDomain>(style_id)?;
+        let (model_id, inner_voice_id) = self.ids_for::<StreamingTalkDomain>(style_id)?;
 
         let (length_with_padding, f0_with_padding, phoneme_with_padding) =
             pad_decoder_feature::<PADDING_FRAME_LENGTH>(
@@ -1348,7 +1348,7 @@ impl<R: InferenceRuntime> Status<R> {
         spec: ndarray::Array2<f32>,
         style_id: StyleId,
     ) -> Result<ndarray::Array1<f32>> {
-        let (model_id, _inner_voice_id) = self.ids_for::<ExperimentalTalkDomain>(style_id)?;
+        let (model_id, _inner_voice_id) = self.ids_for::<StreamingTalkDomain>(style_id)?;
         let RenderAudioSegmentOutput { wave } = self
             .run_session::<A, _>(
                 model_id,
@@ -1368,7 +1368,7 @@ impl<R: InferenceRuntime> Status<R> {
         style_id: StyleId,
         cancellable: A::Cancellable,
     ) -> Result<Vec<f32>> {
-        // `TalkDomain`と`ExperimentalTalkDomain`の両方がある場合、`TalkDomain`を優先
+        // `TalkDomain`と`StreamingTalkDomain`の両方がある場合、`TalkDomain`を優先
         if self.contains_domain::<TalkDomain>(style_id) {
             let (model_id, inner_voice_id) = self.ids_for::<TalkDomain>(style_id)?;
             let (length_with_padding, f0_with_padding, phoneme_with_padding) =

--- a/model/sample.vvm/manifest.json
+++ b/model/sample.vvm/manifest.json
@@ -20,7 +20,7 @@
       "303": 3
     }
   },
-  "experimental_talk": {
+  "streaming_talk": {
     "predict_duration": {
       "type": "onnx",
       "filename": "predict_duration.onnx"


### PR DESCRIPTION
## 内容

VVMのフォーマットバージョン`2`はこれをもって確定する予定。

BREAKING-CHANGE: VOICEVOX COREが認識する`vvm_format_version=2`形式が変わる。

## 関連 Issue

Resolves: #1396
Resolves: #1365

## その他
