### PR TITLE
ONNXRuntimeのWebGPU対応を追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2797,6 +2797,9 @@ dependencies = [
 name = "ort-sys"
 version = "2.0.0-rc.12"
 source = "git+https://github.com/pykeio/ort.git?rev=94417081c47f47f5a7d6a92ce94bb38fda10019f#94417081c47f47f5a7d6a92ce94bb38fda10019f"
+dependencies = [
+ "glob",
+]
 
 [[package]]
 name = "os_pipe"

--- a/crates/voicevox_core/Cargo.toml
+++ b/crates/voicevox_core/Cargo.toml
@@ -61,7 +61,7 @@ num-bigint.workspace = true
 num-traits.workspace = true
 once_cell.workspace = true
 open_jtalk.workspace = true
-ort = { workspace = true, features = ["std", "ndarray", "tracing", "api-17", "alternative-backend"], default-features = false }
+ort = { workspace = true, features = ["std", "ndarray", "tracing", "api-17", "alternative-backend", "webgpu"], default-features = false }
 ouroboros.workspace = true
 pastey.workspace = true
 phf = { workspace = true, features = ["macros"] }

--- a/crates/voicevox_core/src/core/devices.rs
+++ b/crates/voicevox_core/src/core/devices.rs
@@ -50,7 +50,7 @@ fn test_gpu(
 
 /// 利用可能なデバイスの情報。
 ///
-/// あくまで本ライブラリもしくはONNX Runtimeが対応しているデバイスの情報であることに注意。GPUが使える環境ではなかったとしても`cuda`や`dml`は`true`を示しうる。
+/// あくまで本ライブラリもしくはONNX Runtimeが対応しているデバイスの情報であることに注意。GPUが使える環境ではなかったとしても`cuda`や`dml`、`webgpu`は`true`を示しうる。
 ///
 /// ```
 /// # #[pollster::main]
@@ -86,6 +86,12 @@ pub struct SupportedDevices {
     ///
     /// [DirectML Execution Provider]: https://onnxruntime.ai/docs/execution-providers/DirectML-ExecutionProvider.html
     pub dml: bool,
+    /// WebGPUが利用可能。
+    ///
+    /// ONNX Runtimeの[WebGPU Execution Provider] (`WebGpuExecutionProvider`)に対応する。必要な環境についてはそちらを参照。
+    ///
+    /// [WebGPU Execution Provider]: https://onnxruntime.ai/docs/execution-providers/WebGPU-ExecutionProvider.html
+    pub webgpu: bool,
 }
 
 impl SupportedDevices {
@@ -98,6 +104,7 @@ impl SupportedDevices {
     /// # use voicevox_core::SupportedDevices;
     /// assert!(SupportedDevices::THIS.cuda);
     /// assert!(SupportedDevices::THIS.dml);
+    /// assert!(SupportedDevices::THIS.webgpu);
     /// ```
     ///
     /// `link-onnxruntime`のフィーチャが有効化されているときは`cpu`を除き`false`となる。
@@ -107,18 +114,21 @@ impl SupportedDevices {
     /// # use voicevox_core::SupportedDevices;
     /// assert!(!SupportedDevices::THIS.cuda);
     /// assert!(!SupportedDevices::THIS.dml);
+    /// assert!(!SupportedDevices::THIS.webgpu);
     /// ```
     pub const THIS: Self = if cfg!(feature = "load-onnxruntime") {
         Self {
             cpu: true,
             cuda: true,
             dml: true,
+            webgpu: true,
         }
     } else if cfg!(feature = "link-onnxruntime") {
         Self {
             cpu: true,
             cuda: false,
             dml: false,
+            webgpu: false,
         }
     } else {
         panic!("either `load-onnxruntime` or `link-onnxruntime` must be enabled");
@@ -192,11 +202,14 @@ pub(crate) enum GpuSpec {
 
     #[display("DirectML (device_id=0)")]
     Dml,
+
+    #[display("WebGPU (device_id=0)")]
+    WebGpu,
 }
 
 impl GpuSpec {
     pub(crate) fn defaults() -> Vec<Self> {
-        vec![Self::Cuda, Self::Dml]
+        vec![Self::Cuda, Self::Dml, Self::WebGpu]
     }
 }
 
@@ -207,6 +220,7 @@ impl Index<GpuSpec> for SupportedDevices {
         match gpu {
             GpuSpec::Cuda => &self.cuda,
             GpuSpec::Dml => &self.dml,
+            GpuSpec::WebGpu => &self.webgpu,
         }
     }
 }
@@ -227,8 +241,13 @@ mod tests {
                     unused_variables,
                     reason = "比較対象としてここは網羅されてなければなりません"
                 )]
-                let SupportedDevices { cpu: _, cuda, dml } = &SUPPORTED_DEVICES;
-                [&raw const *cuda, &raw const *dml]
+                let SupportedDevices {
+                    cpu: _,
+                    cuda,
+                    dml,
+                    webgpu,
+                } = &SUPPORTED_DEVICES;
+                [&raw const *cuda, &raw const *dml, &raw const *webgpu]
             },
             *GpuSpec::defaults()
                 .into_iter()

--- a/crates/voicevox_core/src/core/infer/runtimes/onnxruntime.rs
+++ b/crates/voicevox_core/src/core/infer/runtimes/onnxruntime.rs
@@ -26,7 +26,7 @@ use ort::{
     environment::Environment,
     ep::{
         CPUExecutionProvider, CUDAExecutionProvider, DirectMLExecutionProvider,
-        ExecutionProvider as _, cuda::ConvAlgorithmSearch,
+        ExecutionProvider as _, WebGPU, cuda::ConvAlgorithmSearch,
     },
     session::{RunOptions, builder::GraphOptimizationLevel},
     value::{PrimitiveTensorElementType, TensorElementType, ValueType},
@@ -251,6 +251,7 @@ impl InferenceRuntime for self::blocking::Onnxruntime {
             let cpu = CPUExecutionProvider::default().is_available()?;
             let cuda = CUDAExecutionProvider::default().is_available()?;
             let dml = DirectMLExecutionProvider::default().is_available()?;
+            let webgpu = WebGPU::default().is_available()?;
 
             ensure!(cpu, "missing `CPUExecutionProvider`");
 
@@ -258,6 +259,7 @@ impl InferenceRuntime for self::blocking::Onnxruntime {
                 cpu: true,
                 cuda,
                 dml,
+                webgpu,
             })
         })()
         .map_err(ErrorRepr::GetSupportedDevices)
@@ -271,6 +273,7 @@ impl InferenceRuntime for self::blocking::Onnxruntime {
                 .with_conv_algorithm_search(ConvAlgorithmSearch::Heuristic)
                 .register(sess_builder),
             GpuSpec::Dml => DirectMLExecutionProvider::default().register(sess_builder),
+            GpuSpec::WebGpu => WebGPU::default().register(sess_builder),
         }
         .map_err(Into::into)
     }
@@ -307,6 +310,9 @@ impl InferenceRuntime for self::blocking::Onnxruntime {
                     .with_memory_pattern(false)
                     .map_err(ort::Error::<()>::from)?;
                 DirectMLExecutionProvider::default().register(&mut builder)?;
+            }
+            DeviceSpec::Gpu(GpuSpec::WebGpu) => {
+                WebGPU::default().register(&mut builder)?;
             }
         };
 

--- a/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/SupportedDevices.java
+++ b/crates/voicevox_core_java_api/lib/src/main/java/jp/hiroshiba/voicevoxcore/SupportedDevices.java
@@ -7,8 +7,8 @@ import jakarta.annotation.Nonnull;
 /**
  * ONNX Runtime利用可能なデバイスの情報。
  *
- * <p>あくまでONNX Runtimeが対応しているデバイスの情報であることに注意。GPUが使える環境ではなかったとしても {@link #cuda} や {@link #dml} は
- * {@code true} を示しうる。
+ * <p>あくまでONNX Runtimeが対応しているデバイスの情報であることに注意。GPUが使える環境ではなかったとしても {@link #cuda} や {@link #dml}、{@link
+ * #webgpu} は {@code true} を示しうる。
  *
  * <p>現在この型はGSONに対応しているが、将来的には <a href="https://github.com/VOICEVOX/voicevox_core/issues/984"
  * target="_blank">Jacksonに切り替わる予定</a> 。
@@ -50,14 +50,27 @@ public final class SupportedDevices implements Cloneable {
   @Nonnull
   public final boolean dml;
 
+  /**
+   * WebGPUが利用可能。
+   *
+   * <p>ONNX Runtimeの <a href=
+   * "https://onnxruntime.ai/docs/execution-providers/WebGPU-ExecutionProvider.html"
+   * target="_blank">WebGpuExecutionProvider</a>に対応する。 必要な環境についてはそちらを参照。
+   */
+  @SerializedName("webgpu")
+  @Expose
+  @Nonnull
+  public final boolean webgpu;
+
   private SupportedDevices() {
     throw new UnsupportedOperationException("You cannot deserialize `SupportedDevices`");
   }
 
-  private SupportedDevices(boolean cpu, boolean cuda, boolean dml) {
+  private SupportedDevices(boolean cpu, boolean cuda, boolean dml, boolean webgpu) {
     this.cpu = cpu;
     this.cuda = cuda;
     this.dml = dml;
+    this.webgpu = webgpu;
   }
 
   @Override
@@ -66,11 +79,11 @@ public final class SupportedDevices implements Cloneable {
       return false;
     }
     SupportedDevices other = (SupportedDevices) obj;
-    return cpu == other.cpu && cuda == other.cuda && dml == other.dml;
+    return cpu == other.cpu && cuda == other.cuda && dml == other.dml && webgpu == other.webgpu;
   }
 
   @Override
   public SupportedDevices clone() {
-    return new SupportedDevices(cpu, cuda, dml);
+    return new SupportedDevices(cpu, cuda, dml, webgpu);
   }
 }

--- a/crates/voicevox_core_java_api/src/onnxruntime.rs
+++ b/crates/voicevox_core_java_api/src/onnxruntime.rs
@@ -81,14 +81,19 @@ unsafe extern "system" fn Java_jp_hiroshiba_voicevoxcore_blocking_Onnxruntime_rs
         let devices = this.supported_devices()?;
 
         assert!(match devices.to_json_value() {
-            serde_json::Value::Object(o) => o.len() == 3, // `cpu`, `cuda`, `dml`
+            serde_json::Value::Object(o) => o.len() == 4, // `cpu`, `cuda`, `dml`, `webgpu`
             _ => false,
         });
 
         let devices = env.new_object(
             object!("SupportedDevices"),
-            "(ZZZ)V",
-            &[devices.cpu.into(), devices.cuda.into(), devices.dml.into()],
+            "(ZZZZ)V",
+            &[
+                devices.cpu.into(),
+                devices.cuda.into(),
+                devices.dml.into(),
+                devices.webgpu.into(),
+            ],
         )?;
         Ok(devices.into_raw())
     })

--- a/crates/voicevox_core_python_api/python/voicevox_core/_python/__init__.py
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_python/__init__.py
@@ -183,7 +183,7 @@ class SupportedDevices:
     ONNX Runtimeとして利用可能なデバイスの情報。
 
     あくまでONNX Runtimeが対応しているデバイスの情報であることに注意。GPUが使える環境ではなかったとしても
-    ``cuda`` や ``dml`` は ``True`` を示しうる。
+    ``cuda`` や ``dml``、``webgpu`` は ``True`` を示しうる。
 
     VOICEVOX CORE以外が作ることはできない。作ろうとした場合 ``TypeError`` となる。
     """
@@ -209,6 +209,14 @@ class SupportedDevices:
 
     ONNX Runtimeの `DirectML Execution Provider <https://onnxruntime.ai/docs/execution-providers/DirectML-ExecutionProvider.html>`_
     (``DmlExecutionProvider``)に対応する。必要な環境についてはそちらを参照。
+    """
+
+    webgpu: bool
+    """
+    WebGPUが利用可能。
+
+    ONNX Runtimeの `WebGPU Execution Provider <https://onnxruntime.ai/docs/execution-providers/WebGPU-ExecutionProvider.html>`_
+    (``WebGpuExecutionProvider``)に対応する。必要な環境についてはそちらを参照。
     """
 
     _reserved: InitVar[Never]

--- a/crates/voicevox_core_python_api/src/convert.rs
+++ b/crates/voicevox_core_python_api/src/convert.rs
@@ -472,7 +472,7 @@ pub(crate) impl<T> voicevox_core::Result<T> {
 impl SupportedDevices {
     fn to_py(self, py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {
         assert!(match self.to_json_value() {
-            serde_json::Value::Object(o) => o.len() == 3, // `cpu`, `cuda`, `dml`
+            serde_json::Value::Object(o) => o.len() == 4, // `cpu`, `cuda`, `dml`, `webgpu`
             _ => false,
         });
 

--- a/docs/guide/user/gpu.md
+++ b/docs/guide/user/gpu.md
@@ -15,6 +15,16 @@ DirectML 版を利用するには Downloader の実行が必要です。
 
 macOS の場合、CUDA の macOS サポートは現在終了しているため、VOICEVOX CORE の macOS 向けビルド済みライブラリも CUDA, CUDNN を利用しない CPU 版のみの提供となります。
 
+## WebGPU
+
+VOICEVOX CORE は ONNX Runtime の [WebGPU Execution Provider] にも対応しています。ただし現時点では、Downloader が取得する ONNX Runtime のビルド（[onnxruntime-builder]）に WebGPU Execution Provider は含まれていません。
+
+WebGPU を用いた合成を行うには、WebGPU Execution Provider を有効にしてビルドした ONNX Runtime（`onnxruntime_USE_WEBGPU=ON`）を自前で用意し、[`Onnxruntime::load_once`]（もしくは `voicevox_onnxruntime_load_once`）にそのパスを渡してください。CUDA・DirectML と同様、対応する Execution Provider が利用できない場合は自動的に CPU にフォールバックします。
+
+[WebGPU Execution Provider]: https://onnxruntime.ai/docs/execution-providers/WebGPU-ExecutionProvider.html
+[onnxruntime-builder]: https://github.com/VOICEVOX/onnxruntime-builder
+[`Onnxruntime::load_once`]: https://voicevox.github.io/voicevox_core/apis/rust_api/voicevox_core/blocking/struct.Onnxruntime.html#method.load_once
+
 <!--
 ## Raspberry Piでの使用について
 

--- a/example/python/README.md
+++ b/example/python/README.md
@@ -67,7 +67,7 @@ optional arguments:
 ```console
 ❯ python ./talk.py ./models/vvms/0.vvm
 [INFO] __main__: Loading ONNX Runtime (args.onnxruntime='./onnxruntime/lib/libvoicevox_onnxruntime.so.1.17.3')
-[DEBUG] __main__: onnxruntime.supported_devices()=SupportedDevices(cpu=True, cuda=True, dml=False)
+[DEBUG] __main__: onnxruntime.supported_devices()=SupportedDevices(cpu=True, cuda=True, dml=False, webgpu=False)
 [INFO] __main__: Initializing (args.mode=<AccelerationMode.AUTO: 'AUTO'>, args.dict_dir=PosixPath('dict/open_jtalk_dic_utf_8-1.11'))
 [INFO] voicevox_core.synthesizer: GPUをテストします:
 [INFO] voicevox_core.synthesizer:   * CUDA (device_id=0): OK
@@ -115,7 +115,7 @@ options:
 ```console
 ❯ python ./song.py ./models/vvms/s0.vvm --singer 3002
 [INFO] __main__: Loading ONNX Runtime (args.onnxruntime='./onnxruntime/lib/libvoicevox_onnxruntime.so.1.17.3')
-[DEBUG] __main__: onnxruntime.supported_devices()=SupportedDevices(cpu=True, cuda=True, dml=False)
+[DEBUG] __main__: onnxruntime.supported_devices()=SupportedDevices(cpu=True, cuda=True, dml=False, webgpu=False)
 [INFO] __main__: Initializing (args.mode='AUTO', args.dict_dir=PosixPath('dict/open_jtalk_dic_utf_8-1.11'))
 [INFO] voicevox_core.synthesizer: GPUをテストします:
 [INFO] voicevox_core.synthesizer:   * CUDA (device_id=0): OK


### PR DESCRIPTION
## 内容

LinuxやmacOSでGPUを使う場合、CUDA/DMLでは対応しきれないためclaudeでWebGPUを色々と試してみました
WebGPUという規格自体は、ブラウザに限らずネイティブアプリでも使えるグラフィックAPI見たいです
(markdownのコピペで見づらいのはすいません...)

**m4 mac miniでの結果**:

<h2 dir="ltr">Setup</h2><p dir="ltr">Built ONNX Runtime <strong>v1.29.0</strong> from source at <code data-epitaxy-inline-code="">~/dev/onnxruntime</code> (Release, arm64, <code data-epitaxy-inline-code="">--use_webgpu</code>, Dawn statically linked, Metal-backed). Verified before trusting any number:</p><div class="epitaxy-codeblock relative max-w-full w-fit"><div class="relative"><div class="epitaxy-diff rounded-r6 overflow-clip" style=""><pre>SupportedDevices { cpu: true, cuda: false, dml: false, webgpu: true }</pre></div><div class="pointer-events-none absolute inset-y-0 right-[calc(var(--p4)+var(--p1))]"><div class="pointer-events-auto sticky top-[calc(max(var(--epitaxy-top-scrim-height,0px),var(--fade-top,0px))+var(--p4))] flex gap-[var(--p2)] mt-[calc(var(--p6)+var(--text-code)*var(--leading-code)/2-var(--h3)/2)]"></div></div></div></div><p dir="ltr">CUDA and DML are <code data-epitaxy-inline-code="">false</code> on macOS, so <code data-epitaxy-inline-code="">GpuSpec::defaults()</code> can only resolve to <code data-epitaxy-inline-code="">WebGpu</code> — the GPU path is genuinely WebGPU, not a fallback. The 1.29 runtime also loads fine against <code data-epitaxy-inline-code="">ort</code>'s <code data-epitaxy-inline-code="">api-17</code> pin, which was the risk I'd flagged.</p><h2 dir="ltr">Results — sample.vvm, style 0, SHORT text, same ORT 1.29.0 both sides</h2><div dir="ltr" class="overflow-x-auto">
bench | CPU | WebGPU | speedup
-- | -- | -- | --
synthesis (blocking) | 1.156 s | 353.6 ms | 3.27×
synthesis (nonblocking) | 1.281 s | 352.1 ms | 3.64×
unload_and_load_vvm (blocking) | 803.5 ms | 766.0 ms | 1.05×
unload_and_load_vvm (nonblocking) | 892.8 ms | 870.0 ms | 1.03×
replace_mora_pitch | 401.5 µs | 384.6 µs | ~1.0×
replace_phoneme_length | 44.6 µs | 41.3 µs | ~1.0×
analyze_text | 188.7 µs | 187.8 µs | ~1.0×

</div><p dir="ltr">Medians. WebGPU is also notably more consistent on <code data-epitaxy-inline-code="">synthesis</code> — 349.8–357.5 ms spread versus 1.125–1.26 s on CPU.</p>

**Linux+Radeon 8060S, RTX 5050の結果**:

Done. The one piece the doc couldn't finish — running the branch against a real WebGPU-capable ONNX Runtime — now works.

## What I ran

**§1 — built ONNX Runtime 1.30.0 with `--use_webgpu`.** Clean build, no patches, on CMake 4.1.6 / GCC 15.2. ~7 minutes on your 32 cores, not the "well over 30" the doc estimated.

**§2 — skipped lavapipe as the primary path.** This machine has real GPUs (RTX 5050 + Radeon 8060S) with native drivers. I tested lavapipe anyway as the no-hardware fallback.

**§3a — ONNX Runtime alone.** Rather than a toy model, I ran all nine real VOICEVOX models from `sample.vvm` under both EPs. All load onto WebGPU and agree with CPU to fp32 tolerance (worst relative Δ 1.2e-4, on `decode.onnx`).

**§3b — the voicevox_core patch.** Stock VOICEVOX ORT 1.17.3 reports `webgpu: false`; the new build reports `true`, `test_gpu` returns `WebGPU (device_id=0): OK` while correctly rejecting CUDA/DirectML, and `AccelerationMode::Gpu` selects it. Full TTS matches the CPU waveform to 3.1e-5 — one LSB of 16-bit PCM.

| driver | device | CPU | WebGPU | speedup |
| --- | --- | --- | --- | --- |
| RADV | Radeon 8060S | 567 ms | 103 ms | 5.5× |
| NVIDIA | RTX 5050 | 583 ms | 114 ms | 5.1× |
| lavapipe | software | 514 ms | 3.76 s | 0.14× |

## Three things worth knowing

- `model/sample.vvm` in the repo is an **unzipped directory** — `VoiceModelFile::open` wants the zip that `test_util`'s `build.rs` produces at `crates/test_util/data/model/sample.vvm`.
- voicevox_core warns that 1.30.0 exceeds its supported ceiling of 1.29. Nothing broke, but that range wants widening.
- Cold vs warm is significant: first synthesis 160–200 ms vs 103–114 ms warm, from Dawn's shader compilation.

## Files

- `zundamonttswebgpucontinue.md` — rewritten as a results record; §"What's left" is now just your three open items.
- `~/dev/voicevox-webgpu-validation/` — both harnesses, moved out of the session scratchpad so they survive.
- `rpg-maker-clone` branch `claude/adr-0048-webgpu-validated` — ADR 0048 updated, committed locally, not pushed. I used git plumbing rather than a checkout, so your detached HEAD and `3rd/cmdline/` are untouched.

The voicevox_core repo has no code changes; `0bc5c4c` is unchanged and its `fmt`/unit-test checks still pass.

**One caveat I found that the ADR didn't have:** `new_session()` gates `vv-bin`-format models behind a `"VOICEVOX ORT Build Info: "` marker only VOICEVOX's builder can stamp. `sample.vvm` is all `"type": "onnx"`, which is why a stock upstream build works. That means whether ADR 0048's part 1 is merely a *distribution* problem or a hard blocker depends on which format the released Zundamon `0.vvm` uses — the check is in the doc for when you accept the terms:

```bash
cargo run -p downloader -- --only models --models-pattern 0.vvm -o ./vvdl
unzip -p ./vvdl/models/vvms/0.vvm manifest.json | grep '"type"'
```


## 関連 Issue

https://github.com/VOICEVOX/voicevox_core/pull/1380
https://github.com/VOICEVOX/voicevox_core/issues/491

## その他

onnxモデルをonnxsimで最適化すると多少ダイエットになるかもしれないです。
https://onnxsim.github.io/onnxsim/ でブラウザだけでonnxモデルの最適化とCPU, WebNN, WebGPUのonnxruntime実行も試せます
以下、 https://github.com/onnxsim/onnxsim/pull/616 の時にclaudeで取ってもらった結果です:

## Results: onnxsim vs. 9 real VOICEVOX production models

I extracted all 9 real ONNX models (not LFS stubs, full weights) from `voicevox_core`'s `model/sample.vvm/` and ran the onnxsim build under test against each. Summary:

| Model | Nodes (before → after) | check_n=3 | Notes |
|---|---|---|---|
| `predict_duration.onnx` | 27 → 26 | ✅ pass | works out of the box |
| `predict_intonation.onnx` | 62 → ~55 | ✅ pass* | *needed `--input-fill ones` — default random-fill casts to `0`/`int`, which zeroes out this model's boundary-flag inputs and makes an internal `ConcatFromSequence` degenerate/empty |
| `decode.onnx` (55MB) | 695 → fewer, fully concrete shapes | ✅ pass* | *needed explicit `--overwrite-input-shape` (length=1 hits an `Unsqueeze` axis edge case in the original model itself) |
| `predict_spectrogram.onnx` | 469 → fewer | ✅ pass | 3m7s |
| `vocoder.onnx` (54MB) | 200 → fewer | ✅ pass | 3m34s |
| `predict_sing_consonant_length.onnx` | 318 → fewer | ✅ pass | |
| `sf_decode.onnx` (57MB) | 2220 → **763** | ✅ pass (via API) | ⚠️ CLI crashes on the summary table — see bug below |
| `predict_sing_f0.onnx` | 2884 → **782** | ⚠️ inherently unverifiable | contains `RandomNormalLike` (diffusion-style F0 sampling) — non-deterministic per call, so comparing original vs. simplified output is fundamentally not meaningful. Confirmed by re-running the *unmodified* original model twice and getting different outputs each time. Simplification itself looks fine. |
| `predict_sing_volume.onnx` | 2891 → **787** | ⚠️ same as above | same `RandomNormalLike` issue |
