### PR TITLE
refactor(c): Windowsでのコンパイル警告を直す

### DIFF
--- a/crates/voicevox_core_c_api/tests/e2e/log_mask.rs
+++ b/crates/voicevox_core_c_api/tests/e2e/log_mask.rs
@@ -1,6 +1,5 @@
 use std::sync::LazyLock;
 
-use const_format::concatcp;
 use regex::{Regex, Replacer};
 
 use crate::assert_cdylib::Utf8Output;
@@ -29,6 +28,8 @@ impl Utf8Output {
 
     #[cfg(unix)]
     pub(crate) fn mask_unix_onnxruntime_filename(self) -> Self {
+        use const_format::concatcp;
+
         const ONNXRUNTIME_VERSION: &str =
             include_str!("../../../voicevox_core/onnxruntime-recommended-version.txt");
         self.mask_stderr(


### PR DESCRIPTION
## 内容

うっかりCIが落ちている状態のまま #1404 をマージしてしまったので`main`のCIが落ちている、ので直す。
