### PR TITLE
feat: `AudioFeature::frame_length`を陽に持たない

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [#1364]
 - [#1376]
 - [#1400]
+- [#1418]
 
 [#854]: https://github.com/VOICEVOX/voicevox_core/pull/854
 [#864]: https://github.com/VOICEVOX/voicevox_core/pull/864
@@ -27,6 +28,7 @@
 [#1319]: https://github.com/VOICEVOX/voicevox_core/pull/1319
 [#1364]: https://github.com/VOICEVOX/voicevox_core/pull/1364
 [#1376]: https://github.com/VOICEVOX/voicevox_core/pull/1376
+[#1418]: https://github.com/VOICEVOX/voicevox_core/pull/1418
 
 ### もし`TextAnalyzer`機能を充実させた場合
 

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -192,10 +192,10 @@ fn crop_with_margin(
     audio: &AudioFeature,
     range: std::ops::Range<usize>,
 ) -> ndarray::ArrayView2<'_, f32> {
-    if range.start > audio.frame_length || range.end > audio.frame_length {
+    if range.start > audio.frame_length() || range.end > audio.frame_length() {
         panic!(
             "{range:?} is out of range for audio feature of length {frame_length}",
-            frame_length = audio.frame_length,
+            frame_length = audio.frame_length(),
         );
     }
     if range.start > range.end {
@@ -221,12 +221,17 @@ pub struct AudioFeature {
     internal_state: ndarray::Array2<f32>,
     /// 生成時に指定したスタイル番号。
     style_id: crate::StyleId,
-    /// workaround paddingを除いた音声特徴量のフレーム数。
-    pub frame_length: usize,
-    /// フレームレート。全体の秒数は`frame_length / frame_rate`で表せる。
+    /// フレームレート。音声特徴量のフレーム数をこの値で割ると全体の秒数になる。
     pub frame_rate: f64,
     /// 生成時に利用したクエリ。
     audio_query: ValidatedAudioQuery<'static>,
+}
+
+impl AudioFeature {
+    /// workaround paddingを除いた音声特徴量のフレーム数。
+    pub fn frame_length(&self) -> usize {
+        self.internal_state.nrows() - 2 * MARGIN
+    }
 }
 
 #[derive(derive_more::Debug)]
@@ -466,7 +471,6 @@ trait AsInner {
         Ok(AudioFeature {
             internal_state: spec,
             style_id,
-            frame_length: f0.len(),
             frame_rate: (DEFAULT_SAMPLING_RATE as f64) / 256.0,
             audio_query,
         })
@@ -520,7 +524,7 @@ trait AsInner {
         let audio = self
             .precompute_render(audio_query, style_id, options)
             .await?;
-        let pcm = self.render(&audio, 0..audio.frame_length).await?;
+        let pcm = self.render(&audio, 0..audio.frame_length()).await?;
         Ok(wav_from_s16le(
             &pcm,
             audio_query.output_sampling_rate.get().get(),

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -221,7 +221,7 @@ pub struct AudioFeature {
     internal_state: ndarray::Array2<f32>,
     /// 生成時に指定したスタイル番号。
     style_id: crate::StyleId,
-    /// フレームレート。音声特徴量のフレーム数をこの値で割ると全体の秒数になる。
+    /// フレームレート。全体の秒数は`frame_length() / frame_rate`で表せる。
     pub frame_rate: f64,
     /// 生成時に利用したクエリ。
     audio_query: ValidatedAudioQuery<'static>,

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -651,7 +651,7 @@ mod blocking {
     impl AudioFeature {
         #[getter]
         fn frame_length(&self) -> usize {
-            self.audio.frame_length
+            self.audio.frame_length()
         }
 
         #[getter]
@@ -931,10 +931,10 @@ mod blocking {
             stop: usize,
             py: Python<'_>,
         ) -> PyResult<Vec<u8>> {
-            if start > audio.frame_length() || stop > audio.frame_length() {
+            if start > audio.audio.frame_length() || stop > audio.audio.frame_length() {
                 return Err(PyIndexError::new_err(format!(
                     "({start}, {stop}) is out of range for audio feature of length {len}",
-                    len = audio.frame_length(),
+                    len = audio.audio.frame_length(),
                 )));
             }
             if start > stop {


### PR DESCRIPTION
## 内容

`AudioFeature::frame_length`を独立したフィールドではなく、スペクトログラムのnrowsから14×2（左右マージン）を引いたものとして算出する。

理由の一つは`AudioFeature`のデータ構造を簡潔にして見通しを良くするため。もう一つの理由としてはRust APIとしてちょっと良くないと感じたため。書き換え可能な`pub`フィールドとして`frame_length`を露出するというのはちょっと混乱するデザインだと感じた。
