### PR TITLE
chore: `download_test`の`workflow_call`に`contents=write`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -571,6 +571,8 @@ jobs:
   download_test:
     needs: [config, set_tag_name]
     if: needs.config.outputs.mode == 'draft-release'
+    permissions:
+      contents: write
     uses: ./.github/workflows/download_test.yml
     with:
       version: ${{ inputs.version }}


### PR DESCRIPTION
## 内容

おそらく VOICEVOX/voicevox_project#93 以降`workflow_call`から起動される`download_test`が動かなくなったので、`permissions.contents=write`を設定する。

## その他

まだ未検証。
