### PR TITLE
feat!: `Onnxruntime`の定数APIを再編する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 ### Added
 
 - `Synthesizer::load_voice_model`にオプション`on_existing`が追加されます ([#1331], [#1337])。
+- `Onnxruntime`の関連定数として`LIB_MIN_REQUIRED_MINOR_VERSION`と`LIB_MAX_SUPPORTED_MINOR_VERSION`が追加されます ([#1402])。
 - \[Rust\] APIドキュメントが改善されます ([#1343], [#1381])。
     - トップページのコード例で`tracing_subscriber::fmt().init();`が行われるようになります。
     - \[Linux\] muslターゲットでは`load-onnxruntime`が事実上利用不可であることが明記されます。
@@ -54,6 +55,7 @@
 
 ### Changed
 
+- \[BREAKING\] `Onnxruntime`の関連定数４つが`LIB_RECOMMENDED_…`という形に改名されます ([#1402])。
 - \[BREAKING\] `AudioQuery`/`AccentPhrase`/`Mora`の警告が、`output_sampling_rate`のものを除きエラーになります。また入力するテキストにより`AccentPhrase`作成時点でエラーになるケースがあります。Rust APIにおいては、制約が強くなる形で各フィールドの型が変わります ([#1384])。
 - \[Windows,Linux\] CUDA利用時における[`cudnn_conv_algo_search`](https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#cudnn_conv_algo_search)の値が`DEFAULT`から`HEURISTIC`に変わります。これにより、新しいONNX RuntimeのCUDAでも[それなりの動作速度を保ちます](https://github.com/VOICEVOX/voicevox_core/issues/1391#issuecomment-5121934874) ([#1392])。
 - \[Rust\] \[BREAKING\] `Synthesizer::load_voice_model`がビルダースタイルになります ([#1331])。
@@ -1530,6 +1532,7 @@ Windows版ダウンローダーのビルドに失敗しています。
 [#1392]: https://github.com/VOICEVOX/voicevox_core/pull/1392
 [#1394]: https://github.com/VOICEVOX/voicevox_core/pull/1394
 [#1399]: https://github.com/VOICEVOX/voicevox_core/pull/1399
+[#1402]: https://github.com/VOICEVOX/voicevox_core/pull/1402
 
 [VOICEVOX/onnxruntime-builder#25]: https://github.com/VOICEVOX/onnxruntime-builder/pull/25
 

--- a/crates/voicevox_core/examples/talk.rs
+++ b/crates/voicevox_core/examples/talk.rs
@@ -9,7 +9,7 @@ use voicevox_core::blocking::{Onnxruntime, OpenJtalk, Synthesizer, VoiceModelFil
 const VOICEVOX_CORE_DIR: &str = "./voicevox_core";
 const DEFAULT_ONNXRUNTIME: &str = formatcp!(
     "{VOICEVOX_CORE_DIR}/onnxruntime/lib/{}",
-    Onnxruntime::LIB_VERSIONED_FILENAME,
+    Onnxruntime::LIB_RECOMMENDED_VERSIONED_FILENAME,
 );
 const DEFAULT_MODEL: &str = formatcp!("{VOICEVOX_CORE_DIR}/models/vvms/0.vvm");
 const DEFAULT_DICT: &str = formatcp!("{VOICEVOX_CORE_DIR}/dict/open_jtalk_dic_utf_8-1.11");

--- a/crates/voicevox_core/src/core/infer/runtimes/onnxruntime.rs
+++ b/crates/voicevox_core/src/core/infer/runtimes/onnxruntime.rs
@@ -721,15 +721,12 @@ pub(crate) mod blocking {
         }
     }
 
-    #[cfg(feature = "load-onnxruntime")]
-    const _: () = {
-        assert!(
-            Onnxruntime::LIB_MIN_REQUIRED_MINOR_VERSION == super::LIB_MIN_REQUIRED_MINOR_VERSION
-        );
-        assert!(
-            Onnxruntime::LIB_MAX_SUPPORTED_MINOR_VERSION == super::LIB_MAX_SUPPORTED_MINOR_VERSION
-        );
-    };
+    const _: () = assert!(
+        Onnxruntime::LIB_MIN_REQUIRED_MINOR_VERSION == super::LIB_MIN_REQUIRED_MINOR_VERSION,
+    );
+    const _: () = assert!(
+        Onnxruntime::LIB_MAX_SUPPORTED_MINOR_VERSION == super::LIB_MAX_SUPPORTED_MINOR_VERSION,
+    );
 
     /// [`Onnxruntime::load_once`]のビルダー。
     #[cfg(feature = "load-onnxruntime")]
@@ -900,15 +897,12 @@ pub(crate) mod nonblocking {
         }
     }
 
-    #[cfg(feature = "load-onnxruntime")]
-    const _: () = {
-        assert!(
-            Onnxruntime::LIB_MIN_REQUIRED_MINOR_VERSION == super::LIB_MIN_REQUIRED_MINOR_VERSION
-        );
-        assert!(
-            Onnxruntime::LIB_MAX_SUPPORTED_MINOR_VERSION == super::LIB_MAX_SUPPORTED_MINOR_VERSION
-        );
-    };
+    const _: () = assert!(
+        Onnxruntime::LIB_MIN_REQUIRED_MINOR_VERSION == super::LIB_MIN_REQUIRED_MINOR_VERSION,
+    );
+    const _: () = assert!(
+        Onnxruntime::LIB_MAX_SUPPORTED_MINOR_VERSION == super::LIB_MAX_SUPPORTED_MINOR_VERSION,
+    );
 
     /// [`Onnxruntime::load_once`]のビルダー。
     #[cfg(feature = "load-onnxruntime")]

--- a/crates/voicevox_core/src/core/infer/runtimes/onnxruntime.rs
+++ b/crates/voicevox_core/src/core/infer/runtimes/onnxruntime.rs
@@ -44,8 +44,8 @@ use super::super::{
     ParamInfo, PushInputTensor,
 };
 
-const LIB_MIN_REQUIRED_VERSION: u32 = ort::sys::ORT_API_VERSION;
-const LIB_MAX_SUPPORTED_VERSION: u32 = ort::sys::ORT_API_VERSION;
+const LIB_MIN_REQUIRED_MINOR_VERSION: u32 = ort::sys::ORT_API_VERSION;
+const LIB_MAX_SUPPORTED_MINOR_VERSION: u32 = ort::sys::ORT_API_VERSION;
 
 static SINGLETON: once_cell::sync::OnceCell<Inner> = once_cell::sync::OnceCell::new();
 
@@ -163,15 +163,15 @@ fn setup(
     );
 
     match minor_version.try_into() {
-        Ok(..LIB_MIN_REQUIRED_VERSION) => bail!(
+        Ok(..LIB_MIN_REQUIRED_MINOR_VERSION) => bail!(
             "{message_for_version}。\
-             ONNX Runtimeはバージョン1.{LIB_MIN_REQUIRED_VERSION}以降でなくてはなりません",
+             ONNX Runtimeはバージョン1.{LIB_MIN_REQUIRED_MINOR_VERSION}以降でなくてはなりません",
             message_for_version = lib_info.message_for_version(version_string.to_string_lossy()),
         ),
-        Ok(LIB_MIN_REQUIRED_VERSION..=LIB_MAX_SUPPORTED_VERSION) => {}
+        Ok(LIB_MIN_REQUIRED_MINOR_VERSION..=LIB_MAX_SUPPORTED_MINOR_VERSION) => {}
         Ok(_) | Err(_) => warn!(
             "{message_for_version}。\
-             サポートされているONNX Runtimeのバージョンは1.{LIB_MAX_SUPPORTED_VERSION}までなので、\
+             サポートされているONNX Runtimeのバージョンは1.{LIB_MAX_SUPPORTED_MINOR_VERSION}までなので、\
              互換性の問題があるかもしれません",
             message_for_version = lib_info.message_for_version(version_string.to_string_lossy()),
         ),
@@ -584,12 +584,18 @@ pub(crate) mod blocking {
 
     impl Onnxruntime {
         /// 必要なONNX Runtime 1.xの最小マイナーバージョン。
-        #[cfg_attr(doc, doc(alias = "voicevox_get_onnxruntime_lib_min_required_version"))]
-        pub const LIB_MIN_REQUIRED_VERSION: u32 = 17;
+        #[cfg_attr(
+            doc,
+            doc(alias = "voicevox_get_onnxruntime_lib_min_required_minor_version")
+        )]
+        pub const LIB_MIN_REQUIRED_MINOR_VERSION: u32 = 17;
 
         /// サポートされるONNX Runtime 1.xの最大マイナーバージョン。
-        #[cfg_attr(doc, doc(alias = "voicevox_get_onnxruntime_lib_max_supported_version"))]
-        pub const LIB_MAX_SUPPORTED_VERSION: u32 = 17;
+        #[cfg_attr(
+            doc,
+            doc(alias = "voicevox_get_onnxruntime_lib_max_supported_minor_version")
+        )]
+        pub const LIB_MAX_SUPPORTED_MINOR_VERSION: u32 = 17;
 
         /// 推奨されるONNX Runtimeのライブラリ名。
         #[cfg(feature = "load-onnxruntime")]
@@ -662,12 +668,12 @@ pub(crate) mod blocking {
 
         /// ONNX Runtimeをロードして初期化する。
         ///
-        /// 対象のONNX Runtimeはバージョン<code>1.[LIB_MIN_REQUIRED_VERSION]</code>以降のものでなければならない。バージョン<code>1.[LIB_MAX_SUPPORTED_VERSION]</code>よりも新しいONNX Runtimeに対しては[警告]を出す。
+        /// 対象のONNX Runtimeはバージョン<code>1.[LIB_MIN_REQUIRED_MINOR_VERSION]</code>以降のものでなければならない。バージョン<code>1.[LIB_MAX_SUPPORTED_MINOR_VERSION]</code>よりも新しいONNX Runtimeに対しては[警告]を出す。
         ///
         /// 一度成功したら、以後は引数を無視して同じ参照を返す。
         ///
-        /// [LIB_MIN_REQUIRED_VERSION]: Self::LIB_MIN_REQUIRED_VERSION
-        /// [LIB_MAX_SUPPORTED_VERSION]: Self::LIB_MAX_SUPPORTED_VERSION
+        /// [LIB_MIN_REQUIRED_MINOR_VERSION]: Self::LIB_MIN_REQUIRED_MINOR_VERSION
+        /// [LIB_MAX_SUPPORTED_MINOR_VERSION]: Self::LIB_MAX_SUPPORTED_MINOR_VERSION
         /// [警告]: tracing::warn
         #[cfg_attr(doc, doc(alias = "voicevox_onnxruntime_load_once"))]
         #[cfg(feature = "load-onnxruntime")]
@@ -678,12 +684,12 @@ pub(crate) mod blocking {
 
         /// ONNX Runtimeを初期化する。
         ///
-        /// リンクされているONNX Runtimeがバージョン<code>1.[LIB_MIN_REQUIRED_VERSION]</code>よりも古い場合失敗する。バージョン<code>1.[LIB_MAX_SUPPORTED_VERSION]</code>よりも新しい場合は[警告]を出す。
+        /// リンクされているONNX Runtimeがバージョン<code>1.[LIB_MIN_REQUIRED_MINOR_VERSION]</code>よりも古い場合失敗する。バージョン<code>1.[LIB_MAX_SUPPORTED_MINOR_VERSION]</code>よりも新しい場合は[警告]を出す。
         ///
         /// 一度成功したら以後は同じ参照を返す。
         ///
-        /// [LIB_MIN_REQUIRED_VERSION]: Self::LIB_MIN_REQUIRED_VERSION
-        /// [LIB_MAX_SUPPORTED_VERSION]: Self::LIB_MAX_SUPPORTED_VERSION
+        /// [LIB_MIN_REQUIRED_MINOR_VERSION]: Self::LIB_MIN_REQUIRED_MINOR_VERSION
+        /// [LIB_MAX_SUPPORTED_MINOR_VERSION]: Self::LIB_MAX_SUPPORTED_MINOR_VERSION
         /// [警告]: tracing::warn
         #[cfg_attr(doc, doc(alias = "voicevox_onnxruntime_init_once"))]
         #[cfg(feature = "link-onnxruntime")]
@@ -717,8 +723,12 @@ pub(crate) mod blocking {
 
     #[cfg(feature = "load-onnxruntime")]
     const _: () = {
-        assert!(Onnxruntime::LIB_MIN_REQUIRED_VERSION == super::LIB_MIN_REQUIRED_VERSION);
-        assert!(Onnxruntime::LIB_MAX_SUPPORTED_VERSION == super::LIB_MAX_SUPPORTED_VERSION);
+        assert!(
+            Onnxruntime::LIB_MIN_REQUIRED_MINOR_VERSION == super::LIB_MIN_REQUIRED_MINOR_VERSION
+        );
+        assert!(
+            Onnxruntime::LIB_MAX_SUPPORTED_MINOR_VERSION == super::LIB_MAX_SUPPORTED_MINOR_VERSION
+        );
     };
 
     /// [`Onnxruntime::load_once`]のビルダー。
@@ -798,10 +808,10 @@ pub(crate) mod nonblocking {
 
     impl Onnxruntime {
         /// 必要なONNX Runtime 1.xの最小マイナーバージョン。
-        pub const LIB_MIN_REQUIRED_VERSION: u32 = 17;
+        pub const LIB_MIN_REQUIRED_MINOR_VERSION: u32 = 17;
 
         /// サポートされるONNX Runtime 1.xの最大マイナーバージョン。
-        pub const LIB_MAX_SUPPORTED_VERSION: u32 = 17;
+        pub const LIB_MAX_SUPPORTED_MINOR_VERSION: u32 = 17;
 
         /// 推奨されるONNX Runtimeのライブラリ名。
         #[cfg(feature = "load-onnxruntime")]
@@ -848,12 +858,12 @@ pub(crate) mod nonblocking {
 
         /// ONNX Runtimeをロードして初期化する。
         ///
-        /// 対象のONNX Runtimeはバージョン<code>1.[LIB_MIN_REQUIRED_VERSION]</code>以降のものでなければならない。バージョン<code>1.[LIB_MAX_SUPPORTED_VERSION]</code>よりも新しいONNX Runtimeに対しては[警告]を出す。
+        /// 対象のONNX Runtimeはバージョン<code>1.[LIB_MIN_REQUIRED_MINOR_VERSION]</code>以降のものでなければならない。バージョン<code>1.[LIB_MAX_SUPPORTED_MINOR_VERSION]</code>よりも新しいONNX Runtimeに対しては[警告]を出す。
         ///
         /// 一度成功したら、以後は引数を無視して同じ参照を返す。
         ///
-        /// [LIB_MIN_REQUIRED_VERSION]: Self::LIB_MIN_REQUIRED_VERSION
-        /// [LIB_MAX_SUPPORTED_VERSION]: Self::LIB_MAX_SUPPORTED_VERSION
+        /// [LIB_MIN_REQUIRED_MINOR_VERSION]: Self::LIB_MIN_REQUIRED_MINOR_VERSION
+        /// [LIB_MAX_SUPPORTED_MINOR_VERSION]: Self::LIB_MAX_SUPPORTED_MINOR_VERSION
         /// [警告]: tracing::warn
         #[cfg(feature = "load-onnxruntime")]
         #[cfg_attr(docsrs, doc(cfg(feature = "load-onnxruntime")))]
@@ -863,12 +873,12 @@ pub(crate) mod nonblocking {
 
         /// ONNX Runtimeを初期化する。
         ///
-        /// リンクされているONNX Runtimeがバージョン<code>1.[LIB_MIN_REQUIRED_VERSION]</code>よりも古い場合失敗する。バージョン<code>1.[LIB_MAX_SUPPORTED_VERSION]</code>よりも新しい場合は[警告]を出す。
+        /// リンクされているONNX Runtimeがバージョン<code>1.[LIB_MIN_REQUIRED_MINOR_VERSION]</code>よりも古い場合失敗する。バージョン<code>1.[LIB_MAX_SUPPORTED_MINOR_VERSION]</code>よりも新しい場合は[警告]を出す。
         ///
         /// 一度成功したら以後は同じ参照を返す。
         ///
-        /// [LIB_MIN_REQUIRED_VERSION]: Self::LIB_MIN_REQUIRED_VERSION
-        /// [LIB_MAX_SUPPORTED_VERSION]: Self::LIB_MAX_SUPPORTED_VERSION
+        /// [LIB_MIN_REQUIRED_MINOR_VERSION]: Self::LIB_MIN_REQUIRED_MINOR_VERSION
+        /// [LIB_MAX_SUPPORTED_MINOR_VERSION]: Self::LIB_MAX_SUPPORTED_MINOR_VERSION
         /// [警告]: tracing::warn
         #[cfg(feature = "link-onnxruntime")]
         #[cfg_attr(docsrs, doc(cfg(feature = "link-onnxruntime")))]
@@ -892,8 +902,12 @@ pub(crate) mod nonblocking {
 
     #[cfg(feature = "load-onnxruntime")]
     const _: () = {
-        assert!(Onnxruntime::LIB_MIN_REQUIRED_VERSION == super::LIB_MIN_REQUIRED_VERSION);
-        assert!(Onnxruntime::LIB_MAX_SUPPORTED_VERSION == super::LIB_MAX_SUPPORTED_VERSION);
+        assert!(
+            Onnxruntime::LIB_MIN_REQUIRED_MINOR_VERSION == super::LIB_MIN_REQUIRED_MINOR_VERSION
+        );
+        assert!(
+            Onnxruntime::LIB_MAX_SUPPORTED_MINOR_VERSION == super::LIB_MAX_SUPPORTED_MINOR_VERSION
+        );
     };
 
     /// [`Onnxruntime::load_once`]のビルダー。

--- a/crates/voicevox_core/src/core/infer/runtimes/onnxruntime.rs
+++ b/crates/voicevox_core/src/core/infer/runtimes/onnxruntime.rs
@@ -583,11 +583,11 @@ pub(crate) mod blocking {
     pub struct Onnxruntime(Inner);
 
     impl Onnxruntime {
-        /// 必要なONNX Runtimeの最小マイナーバージョン。
+        /// 必要なONNX Runtime 1.xの最小マイナーバージョン。
         #[cfg_attr(doc, doc(alias = "voicevox_get_onnxruntime_lib_min_required_version"))]
         pub const LIB_MIN_REQUIRED_VERSION: u32 = 17;
 
-        /// サポートされるONNX Runtimeの最大マイナーバージョン。
+        /// サポートされるONNX Runtime 1.xの最大マイナーバージョン。
         #[cfg_attr(doc, doc(alias = "voicevox_get_onnxruntime_lib_max_supported_version"))]
         pub const LIB_MAX_SUPPORTED_VERSION: u32 = 17;
 
@@ -797,10 +797,10 @@ pub(crate) mod nonblocking {
     pub struct Onnxruntime(pub(crate) super::blocking::Onnxruntime);
 
     impl Onnxruntime {
-        /// 必要なONNX Runtimeの最小マイナーバージョン。
+        /// 必要なONNX Runtime 1.xの最小マイナーバージョン。
         pub const LIB_MIN_REQUIRED_VERSION: u32 = 17;
 
-        /// サポートされるONNX Runtimeの最大マイナーバージョン。
+        /// サポートされるONNX Runtime 1.xの最大マイナーバージョン。
         pub const LIB_MAX_SUPPORTED_VERSION: u32 = 17;
 
         /// 推奨されるONNX Runtimeのライブラリ名。

--- a/crates/voicevox_core/src/core/infer/runtimes/onnxruntime.rs
+++ b/crates/voicevox_core/src/core/infer/runtimes/onnxruntime.rs
@@ -12,7 +12,6 @@
 // ```
 
 use std::{
-    cmp,
     ffi::CStr,
     fmt::{Debug, Display},
     mem,
@@ -44,6 +43,9 @@ use super::super::{
     InferenceRuntime, InferenceSessionOptions, InputScalarKind, OutputScalarKind, OutputTensor,
     ParamInfo, PushInputTensor,
 };
+
+const LIB_MIN_REQUIRED_VERSION: u32 = ort::sys::ORT_API_VERSION;
+const LIB_MAX_SUPPORTED_VERSION: u32 = ort::sys::ORT_API_VERSION;
 
 static SINGLETON: once_cell::sync::OnceCell<Inner> = once_cell::sync::OnceCell::new();
 
@@ -136,8 +138,6 @@ fn setup(
 ) -> anyhow::Result<()> {
     const EXPECTED_MAJOR_VERSION: u64 = 1;
 
-    const _: () = assert!(ort::sys::ORT_API_VERSION == 17);
-
     // SAFETY: `GetVersionString` should require no preconditions,
     // and should return a valid string.
     let version_string = unsafe { ((api_base).GetVersionString)() };
@@ -151,7 +151,7 @@ fn setup(
             let major_version = version_string.next()?.parse::<u64>().ok()?;
             let minor_version = version_string
                 .next()
-                .and_then(|s| s.parse().ok())
+                .and_then(|s| s.parse::<u64>().ok())
                 .unwrap_or(0);
             Some((major_version, minor_version))
         })
@@ -162,23 +162,20 @@ fn setup(
         "invalid major version",
     );
 
-    match minor_version.cmp(&u64::from(ort::sys::ORT_API_VERSION)) {
-        cmp::Ordering::Less => bail!(
+    match minor_version.try_into() {
+        Ok(..LIB_MIN_REQUIRED_VERSION) => bail!(
             "{message_for_version}。\
-             ONNX Runtimeはバージョン1.{ORT_API_VERSION}でなくてはなりません",
+             ONNX Runtimeはバージョン1.{LIB_MIN_REQUIRED_VERSION}以降でなくてはなりません",
             message_for_version = lib_info.message_for_version(version_string.to_string_lossy()),
-            ORT_API_VERSION = ort::sys::ORT_API_VERSION,
         ),
-        // TODO: 問題ないとわかっている既知のものであれば警告無しで許容しつつ、未来のものは拒否する。
-        cmp::Ordering::Greater => warn!(
+        Ok(LIB_MIN_REQUIRED_VERSION..=LIB_MAX_SUPPORTED_VERSION) => {}
+        Ok(_) | Err(_) => warn!(
             "{message_for_version}。\
-             対応しているONNX Runtimeのバージョンは1.{ORT_API_VERSION}なので、\
+             サポートされているONNX Runtimeのバージョンは1.{LIB_MAX_SUPPORTED_VERSION}までなので、\
              互換性の問題があるかもしれません",
             message_for_version = lib_info.message_for_version(version_string.to_string_lossy()),
-            ORT_API_VERSION = ort::sys::ORT_API_VERSION,
         ),
-        cmp::Ordering::Equal => {}
-    };
+    }
 
     // SAFETY: `GetApi` should require no preconditions, and should return a valid `OrtApi`.
     let api = unsafe { (api_base.GetApi)(ort::sys::ORT_API_VERSION) };
@@ -586,54 +583,69 @@ pub(crate) mod blocking {
     pub struct Onnxruntime(Inner);
 
     impl Onnxruntime {
-        /// ONNX Runtimeのライブラリ名。
+        /// 必要なONNX Runtimeの最小マイナーバージョン。
+        #[cfg_attr(doc, doc(alias = "voicevox_get_onnxruntime_lib_min_required_version"))]
+        pub const LIB_MIN_REQUIRED_VERSION: u32 = 17;
+
+        /// サポートされるONNX Runtimeの最大マイナーバージョン。
+        #[cfg_attr(doc, doc(alias = "voicevox_get_onnxruntime_lib_max_supported_version"))]
+        pub const LIB_MAX_SUPPORTED_VERSION: u32 = 17;
+
+        /// 推奨されるONNX Runtimeのライブラリ名。
         #[cfg(feature = "load-onnxruntime")]
         #[cfg_attr(docsrs, doc(cfg(feature = "load-onnxruntime")))]
-        pub const LIB_NAME: &'static str = "voicevox_onnxruntime";
+        pub const LIB_RECOMMENDED_NAME: &'static str = "voicevox_onnxruntime";
 
         /// 推奨されるONNX Runtimeのバージョン。
         #[cfg(feature = "load-onnxruntime")]
         #[cfg_attr(docsrs, doc(cfg(feature = "load-onnxruntime")))]
-        pub const LIB_VERSION: &'static str = include_str!("../../../../onnxruntime-version.txt");
+        pub const LIB_RECOMMENDED_VERSION: &'static str =
+            include_str!("../../../../onnxruntime-version.txt");
 
-        /// [`LIB_NAME`]と[`LIB_VERSION`]からなる動的ライブラリのファイル名。
+        /// [`LIB_RECOMMENDED_NAME`]と[`LIB_RECOMMENDED_VERSION`]からなる動的ライブラリのファイル名。
         ///
-        /// WindowsとAndroidでは[`LIB_UNVERSIONED_FILENAME`]と同じ。
+        /// WindowsとAndroidでは[`LIB_RECOMMENDED_UNVERSIONED_FILENAME`]と同じ。
         ///
-        /// [`LIB_NAME`]: Self::LIB_NAME
-        /// [`LIB_VERSION`]: Self::LIB_VERSION
-        /// [`LIB_UNVERSIONED_FILENAME`]: Self::LIB_UNVERSIONED_FILENAME
-        #[cfg_attr(doc, doc(alias = "voicevox_get_onnxruntime_lib_versioned_filename"))]
+        /// [`LIB_RECOMMENDED_NAME`]: Self::LIB_RECOMMENDED_NAME
+        /// [`LIB_RECOMMENDED_VERSION`]: Self::LIB_RECOMMENDED_VERSION
+        /// [`LIB_RECOMMENDED_UNVERSIONED_FILENAME`]: Self::LIB_RECOMMENDED_UNVERSIONED_FILENAME
+        #[cfg_attr(
+            doc,
+            doc(alias = "voicevox_get_onnxruntime_lib_recommended_versioned_filename")
+        )]
         #[cfg(feature = "load-onnxruntime")]
         #[cfg_attr(docsrs, doc(cfg(feature = "load-onnxruntime")))]
-        pub const LIB_VERSIONED_FILENAME: &'static str = if cfg!(target_os = "linux") {
+        pub const LIB_RECOMMENDED_VERSIONED_FILENAME: &'static str = if cfg!(target_os = "linux") {
             const_format::concatcp!(
                 "lib",
-                Onnxruntime::LIB_NAME,
+                Onnxruntime::LIB_RECOMMENDED_NAME,
                 ".so.",
-                Onnxruntime::LIB_VERSION,
+                Onnxruntime::LIB_RECOMMENDED_VERSION,
             )
         } else if cfg!(any(target_os = "macos", target_os = "ios")) {
             const_format::concatcp!(
                 "lib",
-                Onnxruntime::LIB_NAME,
+                Onnxruntime::LIB_RECOMMENDED_NAME,
                 ".",
-                Onnxruntime::LIB_VERSION,
+                Onnxruntime::LIB_RECOMMENDED_VERSION,
                 ".dylib",
             )
         } else {
-            Self::LIB_UNVERSIONED_FILENAME
+            Self::LIB_RECOMMENDED_UNVERSIONED_FILENAME
         };
 
-        /// [`LIB_NAME`]からなる動的ライブラリのファイル名。
+        /// [`LIB_RECOMMENDED_NAME`]からなる動的ライブラリのファイル名。
         ///
-        /// [`LIB_NAME`]: Self::LIB_NAME
-        #[cfg_attr(doc, doc(alias = "voicevox_get_onnxruntime_lib_unversioned_filename"))]
+        /// [`LIB_RECOMMENDED_NAME`]: Self::LIB_RECOMMENDED_NAME
+        #[cfg_attr(
+            doc,
+            doc(alias = "voicevox_get_onnxruntime_lib_recommended_unversioned_filename")
+        )]
         #[cfg(feature = "load-onnxruntime")]
         #[cfg_attr(docsrs, doc(cfg(feature = "load-onnxruntime")))]
-        pub const LIB_UNVERSIONED_FILENAME: &'static str = const_format::concatcp!(
+        pub const LIB_RECOMMENDED_UNVERSIONED_FILENAME: &'static str = const_format::concatcp!(
             std::env::consts::DLL_PREFIX,
-            Onnxruntime::LIB_NAME,
+            Onnxruntime::LIB_RECOMMENDED_NAME,
             std::env::consts::DLL_SUFFIX,
         );
 
@@ -650,7 +662,13 @@ pub(crate) mod blocking {
 
         /// ONNX Runtimeをロードして初期化する。
         ///
+        /// 対象のONNX Runtimeはバージョン<code>1.[LIB_MIN_REQUIRED_VERSION]</code>以降のものでなければならない。バージョン<code>1.[LIB_MAX_SUPPORTED_VERSION]</code>よりも新しいONNX Runtimeに対しては[警告]を出す。
+        ///
         /// 一度成功したら、以後は引数を無視して同じ参照を返す。
+        ///
+        /// [LIB_MIN_REQUIRED_VERSION]: Self::LIB_MIN_REQUIRED_VERSION
+        /// [LIB_MAX_SUPPORTED_VERSION]: Self::LIB_MAX_SUPPORTED_VERSION
+        /// [警告]: tracing::warn
         #[cfg_attr(doc, doc(alias = "voicevox_onnxruntime_load_once"))]
         #[cfg(feature = "load-onnxruntime")]
         #[cfg_attr(docsrs, doc(cfg(feature = "load-onnxruntime")))]
@@ -660,7 +678,13 @@ pub(crate) mod blocking {
 
         /// ONNX Runtimeを初期化する。
         ///
+        /// リンクされているONNX Runtimeがバージョン<code>1.[LIB_MIN_REQUIRED_VERSION]</code>よりも古い場合失敗する。バージョン<code>1.[LIB_MAX_SUPPORTED_VERSION]</code>よりも新しい場合は[警告]を出す。
+        ///
         /// 一度成功したら以後は同じ参照を返す。
+        ///
+        /// [LIB_MIN_REQUIRED_VERSION]: Self::LIB_MIN_REQUIRED_VERSION
+        /// [LIB_MAX_SUPPORTED_VERSION]: Self::LIB_MAX_SUPPORTED_VERSION
+        /// [警告]: tracing::warn
         #[cfg_attr(doc, doc(alias = "voicevox_onnxruntime_init_once"))]
         #[cfg(feature = "link-onnxruntime")]
         #[cfg_attr(docsrs, doc(cfg(feature = "link-onnxruntime")))]
@@ -691,6 +715,12 @@ pub(crate) mod blocking {
         }
     }
 
+    #[cfg(feature = "load-onnxruntime")]
+    const _: () = {
+        assert!(Onnxruntime::LIB_MIN_REQUIRED_VERSION == super::LIB_MIN_REQUIRED_VERSION);
+        assert!(Onnxruntime::LIB_MAX_SUPPORTED_VERSION == super::LIB_MAX_SUPPORTED_VERSION);
+    };
+
     /// [`Onnxruntime::load_once`]のビルダー。
     #[cfg(feature = "load-onnxruntime")]
     #[must_use = "this is a builder. it does nothing until `perform`ed"]
@@ -702,7 +732,7 @@ pub(crate) mod blocking {
     #[cfg(feature = "load-onnxruntime")]
     impl Default for LoadOnce {
         fn default() -> Self {
-            let filename = Onnxruntime::LIB_VERSIONED_FILENAME.into();
+            let filename = Onnxruntime::LIB_RECOMMENDED_VERSIONED_FILENAME.into();
             Self { filename }
         }
     }
@@ -711,7 +741,7 @@ pub(crate) mod blocking {
     impl LoadOnce {
         /// ONNX Runtimeのファイル名（モジュール名）もしくはファイルパスを指定する。
         ///
-        /// `dlopen`/[`LoadLibraryExW`]の引数に使われる。デフォルトは[`Onnxruntime::LIB_VERSIONED_FILENAME`]。
+        /// `dlopen`/[`LoadLibraryExW`]の引数に使われる。デフォルトは[`Onnxruntime::LIB_RECOMMENDED_VERSIONED_FILENAME`]。
         ///
         /// [`LoadLibraryExW`]:
         /// https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexw
@@ -767,37 +797,44 @@ pub(crate) mod nonblocking {
     pub struct Onnxruntime(pub(crate) super::blocking::Onnxruntime);
 
     impl Onnxruntime {
-        /// ONNX Runtimeのライブラリ名。
+        /// 必要なONNX Runtimeの最小マイナーバージョン。
+        pub const LIB_MIN_REQUIRED_VERSION: u32 = 17;
+
+        /// サポートされるONNX Runtimeの最大マイナーバージョン。
+        pub const LIB_MAX_SUPPORTED_VERSION: u32 = 17;
+
+        /// 推奨されるONNX Runtimeのライブラリ名。
         #[cfg(feature = "load-onnxruntime")]
         #[cfg_attr(docsrs, doc(cfg(feature = "load-onnxruntime")))]
         // ブロッキング版と等しいことはテストで担保
-        pub const LIB_NAME: &'static str = "voicevox_onnxruntime";
+        pub const LIB_RECOMMENDED_NAME: &'static str = "voicevox_onnxruntime";
 
         /// 推奨されるONNX Runtimeのバージョン。
         #[cfg(feature = "load-onnxruntime")]
         #[cfg_attr(docsrs, doc(cfg(feature = "load-onnxruntime")))]
         // ブロッキング版と等しいことはテストで担保
-        pub const LIB_VERSION: &'static str = include_str!("../../../../onnxruntime-version.txt");
+        pub const LIB_RECOMMENDED_VERSION: &'static str =
+            include_str!("../../../../onnxruntime-version.txt");
 
-        /// [`LIB_NAME`]と[`LIB_VERSION`]からなる動的ライブラリのファイル名。
+        /// [`LIB_RECOMMENDED_NAME`]と[`LIB_RECOMMENDED_VERSION`]からなる動的ライブラリのファイル名。
         ///
-        /// WindowsとAndroidでは[`LIB_UNVERSIONED_FILENAME`]と同じ。
+        /// WindowsとAndroidでは[`LIB_RECOMMENDED_UNVERSIONED_FILENAME`]と同じ。
         ///
-        /// [`LIB_NAME`]: Self::LIB_NAME
-        /// [`LIB_VERSION`]: Self::LIB_VERSION
-        /// [`LIB_UNVERSIONED_FILENAME`]: Self::LIB_UNVERSIONED_FILENAME
+        /// [`LIB_RECOMMENDED_NAME`]: Self::LIB_RECOMMENDED_NAME
+        /// [`LIB_RECOMMENDED_VERSION`]: Self::LIB_RECOMMENDED_VERSION
+        /// [`LIB_RECOMMENDED_UNVERSIONED_FILENAME`]: Self::LIB_RECOMMENDED_UNVERSIONED_FILENAME
         #[cfg(feature = "load-onnxruntime")]
         #[cfg_attr(docsrs, doc(cfg(feature = "load-onnxruntime")))]
-        pub const LIB_VERSIONED_FILENAME: &'static str =
-            super::blocking::Onnxruntime::LIB_VERSIONED_FILENAME;
+        pub const LIB_RECOMMENDED_VERSIONED_FILENAME: &'static str =
+            super::blocking::Onnxruntime::LIB_RECOMMENDED_VERSIONED_FILENAME;
 
-        /// [`LIB_NAME`]からなる動的ライブラリのファイル名。
+        /// [`LIB_RECOMMENDED_NAME`]からなる動的ライブラリのファイル名。
         ///
-        /// [`LIB_NAME`]: Self::LIB_NAME
+        /// [`LIB_RECOMMENDED_NAME`]: Self::LIB_RECOMMENDED_NAME
         #[cfg(feature = "load-onnxruntime")]
         #[cfg_attr(docsrs, doc(cfg(feature = "load-onnxruntime")))]
-        pub const LIB_UNVERSIONED_FILENAME: &'static str =
-            super::blocking::Onnxruntime::LIB_UNVERSIONED_FILENAME;
+        pub const LIB_RECOMMENDED_UNVERSIONED_FILENAME: &'static str =
+            super::blocking::Onnxruntime::LIB_RECOMMENDED_UNVERSIONED_FILENAME;
 
         #[ref_cast_custom]
         pub(crate) const fn from_blocking(blocking: &super::blocking::Onnxruntime) -> &Self;
@@ -811,7 +848,13 @@ pub(crate) mod nonblocking {
 
         /// ONNX Runtimeをロードして初期化する。
         ///
+        /// 対象のONNX Runtimeはバージョン<code>1.[LIB_MIN_REQUIRED_VERSION]</code>以降のものでなければならない。バージョン<code>1.[LIB_MAX_SUPPORTED_VERSION]</code>よりも新しいONNX Runtimeに対しては[警告]を出す。
+        ///
         /// 一度成功したら、以後は引数を無視して同じ参照を返す。
+        ///
+        /// [LIB_MIN_REQUIRED_VERSION]: Self::LIB_MIN_REQUIRED_VERSION
+        /// [LIB_MAX_SUPPORTED_VERSION]: Self::LIB_MAX_SUPPORTED_VERSION
+        /// [警告]: tracing::warn
         #[cfg(feature = "load-onnxruntime")]
         #[cfg_attr(docsrs, doc(cfg(feature = "load-onnxruntime")))]
         pub fn load_once() -> LoadOnce {
@@ -820,7 +863,13 @@ pub(crate) mod nonblocking {
 
         /// ONNX Runtimeを初期化する。
         ///
+        /// リンクされているONNX Runtimeがバージョン<code>1.[LIB_MIN_REQUIRED_VERSION]</code>よりも古い場合失敗する。バージョン<code>1.[LIB_MAX_SUPPORTED_VERSION]</code>よりも新しい場合は[警告]を出す。
+        ///
         /// 一度成功したら以後は同じ参照を返す。
+        ///
+        /// [LIB_MIN_REQUIRED_VERSION]: Self::LIB_MIN_REQUIRED_VERSION
+        /// [LIB_MAX_SUPPORTED_VERSION]: Self::LIB_MAX_SUPPORTED_VERSION
+        /// [警告]: tracing::warn
         #[cfg(feature = "link-onnxruntime")]
         #[cfg_attr(docsrs, doc(cfg(feature = "link-onnxruntime")))]
         pub async fn init_once() -> crate::Result<&'static Self> {
@@ -841,6 +890,12 @@ pub(crate) mod nonblocking {
         }
     }
 
+    #[cfg(feature = "load-onnxruntime")]
+    const _: () = {
+        assert!(Onnxruntime::LIB_MIN_REQUIRED_VERSION == super::LIB_MIN_REQUIRED_VERSION);
+        assert!(Onnxruntime::LIB_MAX_SUPPORTED_VERSION == super::LIB_MAX_SUPPORTED_VERSION);
+    };
+
     /// [`Onnxruntime::load_once`]のビルダー。
     #[cfg(feature = "load-onnxruntime")]
     #[derive(Default, derive_more::Debug)]
@@ -852,7 +907,7 @@ pub(crate) mod nonblocking {
     impl LoadOnce {
         /// ONNX Runtimeのファイル名（モジュール名）もしくはファイルパスを指定する。
         ///
-        /// `dlopen`/[`LoadLibraryExW`]の引数に使われる。デフォルトは[`Onnxruntime::LIB_VERSIONED_FILENAME`]。
+        /// `dlopen`/[`LoadLibraryExW`]の引数に使われる。デフォルトは[`Onnxruntime::LIB_RECOMMENDED_VERSIONED_FILENAME`]。
         ///
         /// [`LoadLibraryExW`]:
         /// https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexw
@@ -878,12 +933,12 @@ mod tests {
         use pretty_assertions::assert_eq;
 
         assert_eq!(
-            super::blocking::Onnxruntime::LIB_NAME,
-            super::nonblocking::Onnxruntime::LIB_NAME,
+            super::blocking::Onnxruntime::LIB_RECOMMENDED_NAME,
+            super::nonblocking::Onnxruntime::LIB_RECOMMENDED_NAME,
         );
         assert_eq!(
-            super::blocking::Onnxruntime::LIB_VERSION,
-            super::nonblocking::Onnxruntime::LIB_VERSION,
+            super::blocking::Onnxruntime::LIB_RECOMMENDED_VERSION,
+            super::nonblocking::Onnxruntime::LIB_RECOMMENDED_VERSION,
         );
     }
 

--- a/crates/voicevox_core/src/lib.rs
+++ b/crates/voicevox_core/src/lib.rs
@@ -46,7 +46,7 @@
 //! # #[cfg(false)]
 //! const VVORT: &str = concatcp!(
 //!     "./voicevox_core/onnxruntime/lib/",
-//!     Onnxruntime::LIB_VERSIONED_FILENAME,
+//!     Onnxruntime::LIB_RECOMMENDED_VERSIONED_FILENAME,
 //! );
 //! # use test_util::ONNXRUNTIME_DYLIB_PATH as VVORT;
 //!
@@ -132,7 +132,7 @@
 //! # #[cfg(false)]
 //! const VVORT: &str = concatcp!(
 //!     "./voicevox_core/onnxruntime/lib/",
-//!     Onnxruntime::LIB_VERSIONED_FILENAME,
+//!     Onnxruntime::LIB_RECOMMENDED_VERSIONED_FILENAME,
 //! );
 //! # use test_util::ONNXRUNTIME_DYLIB_PATH as VVORT;
 //!

--- a/crates/voicevox_core_c_api/include/voicevox_core.h
+++ b/crates/voicevox_core_c_api/include/voicevox_core.h
@@ -609,7 +609,7 @@ const struct VoicevoxOnnxruntime *voicevox_onnxruntime_get(void);
 /**
  * ONNX Runtimeをロードして初期化する。
  *
- * 対象のONNX Runtimeのマイナーバージョンは ::voicevox_get_onnxruntime_lib_min_required_minor_version よりも大きくなければならない。 ::voicevox_get_onnxruntime_lib_max_supported_minor_version よりも大きい場合は警告を出す。
+ * 対象のONNX Runtimeのマイナーバージョンは ::voicevox_get_onnxruntime_lib_min_required_minor_version 以上でなければならない。 ::voicevox_get_onnxruntime_lib_max_supported_minor_version よりも大きい場合は警告を出す。
  *
  * 一度成功したら、以後は引数を無視して同じ参照を返す。
  *

--- a/crates/voicevox_core_c_api/include/voicevox_core.h
+++ b/crates/voicevox_core_c_api/include/voicevox_core.h
@@ -396,7 +396,7 @@ typedef struct VoicevoxLoadOnnxruntimeOptions {
   /**
    * ONNX Runtimeのファイル名（モジュール名）もしくはファイルパスを指定する。
    *
-   * `dlopen`/[`LoadLibraryExW`](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexw)の引数に使われる。デフォルトは ::voicevox_get_onnxruntime_lib_versioned_filename と同じ。
+   * `dlopen`/[`LoadLibraryExW`](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexw)の引数に使われる。デフォルトは ::voicevox_get_onnxruntime_lib_recommended_versioned_filename と同じ。
    */
   const char *filename;
 } VoicevoxLoadOnnxruntimeOptions;
@@ -515,38 +515,62 @@ typedef struct VoicevoxUserDictWord {
 extern "C" {
 #endif // __cplusplus
 
+/**
+ * 必要なONNX Runtime 1.xの最小マイナーバージョンを取得する。
+ *
+ * @return 必要な最小マイナーバージョン
+ *
+ * \orig-impl{voicevox_get_onnxruntime_lib_min_required_version}
+ */
+#ifdef _WIN32
+__declspec(dllimport)
+#endif
+uint32_t voicevox_get_onnxruntime_lib_min_required_version(void);
+
+/**
+ * サポートされるONNX Runtime 1.xの最大マイナーバージョンを取得する。
+ *
+ * @return サポートされる最大マイナーバージョン
+ *
+ * \orig-impl{voicevox_get_onnxruntime_lib_max_supported_version}
+ */
+#ifdef _WIN32
+__declspec(dllimport)
+#endif
+uint32_t voicevox_get_onnxruntime_lib_max_supported_version(void);
+
 #if defined(VOICEVOX_LOAD_ONNXRUNTIME)
 /**
- * ONNX Runtimeの動的ライブラリの、バージョン付きのファイル名。
+ * 推奨されるONNX Runtimeの動的ライブラリの、バージョン付きのファイル名。
  *
- * WindowsとAndroidでは ::voicevox_get_onnxruntime_lib_unversioned_filename と同じ。
+ * WindowsとAndroidでは ::voicevox_get_onnxruntime_lib_recommended_unversioned_filename と同じ。
  *
  * \availability{
  *   [リリース](https://github.com/voicevox/voicevox_core/releases)されているライブラリではiOSを除くプラットフォームで利用可能。詳細は<a href="#voicevox-core-availability">ファイルレベルの"Availability"の節</a>を参照。
  * }
  *
- * \orig-impl{voicevox_get_onnxruntime_lib_versioned_filename}
+ * \orig-impl{voicevox_get_onnxruntime_lib_recommended_versioned_filename}
  */
 #ifdef _WIN32
 __declspec(dllimport)
 #endif
-const char *voicevox_get_onnxruntime_lib_versioned_filename(void);
+const char *voicevox_get_onnxruntime_lib_recommended_versioned_filename(void);
 #endif
 
 #if defined(VOICEVOX_LOAD_ONNXRUNTIME)
 /**
- * ONNX Runtimeの動的ライブラリの、バージョン無しのファイル名。
+ * 推奨されるONNX Runtimeの動的ライブラリの、バージョン無しのファイル名。
  *
  * \availability{
  *   [リリース](https://github.com/voicevox/voicevox_core/releases)されているライブラリではiOSを除くプラットフォームで利用可能。詳細は<a href="#voicevox-core-availability">ファイルレベルの"Availability"の節</a>を参照。
  * }
  *
- * \orig-impl{voicevox_get_onnxruntime_lib_unversioned_filename}
+ * \orig-impl{voicevox_get_onnxruntime_lib_recommended_unversioned_filename}
  */
 #ifdef _WIN32
 __declspec(dllimport)
 #endif
-const char *voicevox_get_onnxruntime_lib_unversioned_filename(void);
+const char *voicevox_get_onnxruntime_lib_recommended_unversioned_filename(void);
 #endif
 
 #if defined(VOICEVOX_LOAD_ONNXRUNTIME)
@@ -585,6 +609,8 @@ const struct VoicevoxOnnxruntime *voicevox_onnxruntime_get(void);
 /**
  * ONNX Runtimeをロードして初期化する。
  *
+ * 対象のONNX Runtimeのマイナーバージョンは ::voicevox_get_onnxruntime_lib_min_required_version よりも大きくなければならない。 ::voicevox_get_onnxruntime_lib_max_supported_version よりも大きい場合は警告を出す。
+ *
  * 一度成功したら、以後は引数を無視して同じ参照を返す。
  *
  * @param [in] options オプション
@@ -613,6 +639,8 @@ VoicevoxResultCode voicevox_onnxruntime_load_once(struct VoicevoxLoadOnnxruntime
 #if defined(VOICEVOX_LINK_ONNXRUNTIME)
 /**
  * ONNX Runtimeを初期化する。
+ *
+ * リンクされているONNX Runtimeのマイナーバージョンが ::voicevox_get_onnxruntime_lib_min_required_version よりも小さい場合失敗する。 ::voicevox_get_onnxruntime_lib_max_supported_version よりも大きい場合は警告を出す。
  *
  * 一度成功したら以後は同じ参照を返す。
  *

--- a/crates/voicevox_core_c_api/include/voicevox_core.h
+++ b/crates/voicevox_core_c_api/include/voicevox_core.h
@@ -520,24 +520,24 @@ extern "C" {
  *
  * @return 必要な最小マイナーバージョン
  *
- * \orig-impl{voicevox_get_onnxruntime_lib_min_required_version}
+ * \orig-impl{voicevox_get_onnxruntime_lib_min_required_minor_version}
  */
 #ifdef _WIN32
 __declspec(dllimport)
 #endif
-uint32_t voicevox_get_onnxruntime_lib_min_required_version(void);
+uint32_t voicevox_get_onnxruntime_lib_min_required_minor_version(void);
 
 /**
  * サポートされるONNX Runtime 1.xの最大マイナーバージョンを取得する。
  *
  * @return サポートされる最大マイナーバージョン
  *
- * \orig-impl{voicevox_get_onnxruntime_lib_max_supported_version}
+ * \orig-impl{voicevox_get_onnxruntime_lib_max_supported_minor_version}
  */
 #ifdef _WIN32
 __declspec(dllimport)
 #endif
-uint32_t voicevox_get_onnxruntime_lib_max_supported_version(void);
+uint32_t voicevox_get_onnxruntime_lib_max_supported_minor_version(void);
 
 #if defined(VOICEVOX_LOAD_ONNXRUNTIME)
 /**
@@ -609,7 +609,7 @@ const struct VoicevoxOnnxruntime *voicevox_onnxruntime_get(void);
 /**
  * ONNX Runtimeをロードして初期化する。
  *
- * 対象のONNX Runtimeのマイナーバージョンは ::voicevox_get_onnxruntime_lib_min_required_version よりも大きくなければならない。 ::voicevox_get_onnxruntime_lib_max_supported_version よりも大きい場合は警告を出す。
+ * 対象のONNX Runtimeのマイナーバージョンは ::voicevox_get_onnxruntime_lib_min_required_minor_version よりも大きくなければならない。 ::voicevox_get_onnxruntime_lib_max_supported_minor_version よりも大きい場合は警告を出す。
  *
  * 一度成功したら、以後は引数を無視して同じ参照を返す。
  *
@@ -640,7 +640,7 @@ VoicevoxResultCode voicevox_onnxruntime_load_once(struct VoicevoxLoadOnnxruntime
 /**
  * ONNX Runtimeを初期化する。
  *
- * リンクされているONNX Runtimeのマイナーバージョンが ::voicevox_get_onnxruntime_lib_min_required_version よりも小さい場合失敗する。 ::voicevox_get_onnxruntime_lib_max_supported_version よりも大きい場合は警告を出す。
+ * リンクされているONNX Runtimeのマイナーバージョンが ::voicevox_get_onnxruntime_lib_min_required_minor_version よりも小さい場合失敗する。 ::voicevox_get_onnxruntime_lib_max_supported_minor_version よりも大きい場合は警告を出す。
  *
  * 一度成功したら以後は同じ参照を返す。
  *

--- a/crates/voicevox_core_c_api/src/c_impls.rs
+++ b/crates/voicevox_core_c_api/src/c_impls.rs
@@ -24,13 +24,19 @@ use crate::{
 // 欠いている
 
 impl VoicevoxOnnxruntime {
-    #[cfg(feature = "load-onnxruntime")]
-    pub(crate) const LIB_VERSIONED_FILENAME: &'static std::ffi::CStr =
-        to_cstr!(voicevox_core::blocking::Onnxruntime::LIB_VERSIONED_FILENAME);
+    pub(crate) const LIB_MIN_REQUIRED_VERSION: u32 =
+        voicevox_core::blocking::Onnxruntime::LIB_MIN_REQUIRED_VERSION;
+
+    pub(crate) const LIB_MAX_SUPPORTED_VERSION: u32 =
+        voicevox_core::blocking::Onnxruntime::LIB_MAX_SUPPORTED_VERSION;
 
     #[cfg(feature = "load-onnxruntime")]
-    pub(crate) const LIB_UNVERSIONED_FILENAME: &'static std::ffi::CStr =
-        to_cstr!(voicevox_core::blocking::Onnxruntime::LIB_UNVERSIONED_FILENAME);
+    pub(crate) const LIB_RECOMMENDED_VERSIONED_FILENAME: &'static std::ffi::CStr =
+        to_cstr!(voicevox_core::blocking::Onnxruntime::LIB_RECOMMENDED_VERSIONED_FILENAME);
+
+    #[cfg(feature = "load-onnxruntime")]
+    pub(crate) const LIB_RECOMMENDED_UNVERSIONED_FILENAME: &'static std::ffi::CStr =
+        to_cstr!(voicevox_core::blocking::Onnxruntime::LIB_RECOMMENDED_UNVERSIONED_FILENAME);
 
     #[ref_cast_custom]
     fn new(rust: &voicevox_core::blocking::Onnxruntime) -> &Self;

--- a/crates/voicevox_core_c_api/src/c_impls.rs
+++ b/crates/voicevox_core_c_api/src/c_impls.rs
@@ -24,11 +24,11 @@ use crate::{
 // 欠いている
 
 impl VoicevoxOnnxruntime {
-    pub(crate) const LIB_MIN_REQUIRED_VERSION: u32 =
-        voicevox_core::blocking::Onnxruntime::LIB_MIN_REQUIRED_VERSION;
+    pub(crate) const LIB_MIN_REQUIRED_MINOR_VERSION: u32 =
+        voicevox_core::blocking::Onnxruntime::LIB_MIN_REQUIRED_MINOR_VERSION;
 
-    pub(crate) const LIB_MAX_SUPPORTED_VERSION: u32 =
-        voicevox_core::blocking::Onnxruntime::LIB_MAX_SUPPORTED_VERSION;
+    pub(crate) const LIB_MAX_SUPPORTED_MINOR_VERSION: u32 =
+        voicevox_core::blocking::Onnxruntime::LIB_MAX_SUPPORTED_MINOR_VERSION;
 
     #[cfg(feature = "load-onnxruntime")]
     pub(crate) const LIB_RECOMMENDED_VERSIONED_FILENAME: &'static std::ffi::CStr =

--- a/crates/voicevox_core_c_api/src/compatible_engine.rs
+++ b/crates/voicevox_core_c_api/src/compatible_engine.rs
@@ -30,9 +30,9 @@ macro_rules! ensure_initialized {
 static ERROR_MESSAGE: LazyLock<Mutex<String>> = LazyLock::new(|| Mutex::new(String::new()));
 
 static ONNXRUNTIME: LazyLock<&'static voicevox_core::blocking::Onnxruntime> = LazyLock::new(|| {
-    let alt_onnxruntime_filename = voicevox_core::blocking::Onnxruntime::LIB_VERSIONED_FILENAME
-        .replace(
-            voicevox_core::blocking::Onnxruntime::LIB_NAME,
+    let alt_onnxruntime_filename =
+        voicevox_core::blocking::Onnxruntime::LIB_RECOMMENDED_VERSIONED_FILENAME.replace(
+            voicevox_core::blocking::Onnxruntime::LIB_RECOMMENDED_NAME,
             "onnxruntime",
         );
     voicevox_core::blocking::Onnxruntime::load_once()

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -101,11 +101,11 @@ fn init_logger_once() {
 ///
 /// @return 必要な最小マイナーバージョン
 ///
-/// \orig-impl{voicevox_get_onnxruntime_lib_min_required_version}
+/// \orig-impl{voicevox_get_onnxruntime_lib_min_required_minor_version}
 #[unsafe(no_mangle)]
-pub extern "C" fn voicevox_get_onnxruntime_lib_min_required_version() -> u32 {
+pub extern "C" fn voicevox_get_onnxruntime_lib_min_required_minor_version() -> u32 {
     init_logger_once();
-    VoicevoxOnnxruntime::LIB_MIN_REQUIRED_VERSION
+    VoicevoxOnnxruntime::LIB_MIN_REQUIRED_MINOR_VERSION
 }
 
 // SAFETY: voicevox_core_c_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
@@ -113,11 +113,11 @@ pub extern "C" fn voicevox_get_onnxruntime_lib_min_required_version() -> u32 {
 ///
 /// @return サポートされる最大マイナーバージョン
 ///
-/// \orig-impl{voicevox_get_onnxruntime_lib_max_supported_version}
+/// \orig-impl{voicevox_get_onnxruntime_lib_max_supported_minor_version}
 #[unsafe(no_mangle)]
-pub extern "C" fn voicevox_get_onnxruntime_lib_max_supported_version() -> u32 {
+pub extern "C" fn voicevox_get_onnxruntime_lib_max_supported_minor_version() -> u32 {
     init_logger_once();
-    VoicevoxOnnxruntime::LIB_MAX_SUPPORTED_VERSION
+    VoicevoxOnnxruntime::LIB_MAX_SUPPORTED_MINOR_VERSION
 }
 
 // SAFETY: voicevox_core_c_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
@@ -228,7 +228,7 @@ pub extern "C" fn voicevox_onnxruntime_get() -> Option<&'static VoicevoxOnnxrunt
 // SAFETY: voicevox_core_c_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
 /// ONNX Runtimeをロードして初期化する。
 ///
-/// 対象のONNX Runtimeのマイナーバージョンは ::voicevox_get_onnxruntime_lib_min_required_version よりも大きくなければならない。 ::voicevox_get_onnxruntime_lib_max_supported_version よりも大きい場合は警告を出す。
+/// 対象のONNX Runtimeのマイナーバージョンは ::voicevox_get_onnxruntime_lib_min_required_minor_version よりも大きくなければならない。 ::voicevox_get_onnxruntime_lib_max_supported_minor_version よりも大きい場合は警告を出す。
 ///
 /// 一度成功したら、以後は引数を無視して同じ参照を返す。
 ///
@@ -271,7 +271,7 @@ pub unsafe extern "C" fn voicevox_onnxruntime_load_once(
 // SAFETY: voicevox_core_c_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
 /// ONNX Runtimeを初期化する。
 ///
-/// リンクされているONNX Runtimeのマイナーバージョンが ::voicevox_get_onnxruntime_lib_min_required_version よりも小さい場合失敗する。 ::voicevox_get_onnxruntime_lib_max_supported_version よりも大きい場合は警告を出す。
+/// リンクされているONNX Runtimeのマイナーバージョンが ::voicevox_get_onnxruntime_lib_min_required_minor_version よりも小さい場合失敗する。 ::voicevox_get_onnxruntime_lib_max_supported_minor_version よりも大きい場合は警告を出す。
 ///
 /// 一度成功したら以後は同じ参照を返す。
 ///

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -228,7 +228,7 @@ pub extern "C" fn voicevox_onnxruntime_get() -> Option<&'static VoicevoxOnnxrunt
 // SAFETY: voicevox_core_c_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
 /// ONNX Runtimeをロードして初期化する。
 ///
-/// 対象のONNX Runtimeのマイナーバージョンは ::voicevox_get_onnxruntime_lib_min_required_minor_version よりも大きくなければならない。 ::voicevox_get_onnxruntime_lib_max_supported_minor_version よりも大きい場合は警告を出す。
+/// 対象のONNX Runtimeのマイナーバージョンは ::voicevox_get_onnxruntime_lib_min_required_minor_version 以上でなければならない。 ::voicevox_get_onnxruntime_lib_max_supported_minor_version よりも大きい場合は警告を出す。
 ///
 /// 一度成功したら、以後は引数を無視して同じ参照を返す。
 ///

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -92,41 +92,65 @@ fn init_logger_once() {
 
 // TODO: https://github.com/mozilla/cbindgen/issues/927
 //#[cfg(feature = "load-onnxruntime")]
-//pub const VOICEVOX_ONNXRUNTIME_LIB_NAME: &CStr = ..;
+//pub const VOICEVOX_ONNXRUNTIME_LIB_RECOMMENDED_NAME: &CStr = ..;
 //#[cfg(feature = "load-onnxruntime")]
-//pub const VOICEVOX_ONNXRUNTIME_LIB_VERSION: &CStr = ..;
+//pub const VOICEVOX_ONNXRUNTIME_LIB_RECOMMENDED_VERSION: &CStr = ..;
 
 // SAFETY: voicevox_core_c_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
-/// ONNX Runtimeの動的ライブラリの、バージョン付きのファイル名。
+/// 必要なONNX Runtime 1.xの最小マイナーバージョンを取得する。
 ///
-/// WindowsとAndroidでは ::voicevox_get_onnxruntime_lib_unversioned_filename と同じ。
+/// @return 必要な最小マイナーバージョン
+///
+/// \orig-impl{voicevox_get_onnxruntime_lib_min_required_version}
+#[unsafe(no_mangle)]
+pub extern "C" fn voicevox_get_onnxruntime_lib_min_required_version() -> u32 {
+    init_logger_once();
+    VoicevoxOnnxruntime::LIB_MIN_REQUIRED_VERSION
+}
+
+// SAFETY: voicevox_core_c_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
+/// サポートされるONNX Runtime 1.xの最大マイナーバージョンを取得する。
+///
+/// @return サポートされる最大マイナーバージョン
+///
+/// \orig-impl{voicevox_get_onnxruntime_lib_max_supported_version}
+#[unsafe(no_mangle)]
+pub extern "C" fn voicevox_get_onnxruntime_lib_max_supported_version() -> u32 {
+    init_logger_once();
+    VoicevoxOnnxruntime::LIB_MAX_SUPPORTED_VERSION
+}
+
+// SAFETY: voicevox_core_c_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
+/// 推奨されるONNX Runtimeの動的ライブラリの、バージョン付きのファイル名。
+///
+/// WindowsとAndroidでは ::voicevox_get_onnxruntime_lib_recommended_unversioned_filename と同じ。
 ///
 /// \availability{
 ///   [リリース](https://github.com/voicevox/voicevox_core/releases)されているライブラリではiOSを除くプラットフォームで利用可能。詳細は<a href="#voicevox-core-availability">ファイルレベルの"Availability"の節</a>を参照。
 /// }
 ///
-/// \orig-impl{voicevox_get_onnxruntime_lib_versioned_filename}
+/// \orig-impl{voicevox_get_onnxruntime_lib_recommended_versioned_filename}
 #[cfg(feature = "load-onnxruntime")]
 #[unsafe(no_mangle)]
-pub extern "C" fn voicevox_get_onnxruntime_lib_versioned_filename() -> *const c_char {
+pub extern "C" fn voicevox_get_onnxruntime_lib_recommended_versioned_filename() -> *const c_char {
     init_logger_once();
-    const FILENAME: &CStr = VoicevoxOnnxruntime::LIB_VERSIONED_FILENAME;
+    const FILENAME: &CStr = VoicevoxOnnxruntime::LIB_RECOMMENDED_VERSIONED_FILENAME;
     C_STRING_DROP_CHECKER.blacklist(FILENAME).as_ptr()
 }
 
 // SAFETY: voicevox_core_c_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
-/// ONNX Runtimeの動的ライブラリの、バージョン無しのファイル名。
+/// 推奨されるONNX Runtimeの動的ライブラリの、バージョン無しのファイル名。
 ///
 /// \availability{
 ///   [リリース](https://github.com/voicevox/voicevox_core/releases)されているライブラリではiOSを除くプラットフォームで利用可能。詳細は<a href="#voicevox-core-availability">ファイルレベルの"Availability"の節</a>を参照。
 /// }
 ///
-/// \orig-impl{voicevox_get_onnxruntime_lib_unversioned_filename}
+/// \orig-impl{voicevox_get_onnxruntime_lib_recommended_unversioned_filename}
 #[cfg(feature = "load-onnxruntime")]
 #[unsafe(no_mangle)]
-pub extern "C" fn voicevox_get_onnxruntime_lib_unversioned_filename() -> *const c_char {
+pub extern "C" fn voicevox_get_onnxruntime_lib_recommended_unversioned_filename() -> *const c_char {
     init_logger_once();
-    const FILENAME: &CStr = VoicevoxOnnxruntime::LIB_UNVERSIONED_FILENAME;
+    const FILENAME: &CStr = VoicevoxOnnxruntime::LIB_RECOMMENDED_UNVERSIONED_FILENAME;
     C_STRING_DROP_CHECKER.blacklist(FILENAME).as_ptr()
 }
 
@@ -142,7 +166,7 @@ pub extern "C" fn voicevox_get_onnxruntime_lib_unversioned_filename() -> *const 
 pub struct VoicevoxLoadOnnxruntimeOptions {
     /// ONNX Runtimeのファイル名（モジュール名）もしくはファイルパスを指定する。
     ///
-    /// `dlopen`/[`LoadLibraryExW`](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexw)の引数に使われる。デフォルトは ::voicevox_get_onnxruntime_lib_versioned_filename と同じ。
+    /// `dlopen`/[`LoadLibraryExW`](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexw)の引数に使われる。デフォルトは ::voicevox_get_onnxruntime_lib_recommended_versioned_filename と同じ。
     filename: *const c_char,
 }
 
@@ -161,7 +185,7 @@ pub struct VoicevoxLoadOnnxruntimeOptions {
 pub extern "C" fn voicevox_make_default_load_onnxruntime_options() -> VoicevoxLoadOnnxruntimeOptions
 {
     init_logger_once();
-    let filename = VoicevoxOnnxruntime::LIB_VERSIONED_FILENAME;
+    let filename = VoicevoxOnnxruntime::LIB_RECOMMENDED_VERSIONED_FILENAME;
     let filename = C_STRING_DROP_CHECKER.blacklist(filename).as_ptr();
     VoicevoxLoadOnnxruntimeOptions { filename }
 }
@@ -204,6 +228,8 @@ pub extern "C" fn voicevox_onnxruntime_get() -> Option<&'static VoicevoxOnnxrunt
 // SAFETY: voicevox_core_c_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
 /// ONNX Runtimeをロードして初期化する。
 ///
+/// 対象のONNX Runtimeのマイナーバージョンは ::voicevox_get_onnxruntime_lib_min_required_version よりも大きくなければならない。 ::voicevox_get_onnxruntime_lib_max_supported_version よりも大きい場合は警告を出す。
+///
 /// 一度成功したら、以後は引数を無視して同じ参照を返す。
 ///
 /// @param [in] options オプション
@@ -244,6 +270,8 @@ pub unsafe extern "C" fn voicevox_onnxruntime_load_once(
 
 // SAFETY: voicevox_core_c_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
 /// ONNX Runtimeを初期化する。
+///
+/// リンクされているONNX Runtimeのマイナーバージョンが ::voicevox_get_onnxruntime_lib_min_required_version よりも小さい場合失敗する。 ::voicevox_get_onnxruntime_lib_max_supported_version よりも大きい場合は警告を出す。
 ///
 /// 一度成功したら以後は同じ参照を返す。
 ///

--- a/crates/voicevox_core_java_api/lib/build.gradle
+++ b/crates/voicevox_core_java_api/lib/build.gradle
@@ -56,6 +56,7 @@ javadoc.options.encoding = 'UTF-8'
 spotless {
     java {
         googleJavaFormat()
+        toggleOffOn()
     }
 }
 

--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/blocking/Onnxruntime.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/blocking/Onnxruntime.java
@@ -22,21 +22,29 @@ public class Onnxruntime {
     Dll.loadLibrary();
   }
 
-  /** ONNX Runtimeのライブラリ名。 */
-  public static final String LIB_NAME = "voicevox_onnxruntime";
+  /** 必要なONNX Runtime 1.xの最小マイナーバージョン。 */
+  public static final int LIB_MIN_REQUIRED_VERSION = 17;
+
+  /** サポートされるONNX Runtime 1.xの最大マイナーバージョン。 */
+  public static final int LIB_MAX_SUPPORTED_VERSION = 17;
+
+  /** 推奨されるONNX Runtimeのライブラリ名。 */
+  public static final String LIB_RECOMMENDED_NAME = "voicevox_onnxruntime";
 
   /** 推奨されるONNX Runtimeのバージョン。 */
-  public static final String LIB_VERSION = "1.17.3";
+  public static final String LIB_RECOMMENDED_VERSION = "1.17.3";
 
   /**
-   * {@link LIB_NAME}と{@link LIB_VERSION}からなる動的ライブラリのファイル名。
+   * {@link LIB_RECOMMENDED_NAME}と{@link LIB_RECOMMENDED_VERSION}からなる動的ライブラリのファイル名。
    *
-   * <p>WindowsとAndroidでは{@link LIB_UNVERSIONED_FILENAME}と同じ。
+   * <p>WindowsとAndroidでは{@link LIB_RECOMMENDED_UNVERSIONED_FILENAME}と同じ。
    */
-  public static final String LIB_VERSIONED_FILENAME = rsLibVersionedFilename();
+  public static final String LIB_RECOMMENDED_VERSIONED_FILENAME =
+      rsLibRecommendedVersionedFilename();
 
-  /** {@link LIB_NAME}からなる動的ライブラリのファイル名。 */
-  public static final String LIB_UNVERSIONED_FILENAME = rsLibUnversionedFilename();
+  /** {@link LIB_RECOMMENDED_NAME}からなる動的ライブラリのファイル名。 */
+  public static final String LIB_RECOMMENDED_UNVERSIONED_FILENAME =
+      rsLibRecommendedUnversionedFilename();
 
   @Nullable private static Onnxruntime instance = null;
 
@@ -54,6 +62,9 @@ public class Onnxruntime {
   /**
    * ONNX Runtimeをロードして初期化する。
    *
+   * <p>対象のONNX Runtimeはバージョン<code>1.{@link #LIB_MIN_REQUIRED_VERSION}</code>以降のものでなければならない。バージョン
+   * <code>1.{@link #LIB_MAX_SUPPORTED_VERSION}</code>よりも新しいONNX Runtimeに対しては警告を出す。
+   *
    * <p>一度成功したら、以後は引数を無視して同じインスタンスを返す。
    *
    * @return {@link LoadOnce}。
@@ -62,16 +73,23 @@ public class Onnxruntime {
     return new LoadOnce();
   }
 
-  private static native String rsLibName();
+  private static native int rsLibMinRequiredVersion();
 
-  private static native String rsLibVersion();
+  private static native int rsLibMaxSupportedVersion();
 
-  private static native String rsLibVersionedFilename();
+  private static native String rsLibRecommendedName();
 
-  private static native String rsLibUnversionedFilename();
+  private static native String rsLibRecommendedVersion();
+
+  private static native String rsLibRecommendedVersionedFilename();
+
+  private static native String rsLibRecommendedUnversionedFilename();
 
   static {
-    assert LIB_NAME.equals(rsLibName()) && LIB_VERSION.equals(rsLibVersion());
+    assert LIB_MIN_REQUIRED_VERSION == rsLibMinRequiredVersion()
+        && LIB_MAX_SUPPORTED_VERSION == rsLibMaxSupportedVersion()
+        && LIB_RECOMMENDED_NAME.equals(rsLibRecommendedName())
+        && LIB_RECOMMENDED_VERSION.equals(rsLibRecommendedVersion());
   }
 
   /** {@link #loadOnce}のビルダー。 */
@@ -81,7 +99,7 @@ public class Onnxruntime {
      *
      * @param filename {@code dlopen}/<a
      *     href="https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexw">{@code
-     *     LoadLibraryExW}</a>の引数に使われる。デフォルトは{@link LIB_VERSIONED_FILENAME}。
+     *     LoadLibraryExW}</a>の引数に使われる。デフォルトは{@link LIB_RECOMMENDED_VERSIONED_FILENAME}。
      * @return このオブジェクト。
      */
     public LoadOnce filename(@Nonnull String filename) {
@@ -105,7 +123,7 @@ public class Onnxruntime {
 
     private LoadOnce() {}
 
-    @Nonnull private String filename = LIB_VERSIONED_FILENAME;
+    @Nonnull private String filename = LIB_RECOMMENDED_VERSIONED_FILENAME;
   }
 
   private long handle;

--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/blocking/Onnxruntime.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/blocking/Onnxruntime.java
@@ -23,10 +23,10 @@ public class Onnxruntime {
   }
 
   /** 必要なONNX Runtime 1.xの最小マイナーバージョン。 */
-  public static final int LIB_MIN_REQUIRED_VERSION = 17;
+  public static final int LIB_MIN_REQUIRED_MINOR_VERSION = 17;
 
   /** サポートされるONNX Runtime 1.xの最大マイナーバージョン。 */
-  public static final int LIB_MAX_SUPPORTED_VERSION = 17;
+  public static final int LIB_MAX_SUPPORTED_MINOR_VERSION = 17;
 
   /** 推奨されるONNX Runtimeのライブラリ名。 */
   public static final String LIB_RECOMMENDED_NAME = "voicevox_onnxruntime";
@@ -59,23 +59,26 @@ public class Onnxruntime {
     }
   }
 
+  // spotless:off
   /**
    * ONNX Runtimeをロードして初期化する。
    *
-   * <p>対象のONNX Runtimeはバージョン<code>1.{@link #LIB_MIN_REQUIRED_VERSION}</code>以降のものでなければならない。バージョン
-   * <code>1.{@link #LIB_MAX_SUPPORTED_VERSION}</code>よりも新しいONNX Runtimeに対しては警告を出す。
+   * <p>対象のONNX
+   * Runtimeはバージョン<code>1.{@link #LIB_MIN_REQUIRED_MINOR_VERSION}</code>以降のものでなければならない。バージョン<code>1.{@link #LIB_MAX_SUPPORTED_MINOR_VERSION}</code>よりも新しいONNX
+   * Runtimeに対しては警告を出す。
    *
    * <p>一度成功したら、以後は引数を無視して同じインスタンスを返す。
    *
    * @return {@link LoadOnce}。
    */
+  // spotless:on
   public static LoadOnce loadOnce() {
     return new LoadOnce();
   }
 
-  private static native int rsLibMinRequiredVersion();
+  private static native int rsLibMinRequiredMinorVersion();
 
-  private static native int rsLibMaxSupportedVersion();
+  private static native int rsLibMaxSupportedMinorVersion();
 
   private static native String rsLibRecommendedName();
 
@@ -86,8 +89,8 @@ public class Onnxruntime {
   private static native String rsLibRecommendedUnversionedFilename();
 
   static {
-    assert LIB_MIN_REQUIRED_VERSION == rsLibMinRequiredVersion()
-        && LIB_MAX_SUPPORTED_VERSION == rsLibMaxSupportedVersion()
+    assert LIB_MIN_REQUIRED_MINOR_VERSION == rsLibMinRequiredMinorVersion()
+        && LIB_MAX_SUPPORTED_MINOR_VERSION == rsLibMaxSupportedMinorVersion()
         && LIB_RECOMMENDED_NAME.equals(rsLibRecommendedName())
         && LIB_RECOMMENDED_VERSION.equals(rsLibRecommendedVersion());
   }

--- a/crates/voicevox_core_java_api/lib/src/test/java/jp/hiroshiba/voicevoxcore/TestUtils.java
+++ b/crates/voicevox_core_java_api/lib/src/test/java/jp/hiroshiba/voicevoxcore/TestUtils.java
@@ -21,7 +21,8 @@ public class TestUtils {
   protected Onnxruntime loadOnnxruntime() {
     final String FILENAME =
         "../../test_util/data/lib/"
-            + Onnxruntime.LIB_VERSIONED_FILENAME.replace("voicevox_onnxruntime", "onnxruntime");
+            + Onnxruntime.LIB_RECOMMENDED_VERSIONED_FILENAME.replace(
+                "voicevox_onnxruntime", "onnxruntime");
 
     try {
       return Onnxruntime.loadOnce().filename(FILENAME).perform();

--- a/crates/voicevox_core_java_api/src/onnxruntime.rs
+++ b/crates/voicevox_core_java_api/src/onnxruntime.rs
@@ -13,8 +13,8 @@ use crate::{common::throw_if_err, object};
 // SAFETY: voicevox_core_java_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
 #[duplicate_item(
     f CONST;
-    [ Java_jp_hiroshiba_voicevoxcore_blocking_Onnxruntime_rsLibMinRequiredVersion ] [ LIB_MIN_REQUIRED_VERSION ];
-    [ Java_jp_hiroshiba_voicevoxcore_blocking_Onnxruntime_rsLibMaxSupportedVersion ] [ LIB_MAX_SUPPORTED_VERSION ];
+    [ Java_jp_hiroshiba_voicevoxcore_blocking_Onnxruntime_rsLibMinRequiredMinorVersion ] [ LIB_MIN_REQUIRED_MINOR_VERSION ];
+    [ Java_jp_hiroshiba_voicevoxcore_blocking_Onnxruntime_rsLibMaxSupportedMinorVersion ] [ LIB_MAX_SUPPORTED_MINOR_VERSION ];
 )]
 #[unsafe(no_mangle)]
 extern "system" fn f(_: JNIEnv<'_>) -> jint {

--- a/crates/voicevox_core_java_api/src/onnxruntime.rs
+++ b/crates/voicevox_core_java_api/src/onnxruntime.rs
@@ -4,7 +4,7 @@ use duplicate::duplicate_item;
 use jni::{
     JNIEnv,
     objects::{JObject, JString},
-    sys::jobject,
+    sys::{jint, jobject},
 };
 use voicevox_core::__internal::interop::ToJsonValue as _;
 
@@ -13,10 +13,23 @@ use crate::{common::throw_if_err, object};
 // SAFETY: voicevox_core_java_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
 #[duplicate_item(
     f CONST;
-    [ Java_jp_hiroshiba_voicevoxcore_blocking_Onnxruntime_rsLibName ] [ LIB_NAME ];
-    [ Java_jp_hiroshiba_voicevoxcore_blocking_Onnxruntime_rsLibVersion ] [ LIB_VERSION ];
-    [ Java_jp_hiroshiba_voicevoxcore_blocking_Onnxruntime_rsLibVersionedFilename ] [ LIB_VERSIONED_FILENAME ];
-    [ Java_jp_hiroshiba_voicevoxcore_blocking_Onnxruntime_rsLibUnversionedFilename ] [ LIB_UNVERSIONED_FILENAME ];
+    [ Java_jp_hiroshiba_voicevoxcore_blocking_Onnxruntime_rsLibMinRequiredVersion ] [ LIB_MIN_REQUIRED_VERSION ];
+    [ Java_jp_hiroshiba_voicevoxcore_blocking_Onnxruntime_rsLibMaxSupportedVersion ] [ LIB_MAX_SUPPORTED_VERSION ];
+)]
+#[unsafe(no_mangle)]
+extern "system" fn f(_: JNIEnv<'_>) -> jint {
+    voicevox_core::blocking::Onnxruntime::CONST
+        .try_into()
+        .expect("ONNX Runtime minor version is not considered to be so large")
+}
+
+// SAFETY: voicevox_core_java_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
+#[duplicate_item(
+    f CONST;
+    [ Java_jp_hiroshiba_voicevoxcore_blocking_Onnxruntime_rsLibRecommendedName ] [ LIB_RECOMMENDED_NAME ];
+    [ Java_jp_hiroshiba_voicevoxcore_blocking_Onnxruntime_rsLibRecommendedVersion ] [ LIB_RECOMMENDED_VERSION ];
+    [ Java_jp_hiroshiba_voicevoxcore_blocking_Onnxruntime_rsLibRecommendedVersionedFilename ] [ LIB_RECOMMENDED_VERSIONED_FILENAME ];
+    [ Java_jp_hiroshiba_voicevoxcore_blocking_Onnxruntime_rsLibRecommendedUnversionedFilename ] [ LIB_RECOMMENDED_UNVERSIONED_FILENAME ];
 )]
 #[unsafe(no_mangle)]
 extern "system" fn f(env: JNIEnv<'_>) -> jobject {

--- a/crates/voicevox_core_python_api/python/benches/test_tts.py
+++ b/crates/voicevox_core_python_api/python/benches/test_tts.py
@@ -14,7 +14,7 @@ ONNXRUNTIME_FILENAME = str(
     / "test_util"
     / "data"
     / "lib"
-    / voicevox_core.blocking.Onnxruntime.LIB_VERSIONED_FILENAME.replace(
+    / voicevox_core.blocking.Onnxruntime.LIB_RECOMMENDED_VERSIONED_FILENAME.replace(
         "voicevox_onnxruntime", "onnxruntime"
     )
 )

--- a/crates/voicevox_core_python_api/python/test/conftest.py
+++ b/crates/voicevox_core_python_api/python/test/conftest.py
@@ -13,7 +13,7 @@ onnxruntime_filename = str(
     / "test_util"
     / "data"
     / "lib"
-    / voicevox_core.blocking.Onnxruntime.LIB_VERSIONED_FILENAME.replace(
+    / voicevox_core.blocking.Onnxruntime.LIB_RECOMMENDED_VERSIONED_FILENAME.replace(
         "voicevox_onnxruntime", "onnxruntime"
     )
 )

--- a/crates/voicevox_core_python_api/python/test/test_type_stub_consts.py
+++ b/crates/voicevox_core_python_api/python/test/test_type_stub_consts.py
@@ -9,14 +9,14 @@ import voicevox_core
 
 def test() -> None:
     REAL_BLOCKING = (
-        voicevox_core.blocking.Onnxruntime.LIB_MIN_REQUIRED_VERSION,
-        voicevox_core.blocking.Onnxruntime.LIB_MAX_SUPPORTED_VERSION,
+        voicevox_core.blocking.Onnxruntime.LIB_MIN_REQUIRED_MINOR_VERSION,
+        voicevox_core.blocking.Onnxruntime.LIB_MAX_SUPPORTED_MINOR_VERSION,
         voicevox_core.blocking.Onnxruntime.LIB_RECOMMENDED_NAME,
         voicevox_core.blocking.Onnxruntime.LIB_RECOMMENDED_VERSION,
     )
     REAL_ASYNCIO = (
-        voicevox_core.asyncio.Onnxruntime.LIB_MIN_REQUIRED_VERSION,
-        voicevox_core.asyncio.Onnxruntime.LIB_MAX_SUPPORTED_VERSION,
+        voicevox_core.asyncio.Onnxruntime.LIB_MIN_REQUIRED_MINOR_VERSION,
+        voicevox_core.asyncio.Onnxruntime.LIB_MAX_SUPPORTED_MINOR_VERSION,
         voicevox_core.asyncio.Onnxruntime.LIB_RECOMMENDED_NAME,
         voicevox_core.asyncio.Onnxruntime.LIB_RECOMMENDED_VERSION,
     )
@@ -32,21 +32,21 @@ def extract(pyi: Path) -> tuple[int, int, str, str]:
         for stmt in module.body
         if isinstance(stmt, ClassDef) and stmt.name == "Onnxruntime"
     )
-    lib_min_required_version_value = next(
+    lib_min_required_minor_version_value = next(
         stmt.value.value
         for stmt in class_def.body
         if isinstance(stmt, AnnAssign)
         and isinstance(stmt.target, Name)
-        and stmt.target.id == "LIB_MIN_REQUIRED_VERSION"
+        and stmt.target.id == "LIB_MIN_REQUIRED_MINOR_VERSION"
         and isinstance(stmt.value, Constant)
         and isinstance(stmt.value.value, int)
     )
-    lib_max_supported_version_value = next(
+    lib_max_supported_minor_version_value = next(
         stmt.value.value
         for stmt in class_def.body
         if isinstance(stmt, AnnAssign)
         and isinstance(stmt.target, Name)
-        and stmt.target.id == "LIB_MAX_SUPPORTED_VERSION"
+        and stmt.target.id == "LIB_MAX_SUPPORTED_MINOR_VERSION"
         and isinstance(stmt.value, Constant)
         and isinstance(stmt.value.value, int)
     )
@@ -69,8 +69,8 @@ def extract(pyi: Path) -> tuple[int, int, str, str]:
         and isinstance(stmt.value.value, str)
     )
     return (
-        lib_min_required_version_value,
-        lib_max_supported_version_value,
+        lib_min_required_minor_version_value,
+        lib_max_supported_minor_version_value,
         lib_recommended_name_value,
         lib_recommended_version_value,
     )

--- a/crates/voicevox_core_python_api/python/test/test_type_stub_consts.py
+++ b/crates/voicevox_core_python_api/python/test/test_type_stub_consts.py
@@ -9,41 +9,68 @@ import voicevox_core
 
 def test() -> None:
     REAL_BLOCKING = (
-        voicevox_core.blocking.Onnxruntime.LIB_NAME,
-        voicevox_core.blocking.Onnxruntime.LIB_VERSION,
+        voicevox_core.blocking.Onnxruntime.LIB_MIN_REQUIRED_VERSION,
+        voicevox_core.blocking.Onnxruntime.LIB_MAX_SUPPORTED_VERSION,
+        voicevox_core.blocking.Onnxruntime.LIB_RECOMMENDED_NAME,
+        voicevox_core.blocking.Onnxruntime.LIB_RECOMMENDED_VERSION,
     )
     REAL_ASYNCIO = (
-        voicevox_core.asyncio.Onnxruntime.LIB_NAME,
-        voicevox_core.asyncio.Onnxruntime.LIB_VERSION,
+        voicevox_core.asyncio.Onnxruntime.LIB_MIN_REQUIRED_VERSION,
+        voicevox_core.asyncio.Onnxruntime.LIB_MAX_SUPPORTED_VERSION,
+        voicevox_core.asyncio.Onnxruntime.LIB_RECOMMENDED_NAME,
+        voicevox_core.asyncio.Onnxruntime.LIB_RECOMMENDED_VERSION,
     )
     stub_blocking = extract(Path("./python/voicevox_core/_rust/blocking.pyi"))
     stub_asyncio = extract(Path("./python/voicevox_core/_rust/asyncio.pyi"))
     assert len({REAL_BLOCKING, REAL_ASYNCIO, stub_blocking, stub_asyncio}) == 1
 
 
-def extract(pyi: Path) -> tuple[str, str]:
+def extract(pyi: Path) -> tuple[int, int, str, str]:
     module = ast.parse(pyi.read_text(encoding="utf-8"))
     class_def = next(
         stmt
         for stmt in module.body
         if isinstance(stmt, ClassDef) and stmt.name == "Onnxruntime"
     )
-    lib_name_value = next(
+    lib_min_required_version_value = next(
         stmt.value.value
         for stmt in class_def.body
         if isinstance(stmt, AnnAssign)
         and isinstance(stmt.target, Name)
-        and stmt.target.id == "LIB_NAME"
+        and stmt.target.id == "LIB_MIN_REQUIRED_VERSION"
         and isinstance(stmt.value, Constant)
-        and isinstance(stmt.value.value, str)
+        and isinstance(stmt.value.value, int)
     )
-    lib_version_value = next(
+    lib_max_supported_version_value = next(
         stmt.value.value
         for stmt in class_def.body
         if isinstance(stmt, AnnAssign)
         and isinstance(stmt.target, Name)
-        and stmt.target.id == "LIB_VERSION"
+        and stmt.target.id == "LIB_MAX_SUPPORTED_VERSION"
+        and isinstance(stmt.value, Constant)
+        and isinstance(stmt.value.value, int)
+    )
+    lib_recommended_name_value = next(
+        stmt.value.value
+        for stmt in class_def.body
+        if isinstance(stmt, AnnAssign)
+        and isinstance(stmt.target, Name)
+        and stmt.target.id == "LIB_RECOMMENDED_NAME"
         and isinstance(stmt.value, Constant)
         and isinstance(stmt.value.value, str)
     )
-    return (lib_name_value, lib_version_value)
+    lib_recommended_version_value = next(
+        stmt.value.value
+        for stmt in class_def.body
+        if isinstance(stmt, AnnAssign)
+        and isinstance(stmt.target, Name)
+        and stmt.target.id == "LIB_RECOMMENDED_VERSION"
+        and isinstance(stmt.value, Constant)
+        and isinstance(stmt.value.value, str)
+    )
+    return (
+        lib_min_required_version_value,
+        lib_max_supported_version_value,
+        lib_recommended_name_value,
+        lib_recommended_version_value,
+    )

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/asyncio.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/asyncio.pyi
@@ -86,21 +86,27 @@ class Onnxruntime:
 
     # ここの定数値が本物と合致するかどうかは、test_type_stub_consts.pyで担保する。
 
-    LIB_NAME: str = "voicevox_onnxruntime"
-    """ONNX Runtimeのライブラリ名。"""
+    LIB_MIN_REQUIRED_VERSION: int = 17
+    """必要なONNX Runtime 1.xの最小マイナーバージョン。"""
 
-    LIB_VERSION: str = "1.17.3"
+    LIB_MAX_SUPPORTED_VERSION: int = 17
+    """サポートされるONNX Runtime 1.xの最大マイナーバージョン。"""
+
+    LIB_RECOMMENDED_NAME: str = "voicevox_onnxruntime"
+    """推奨されるONNX Runtimeのライブラリ名。"""
+
+    LIB_RECOMMENDED_VERSION: str = "1.17.3"
     """推奨されるONNX Runtimeのバージョン。"""
 
-    LIB_VERSIONED_FILENAME: str
+    LIB_RECOMMENDED_VERSIONED_FILENAME: str
     """
-    :attr:`LIB_NAME` と :attr:`LIB_VERSION` からなる動的ライブラリのファイル名。
+    :attr:`LIB_RECOMMENDED_NAME` と :attr:`LIB_RECOMMENDED_VERSION` からなる動的ライブラリのファイル名。
 
-    WindowsとAndroidでは :attr:`LIB_UNVERSIONED_FILENAME` と同じ。
+    WindowsとAndroidでは :attr:`LIB_RECOMMENDED_UNVERSIONED_FILENAME` と同じ。
     """
 
-    LIB_UNVERSIONED_FILENAME: str
-    """:attr:`LIB_NAME` からなる動的ライブラリのファイル名。"""
+    LIB_RECOMMENDED_UNVERSIONED_FILENAME: str
+    """:attr:`LIB_RECOMMENDED_NAME` からなる動的ライブラリのファイル名。"""
 
     def __new__(cls, *args: object, **kwargs: object) -> NoReturn: ...
     @staticmethod
@@ -112,9 +118,15 @@ class Onnxruntime:
         """
         ...
     @staticmethod
-    async def load_once(*, filename: str = LIB_VERSIONED_FILENAME) -> "Onnxruntime":
+    async def load_once(
+        *, filename: str = LIB_RECOMMENDED_VERSIONED_FILENAME
+    ) -> "Onnxruntime":
         """
         ONNX Runtimeをロードして初期化する。
+
+        対象のONNX Runtimeのマイナーバージョンは :attr:`LIB_MIN_REQUIRED_VERSION`
+        よりも大きくなくてはならない。 :attr:`LIB_MAX_SUPPORTED_VERSION`
+        より大きい場合は警告を出す。
 
         一度成功したら、以後は引数を無視して同じインスタンスを返す。
 

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/asyncio.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/asyncio.pyi
@@ -86,10 +86,10 @@ class Onnxruntime:
 
     # ここの定数値が本物と合致するかどうかは、test_type_stub_consts.pyで担保する。
 
-    LIB_MIN_REQUIRED_VERSION: int = 17
+    LIB_MIN_REQUIRED_MINOR_VERSION: int = 17
     """必要なONNX Runtime 1.xの最小マイナーバージョン。"""
 
-    LIB_MAX_SUPPORTED_VERSION: int = 17
+    LIB_MAX_SUPPORTED_MINOR_VERSION: int = 17
     """サポートされるONNX Runtime 1.xの最大マイナーバージョン。"""
 
     LIB_RECOMMENDED_NAME: str = "voicevox_onnxruntime"
@@ -124,8 +124,8 @@ class Onnxruntime:
         """
         ONNX Runtimeをロードして初期化する。
 
-        対象のONNX Runtimeのマイナーバージョンは :attr:`LIB_MIN_REQUIRED_VERSION`
-        よりも大きくなくてはならない。 :attr:`LIB_MAX_SUPPORTED_VERSION`
+        対象のONNX Runtimeのマイナーバージョンは :attr:`LIB_MIN_REQUIRED_MINOR_VERSION`
+        よりも大きくなくてはならない。 :attr:`LIB_MAX_SUPPORTED_MINOR_VERSION`
         より大きい場合は警告を出す。
 
         一度成功したら、以後は引数を無視して同じインスタンスを返す。

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/asyncio.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/asyncio.pyi
@@ -125,7 +125,7 @@ class Onnxruntime:
         ONNX Runtimeをロードして初期化する。
 
         対象のONNX Runtimeのマイナーバージョンは :attr:`LIB_MIN_REQUIRED_MINOR_VERSION`
-        よりも大きくなくてはならない。 :attr:`LIB_MAX_SUPPORTED_MINOR_VERSION`
+        以上でなくてはならない。 :attr:`LIB_MAX_SUPPORTED_MINOR_VERSION`
         より大きい場合は警告を出す。
 
         一度成功したら、以後は引数を無視して同じインスタンスを返す。

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
@@ -86,10 +86,10 @@ class Onnxruntime:
 
     # ここの定数値が本物と合致するかどうかは、test_type_stub_consts.pyで担保する。
 
-    LIB_MIN_REQUIRED_VERSION: int = 17
+    LIB_MIN_REQUIRED_MINOR_VERSION: int = 17
     """必要なONNX Runtime 1.xの最小マイナーバージョン。"""
 
-    LIB_MAX_SUPPORTED_VERSION: int = 17
+    LIB_MAX_SUPPORTED_MINOR_VERSION: int = 17
     """サポートされるONNX Runtime 1.xの最大マイナーバージョン。"""
 
     LIB_RECOMMENDED_NAME: str = "voicevox_onnxruntime"
@@ -124,8 +124,8 @@ class Onnxruntime:
         """
         ONNX Runtimeをロードして初期化する。
 
-        対象のONNX Runtimeのマイナーバージョンは :attr:`LIB_MIN_REQUIRED_VERSION`
-        よりも大きくなくてはならない。 :attr:`LIB_MAX_SUPPORTED_VERSION`
+        対象のONNX Runtimeのマイナーバージョンは :attr:`LIB_MIN_REQUIRED_MINOR_VERSION`
+        よりも大きくなくてはならない。 :attr:`LIB_MAX_SUPPORTED_MINOR_VERSION`
         より大きい場合は警告を出す。
 
         一度成功したら、以後は引数を無視して同じインスタンスを返す。

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
@@ -125,7 +125,7 @@ class Onnxruntime:
         ONNX Runtimeをロードして初期化する。
 
         対象のONNX Runtimeのマイナーバージョンは :attr:`LIB_MIN_REQUIRED_MINOR_VERSION`
-        よりも大きくなくてはならない。 :attr:`LIB_MAX_SUPPORTED_MINOR_VERSION`
+        以上でなくてはならない。 :attr:`LIB_MAX_SUPPORTED_MINOR_VERSION`
         より大きい場合は警告を出す。
 
         一度成功したら、以後は引数を無視して同じインスタンスを返す。

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
@@ -86,21 +86,27 @@ class Onnxruntime:
 
     # ここの定数値が本物と合致するかどうかは、test_type_stub_consts.pyで担保する。
 
-    LIB_NAME: str = "voicevox_onnxruntime"
-    """ONNX Runtimeのライブラリ名。"""
+    LIB_MIN_REQUIRED_VERSION: int = 17
+    """必要なONNX Runtime 1.xの最小マイナーバージョン。"""
 
-    LIB_VERSION: str = "1.17.3"
+    LIB_MAX_SUPPORTED_VERSION: int = 17
+    """サポートされるONNX Runtime 1.xの最大マイナーバージョン。"""
+
+    LIB_RECOMMENDED_NAME: str = "voicevox_onnxruntime"
+    """推奨されるONNX Runtimeのライブラリ名。"""
+
+    LIB_RECOMMENDED_VERSION: str = "1.17.3"
     """推奨されるONNX Runtimeのバージョン。"""
 
-    LIB_VERSIONED_FILENAME: str
+    LIB_RECOMMENDED_VERSIONED_FILENAME: str
     """
-    :attr:`LIB_NAME` と :attr:`LIB_VERSION` からなる動的ライブラリのファイル名。
+    :attr:`LIB_RECOMMENDED_NAME` と :attr:`LIB_RECOMMENDED_VERSION` からなる動的ライブラリのファイル名。
 
-    WindowsとAndroidでは :attr:`LIB_UNVERSIONED_FILENAME` と同じ。
+    WindowsとAndroidでは :attr:`LIB_RECOMMENDED_UNVERSIONED_FILENAME` と同じ。
     """
 
-    LIB_UNVERSIONED_FILENAME: str
-    """:attr:`LIB_NAME` からなる動的ライブラリのファイル名。"""
+    LIB_RECOMMENDED_UNVERSIONED_FILENAME: str
+    """:attr:`LIB_RECOMMENDED_NAME` からなる動的ライブラリのファイル名。"""
 
     def __new__(cls, *args: object, **kwargs: object) -> NoReturn: ...
     @staticmethod
@@ -112,9 +118,15 @@ class Onnxruntime:
         """
         ...
     @staticmethod
-    def load_once(*, filename: str = LIB_VERSIONED_FILENAME) -> "Onnxruntime":
+    def load_once(
+        *, filename: str = LIB_RECOMMENDED_VERSIONED_FILENAME
+    ) -> "Onnxruntime":
         """
         ONNX Runtimeをロードして初期化する。
+
+        対象のONNX Runtimeのマイナーバージョンは :attr:`LIB_MIN_REQUIRED_VERSION`
+        よりも大きくなくてはならない。 :attr:`LIB_MAX_SUPPORTED_VERSION`
+        より大きい場合は警告を出す。
 
         一度成功したら、以後は引数を無視して同じインスタンスを返す。
 

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -498,12 +498,12 @@ mod blocking {
     #[pymethods]
     impl Onnxruntime {
         #[classattr]
-        const LIB_MIN_REQUIRED_VERSION: u32 =
-            voicevox_core::blocking::Onnxruntime::LIB_MIN_REQUIRED_VERSION;
+        const LIB_MIN_REQUIRED_MINOR_VERSION: u32 =
+            voicevox_core::blocking::Onnxruntime::LIB_MIN_REQUIRED_MINOR_VERSION;
 
         #[classattr]
-        const LIB_MAX_SUPPORTED_VERSION: u32 =
-            voicevox_core::blocking::Onnxruntime::LIB_MAX_SUPPORTED_VERSION;
+        const LIB_MAX_SUPPORTED_MINOR_VERSION: u32 =
+            voicevox_core::blocking::Onnxruntime::LIB_MAX_SUPPORTED_MINOR_VERSION;
 
         #[classattr]
         const LIB_RECOMMENDED_NAME: &'static str =
@@ -1279,12 +1279,12 @@ mod asyncio {
     #[pymethods]
     impl Onnxruntime {
         #[classattr]
-        const LIB_MIN_REQUIRED_VERSION: u32 =
-            voicevox_core::nonblocking::Onnxruntime::LIB_MIN_REQUIRED_VERSION;
+        const LIB_MIN_REQUIRED_MINOR_VERSION: u32 =
+            voicevox_core::nonblocking::Onnxruntime::LIB_MIN_REQUIRED_MINOR_VERSION;
 
         #[classattr]
-        const LIB_MAX_SUPPORTED_VERSION: u32 =
-            voicevox_core::nonblocking::Onnxruntime::LIB_MAX_SUPPORTED_VERSION;
+        const LIB_MAX_SUPPORTED_MINOR_VERSION: u32 =
+            voicevox_core::nonblocking::Onnxruntime::LIB_MAX_SUPPORTED_MINOR_VERSION;
 
         #[classattr]
         const LIB_RECOMMENDED_NAME: &'static str =

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -498,18 +498,28 @@ mod blocking {
     #[pymethods]
     impl Onnxruntime {
         #[classattr]
-        const LIB_NAME: &'static str = voicevox_core::blocking::Onnxruntime::LIB_NAME;
+        const LIB_MIN_REQUIRED_VERSION: u32 =
+            voicevox_core::blocking::Onnxruntime::LIB_MIN_REQUIRED_VERSION;
 
         #[classattr]
-        const LIB_VERSION: &'static str = voicevox_core::blocking::Onnxruntime::LIB_VERSION;
+        const LIB_MAX_SUPPORTED_VERSION: u32 =
+            voicevox_core::blocking::Onnxruntime::LIB_MAX_SUPPORTED_VERSION;
 
         #[classattr]
-        const LIB_VERSIONED_FILENAME: &'static str =
-            voicevox_core::blocking::Onnxruntime::LIB_VERSIONED_FILENAME;
+        const LIB_RECOMMENDED_NAME: &'static str =
+            voicevox_core::blocking::Onnxruntime::LIB_RECOMMENDED_NAME;
 
         #[classattr]
-        const LIB_UNVERSIONED_FILENAME: &'static str =
-            voicevox_core::blocking::Onnxruntime::LIB_UNVERSIONED_FILENAME;
+        const LIB_RECOMMENDED_VERSION: &'static str =
+            voicevox_core::blocking::Onnxruntime::LIB_RECOMMENDED_VERSION;
+
+        #[classattr]
+        const LIB_RECOMMENDED_VERSIONED_FILENAME: &'static str =
+            voicevox_core::blocking::Onnxruntime::LIB_RECOMMENDED_VERSIONED_FILENAME;
+
+        #[classattr]
+        const LIB_RECOMMENDED_UNVERSIONED_FILENAME: &'static str =
+            voicevox_core::blocking::Onnxruntime::LIB_RECOMMENDED_UNVERSIONED_FILENAME;
 
         #[new]
         #[classmethod]
@@ -547,7 +557,7 @@ mod blocking {
         }
 
         #[staticmethod]
-        #[pyo3(signature = (*, filename = Self::LIB_VERSIONED_FILENAME.into()))]
+        #[pyo3(signature = (*, filename = Self::LIB_RECOMMENDED_VERSIONED_FILENAME.into()))]
         fn load_once(filename: OsString, py: Python<'_>) -> PyResult<Py<Self>> {
             ONNXRUNTIME
                 .get_or_try_init(py, || {
@@ -1269,18 +1279,28 @@ mod asyncio {
     #[pymethods]
     impl Onnxruntime {
         #[classattr]
-        const LIB_NAME: &'static str = voicevox_core::nonblocking::Onnxruntime::LIB_NAME;
+        const LIB_MIN_REQUIRED_VERSION: u32 =
+            voicevox_core::nonblocking::Onnxruntime::LIB_MIN_REQUIRED_VERSION;
 
         #[classattr]
-        const LIB_VERSION: &'static str = voicevox_core::nonblocking::Onnxruntime::LIB_VERSION;
+        const LIB_MAX_SUPPORTED_VERSION: u32 =
+            voicevox_core::nonblocking::Onnxruntime::LIB_MAX_SUPPORTED_VERSION;
 
         #[classattr]
-        const LIB_VERSIONED_FILENAME: &'static str =
-            voicevox_core::nonblocking::Onnxruntime::LIB_VERSIONED_FILENAME;
+        const LIB_RECOMMENDED_NAME: &'static str =
+            voicevox_core::nonblocking::Onnxruntime::LIB_RECOMMENDED_NAME;
 
         #[classattr]
-        const LIB_UNVERSIONED_FILENAME: &'static str =
-            voicevox_core::nonblocking::Onnxruntime::LIB_UNVERSIONED_FILENAME;
+        const LIB_RECOMMENDED_VERSION: &'static str =
+            voicevox_core::nonblocking::Onnxruntime::LIB_RECOMMENDED_VERSION;
+
+        #[classattr]
+        const LIB_RECOMMENDED_VERSIONED_FILENAME: &'static str =
+            voicevox_core::nonblocking::Onnxruntime::LIB_RECOMMENDED_VERSIONED_FILENAME;
+
+        #[classattr]
+        const LIB_RECOMMENDED_UNVERSIONED_FILENAME: &'static str =
+            voicevox_core::nonblocking::Onnxruntime::LIB_RECOMMENDED_UNVERSIONED_FILENAME;
 
         #[new]
         #[classmethod]
@@ -1314,7 +1334,7 @@ mod asyncio {
         }
 
         #[staticmethod]
-        #[pyo3(signature = (*, filename = Self::LIB_VERSIONED_FILENAME.into()))]
+        #[pyo3(signature = (*, filename = Self::LIB_RECOMMENDED_VERSIONED_FILENAME.into()))]
         async fn load_once(filename: OsString) -> PyResult<&'static Py<Onnxruntime>> {
             let inner = voicevox_core::nonblocking::Onnxruntime::load_once()
                 .filename(filename)

--- a/docs/guide/user/usage.md
+++ b/docs/guide/user/usage.md
@@ -87,7 +87,7 @@ from pprint import pprint
 from voicevox_core.blocking import Onnxruntime, OpenJtalk, Synthesizer, VoiceModelFile
 
 # 1. Synthesizerの初期化
-voicevox_onnxruntime_path = "onnxruntime/lib/" + Onnxruntime.LIB_VERSIONED_FILENAME
+voicevox_onnxruntime_path = "onnxruntime/lib/" + Onnxruntime.LIB_RECOMMENDED_VERSIONED_FILENAME
 open_jtalk_dict_dir = "dict/open_jtalk_dic_utf_8-1.11"
 synthesizer = Synthesizer(Onnxruntime.load_once(filename=voicevox_onnxruntime_path), OpenJtalk(open_jtalk_dict_dir))
 

--- a/example/cpp/unix/song.cpp
+++ b/example/cpp/unix/song.cpp
@@ -47,10 +47,10 @@ int main(int argc, char* argv[]) {
   VoicevoxLoadOnnxruntimeOptions load_onnxruntime_options =
       voicevox_make_default_load_onnxruntime_options();
   char libonnxruntime_filename[128];
-  assert(strlen(voicevox_get_onnxruntime_lib_versioned_filename()) <
+  assert(strlen(voicevox_get_onnxruntime_lib_recommended_versioned_filename()) <
          128 - strlen("./voicevox_core/onnxruntime/lib/"));
   snprintf(libonnxruntime_filename, 128, "./voicevox_core/onnxruntime/lib/%s",
-           voicevox_get_onnxruntime_lib_versioned_filename());
+           voicevox_get_onnxruntime_lib_recommended_versioned_filename());
   load_onnxruntime_options.filename = libonnxruntime_filename;
 
   VoicevoxInitializeOptions initialize_options =

--- a/example/cpp/unix/talk.cpp
+++ b/example/cpp/unix/talk.cpp
@@ -31,7 +31,7 @@ int main(int argc, char *argv[]) {
   const VoicevoxOnnxruntime* onnxruntime;
   auto load_ort_options = voicevox_make_default_load_onnxruntime_options();
   std::string ort_filename = "./voicevox_core/onnxruntime/lib/";
-  ort_filename += voicevox_get_onnxruntime_lib_versioned_filename();
+  ort_filename += voicevox_get_onnxruntime_lib_recommended_versioned_filename();
   load_ort_options.filename = ort_filename.c_str();
   auto result = voicevox_onnxruntime_load_once(load_ort_options, &onnxruntime);
   if (result != VOICEVOX_RESULT_OK){

--- a/example/kotlin/app/src/main/kotlin/app/App.kt
+++ b/example/kotlin/app/src/main/kotlin/app/App.kt
@@ -19,7 +19,7 @@ fun main(args: Array<String>) {
   val onnxruntime by
       parser
           .option(ArgType.String, description = "ONNX Runtimeのファイル名（モジュール名）もしくはファイルパス")
-          .default(Onnxruntime.LIB_VERSIONED_FILENAME)
+          .default(Onnxruntime.LIB_RECOMMENDED_VERSIONED_FILENAME)
   val dictDir by
       parser
           .option(ArgType.String, description = "Open JTalkの辞書ディレクトリ")

--- a/example/python/song-asyncio.py
+++ b/example/python/song-asyncio.py
@@ -39,7 +39,7 @@ class Args:
         )
         argparser.add_argument(
             "--onnxruntime",
-            default=f"./onnxruntime/lib/{Onnxruntime.LIB_VERSIONED_FILENAME}",
+            default=f"./onnxruntime/lib/{Onnxruntime.LIB_RECOMMENDED_VERSIONED_FILENAME}",
             help="ONNX Runtimeのライブラリのfilename",
         )
         argparser.add_argument(

--- a/example/python/song.py
+++ b/example/python/song.py
@@ -38,7 +38,7 @@ class Args:
         )
         argparser.add_argument(
             "--onnxruntime",
-            default=f"./onnxruntime/lib/{Onnxruntime.LIB_VERSIONED_FILENAME}",
+            default=f"./onnxruntime/lib/{Onnxruntime.LIB_RECOMMENDED_VERSIONED_FILENAME}",
             help="ONNX Runtimeのライブラリのfilename",
         )
         argparser.add_argument(

--- a/example/python/talk-asyncio.py
+++ b/example/python/talk-asyncio.py
@@ -39,7 +39,7 @@ class Args:
         )
         argparser.add_argument(
             "--onnxruntime",
-            default=f"./onnxruntime/lib/{Onnxruntime.LIB_VERSIONED_FILENAME}",
+            default=f"./onnxruntime/lib/{Onnxruntime.LIB_RECOMMENDED_VERSIONED_FILENAME}",
             help="ONNX Runtimeのライブラリのfilename",
         )
         argparser.add_argument(

--- a/example/python/talk.py
+++ b/example/python/talk.py
@@ -40,7 +40,7 @@ class Args:
         )
         argparser.add_argument(
             "--onnxruntime",
-            default=f"./onnxruntime/lib/{Onnxruntime.LIB_VERSIONED_FILENAME}",
+            default=f"./onnxruntime/lib/{Onnxruntime.LIB_RECOMMENDED_VERSIONED_FILENAME}",
             help="ONNX Runtimeのライブラリのfilename",
         )
         argparser.add_argument(


### PR DESCRIPTION
## 内容

`Onnxruntime`の関連定数を次の形に再編する。

| 名前 | Linux版での値 |
| :- | :- |
| `LIB_RECOMMENDED_NAME` | `"voicevox_onnxruntime"` |
| `LIB_RECOMMENDED_VERSION` | `"1.17.3"` |
| `LIB_RECOMMENDED_VERSIONED_FILENAME` | `"libvoicevox_onnxruntime.so.1.17.3"` |
| `LIB_RECOMMENDED_UNVERSIONED_FILENAME` | `"libvoicevox_onnxruntime.so"` |
| `LIB_MIN_REQUIRED_MINOR_VERSION` | `17` |
| `LIB_MAX_SUPPORTED_MINOR_VERSION` | `17` |

また`{load,init}_once`時のエラーと警告のメッセージも少し変える。

BREAKING-CHANGE: 既存の定数の改名。

## 関連 Issue

Resolves: #1388
