### PR TITLE
feat(downloader): `models`の0.17対応

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - \[C,ダウンローダー\] \[macOS\] リリースがコード署名されるようになります ([#1326])。
 - \[ダウンローダー\] `--os`オプションで`android`と`ios`を指定できるようになります。ただしiOSの`c-api`をダウンロードすることはできません ([#1313])。
 - \[ダウンローダー\] 環境変数`VV_DOWNLOADER_C_API_ALLOW_DRAFT`を設定することで、`c-api`のdraft releaseを`--c-api-version`で指定できるようになります。主な用途はこのvoicevox\_coreリポジトリでの内部利用です ([#1315])。
+- \[ダウンローダー\] `models`にてバージョン0.17.*のダウンロードがサポートされるようになります ([#1409])。
 
 ### Changed
 
@@ -1539,6 +1540,7 @@ Windows版ダウンローダーのビルドに失敗しています。
 [#1402]: https://github.com/VOICEVOX/voicevox_core/pull/1402
 [#1404]: https://github.com/VOICEVOX/voicevox_core/pull/1404
 [#1406]: https://github.com/VOICEVOX/voicevox_core/pull/1406
+[#1409]: https://github.com/VOICEVOX/voicevox_core/pull/1409
 
 [VOICEVOX/onnxruntime-builder#25]: https://github.com/VOICEVOX/onnxruntime-builder/pull/25
 

--- a/crates/downloader/src/main.rs
+++ b/crates/downloader/src/main.rs
@@ -71,7 +71,7 @@ static SUPPORTED_ONNXRUNTIME_VERSIONS: LazyLock<VersionReq> =
 static SUPPORTED_ADDITIONAL_LIBRARIES_VERSIONS: LazyLock<VersionReq> =
     LazyLock::new(|| ">=0.2.1,<0.4".parse().unwrap());
 static SUPPORTED_MODELS_VERSIONS: LazyLock<VersionReq> =
-    LazyLock::new(|| ">=0.16,<0.17".parse().unwrap());
+    LazyLock::new(|| ">=0.16,<0.18".parse().unwrap());
 
 const MODELS_README_FILENAME: &str = "README.txt";
 const MODELS_DIR_NAME: &str = "vvms";


### PR DESCRIPTION
## 内容

デフォルトで探しに行くバージョン範囲を拡大し、`0.17.0`のpre-releaseが解除されたときにデフォルトで選択できるようにする。また明示的に`--models-version 0.17.0`としたときの警告も無くする効果もある。
