### PR TITLE
feat: `generate_full_intermediate`が返すフレーム長をチェック

### DIFF
--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -1331,8 +1331,9 @@ impl<R: InferenceRuntime> Status<R> {
             return Err(ErrorRepr::RunModel {
                 note: None,
                 source: anyhow!(
-                    "`generate_full_intermediate` returned an array with {actual} frames. \
-                     expected {f0_with_padding_len} frames",
+                    "`generate_full_intermediate` returned an output with a different number \
+                     of frames than the input: \
+                     expected {f0_with_padding_len} frames, got {actual} frames",
                     actual = spec_with_padding.nrows(),
                 ),
             }

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -1309,6 +1309,8 @@ impl<R: InferenceRuntime> Status<R> {
                     .unwrap(),
             );
 
+        let f0_with_padding_len = f0_with_padding.len();
+
         let GenerateFullIntermediateOutput {
             spec: spec_with_padding,
         } = self
@@ -1324,6 +1326,18 @@ impl<R: InferenceRuntime> Status<R> {
                 A::LIGHT_INFERENCE_CANCELLABLE,
             )
             .await?;
+
+        if spec_with_padding.nrows() != f0_with_padding_len {
+            return Err(ErrorRepr::RunModel {
+                note: None,
+                source: anyhow!(
+                    "`generate_full_intermediate` returned an array with {actual} frames. \
+                     expected {f0_with_padding_len} frames",
+                    actual = spec_with_padding.nrows(),
+                ),
+            }
+            .into());
+        }
 
         // マージンがデータからはみ出さないことを保証
         // cf. https://github.com/VOICEVOX/voicevox_core/pull/854#discussion_r1803691291


### PR DESCRIPTION
## 内容

`generate_full_intermediate`が返すフレーム長が入力の大きさ（= f0サイズ + 2・38）と異なっていたらエラーとする。

動機としては #1418 をやるにあたり、考えることを減らしたいため。

## 関連 Issue

## その他
