### PR TITLE
feat: `AudioFeature`にAudioQueryを丸ごと持たせない

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [#1376]
 - [#1400]
 - [#1418]
+- [#1420]
 
 [#854]: https://github.com/VOICEVOX/voicevox_core/pull/854
 [#864]: https://github.com/VOICEVOX/voicevox_core/pull/864
@@ -29,6 +30,7 @@
 [#1364]: https://github.com/VOICEVOX/voicevox_core/pull/1364
 [#1376]: https://github.com/VOICEVOX/voicevox_core/pull/1376
 [#1418]: https://github.com/VOICEVOX/voicevox_core/pull/1418
+[#1420]: https://github.com/VOICEVOX/voicevox_core/pull/1420
 
 ### もし`TextAnalyzer`機能を充実させた場合
 

--- a/crates/voicevox_core/src/engine.rs
+++ b/crates/voicevox_core/src/engine.rs
@@ -10,7 +10,9 @@ pub(crate) mod talk;
 pub(crate) mod validate;
 
 pub(crate) use self::{
-    acoustic_feature_extractor::PhonemeCode, audio_file::to_s16le_pcm, ndarray::IteratorExt,
+    acoustic_feature_extractor::PhonemeCode,
+    audio_file::{PcmOptions, to_s16le_pcm},
+    ndarray::IteratorExt,
     sampling_rate::DEFAULT_SAMPLING_RATE,
 };
 pub use self::{

--- a/crates/voicevox_core/src/engine/audio_file.rs
+++ b/crates/voicevox_core/src/engine/audio_file.rs
@@ -1,15 +1,17 @@
 use std::io::{Cursor, Write as _};
 
+use typed_floats::PositiveFinite;
+
 use crate::{FrameAudioQuery, SamplingRate};
 
 use super::{DEFAULT_SAMPLING_RATE, talk::ValidatedAudioQuery};
 
-pub(crate) fn to_s16le_pcm(wave: &[f32], query: &impl HasPcmOptions) -> Vec<u8> {
+pub(crate) fn to_s16le_pcm(wave: &[f32], options: PcmOptions) -> Vec<u8> {
     let PcmOptions {
         volume_scale,
         output_sampling_rate,
         output_stereo,
-    } = query.pcm_options();
+    } = options;
     let num_channels: u16 = if output_stereo { 2 } else { 1 };
     let repeat_count: u32 =
         (output_sampling_rate.get().get() / DEFAULT_SAMPLING_RATE) * num_channels as u32;
@@ -18,7 +20,7 @@ pub(crate) fn to_s16le_pcm(wave: &[f32], query: &impl HasPcmOptions) -> Vec<u8> 
     let mut cur = Cursor::new(buf);
 
     for value in wave {
-        let v = (value * volume_scale).clamp(-1., 1.);
+        let v = (value * volume_scale.get()).clamp(-1., 1.);
         let data = (v * 0x7fff as f32) as i16;
         for _ in 0..repeat_count {
             cur.write_all(&data.to_le_bytes()).unwrap();
@@ -28,18 +30,15 @@ pub(crate) fn to_s16le_pcm(wave: &[f32], query: &impl HasPcmOptions) -> Vec<u8> 
     cur.into_inner()
 }
 
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub(crate) struct PcmOptions {
-    volume_scale: f32,
+    volume_scale: PositiveFinite<f32>,
     output_sampling_rate: SamplingRate,
     output_stereo: bool,
 }
 
-pub(crate) trait HasPcmOptions {
-    fn pcm_options(&self) -> PcmOptions;
-}
-
-impl HasPcmOptions for ValidatedAudioQuery<'_> {
-    fn pcm_options(&self) -> PcmOptions {
+impl ValidatedAudioQuery<'_> {
+    pub(crate) fn pcm_options(&self) -> PcmOptions {
         let Self {
             volume_scale,
             output_sampling_rate,
@@ -48,15 +47,15 @@ impl HasPcmOptions for ValidatedAudioQuery<'_> {
         } = *self;
 
         PcmOptions {
-            volume_scale: volume_scale.into(),
+            volume_scale,
             output_sampling_rate,
             output_stereo,
         }
     }
 }
 
-impl HasPcmOptions for FrameAudioQuery {
-    fn pcm_options(&self) -> PcmOptions {
+impl FrameAudioQuery {
+    pub(crate) fn pcm_options(&self) -> PcmOptions {
         let Self {
             volume_scale,
             output_sampling_rate,
@@ -65,7 +64,7 @@ impl HasPcmOptions for FrameAudioQuery {
         } = *self;
 
         PcmOptions {
-            volume_scale: volume_scale.into(),
+            volume_scale,
             output_sampling_rate,
             output_stereo,
         }

--- a/crates/voicevox_core/src/engine/talk/audio_query/validated.rs
+++ b/crates/voicevox_core/src/engine/talk/audio_query/validated.rs
@@ -158,22 +158,6 @@ impl<'original> ValidatedMora<'original> {
             }
         }
     }
-
-    fn into_owned(self) -> ValidatedMora<'static> {
-        let Self {
-            text,
-            consonant,
-            vowel,
-            pitch,
-        } = self;
-        let text = text.into_owned().into();
-        ValidatedMora {
-            text,
-            consonant,
-            vowel,
-            pitch,
-        }
-    }
 }
 
 impl From<ValidatedMora<'_>> for Mora {
@@ -283,23 +267,6 @@ impl<'original> ValidatedAccentPhrase<'original> {
             }
         }
     }
-
-    fn into_owned(self) -> ValidatedAccentPhrase<'static> {
-        let Self {
-            moras,
-            accent,
-            pause_mora,
-            is_interrogative,
-        } = self;
-        let moras = moras.into_iter().map(ValidatedMora::into_owned).collect();
-        let pause_mora = pause_mora.map(ValidatedMora::into_owned);
-        ValidatedAccentPhrase {
-            moras,
-            accent,
-            pause_mora,
-            is_interrogative,
-        }
-    }
 }
 
 impl From<ValidatedAccentPhrase<'_>> for AccentPhrase {
@@ -395,37 +362,6 @@ impl<'original> ValidatedAudioQuery<'original> {
                 value: None,
                 source: Some(source),
             }
-        }
-    }
-
-    pub(crate) fn into_owned(self) -> ValidatedAudioQuery<'static> {
-        let Self {
-            accent_phrases,
-            speed_scale,
-            pitch_scale,
-            intonation_scale,
-            volume_scale,
-            pre_phoneme_length,
-            post_phoneme_length,
-            output_sampling_rate,
-            output_stereo,
-            kana,
-        } = self;
-        let accent_phrases = accent_phrases
-            .into_iter()
-            .map(ValidatedAccentPhrase::into_owned)
-            .collect();
-        ValidatedAudioQuery {
-            accent_phrases,
-            speed_scale,
-            pitch_scale,
-            intonation_scale,
-            volume_scale,
-            pre_phoneme_length,
-            post_phoneme_length,
-            output_sampling_rate,
-            output_stereo,
-            kana,
         }
     }
 }

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -42,7 +42,7 @@ use crate::{
         voice_model,
     },
     engine::{
-        DEFAULT_SAMPLING_RATE, IteratorExt as _, PhonemeCode,
+        DEFAULT_SAMPLING_RATE, IteratorExt as _, PcmOptions, PhonemeCode,
         song::{
             self,
             interpret::{ConsonantLengthsFeature, PhonemeFeature, SfDecoderFeature},
@@ -50,8 +50,8 @@ use crate::{
             validate::{ValidatedNote, ValidatedScore},
         },
         talk::{
-            DecoderFeature, LengthedPhoneme, ValidatedAccentPhrase, ValidatedAudioQuery,
-            ValidatedMora, create_kana, initial_process, parse_kana, split_mora,
+            DecoderFeature, LengthedPhoneme, ValidatedAccentPhrase, ValidatedMora, create_kana,
+            initial_process, parse_kana, split_mora,
         },
         to_s16le_pcm, wav_from_s16le,
     },
@@ -223,8 +223,8 @@ pub struct AudioFeature {
     style_id: crate::StyleId,
     /// フレームレート。全体の秒数は`frame_length() / frame_rate`で表せる。
     pub frame_rate: f64,
-    /// 生成時に利用したクエリ。
-    audio_query: ValidatedAudioQuery<'static>,
+    /// `[f32]`からPCMを作るときのオプション。
+    pcm_options: PcmOptions,
 }
 
 impl AudioFeature {
@@ -454,7 +454,7 @@ trait AsInner {
         style_id: StyleId,
         options: &SynthesisOptions<Self::Async>,
     ) -> Result<AudioFeature> {
-        let audio_query = audio_query.to_validated()?.into_owned();
+        let audio_query = audio_query.to_validated()?;
 
         let DecoderFeature { f0, phoneme } =
             audio_query.decoder_feature(options.enable_interrogative_upspeak);
@@ -472,7 +472,7 @@ trait AsInner {
             internal_state: spec,
             style_id,
             frame_rate: (DEFAULT_SAMPLING_RATE as f64) / 256.0,
-            audio_query,
+            pcm_options: audio_query.pcm_options(),
         })
     }
 
@@ -491,7 +491,7 @@ trait AsInner {
         Ok(to_s16le_pcm(
             wave.as_slice()
                 .expect("`trim_margin_from_wave` should just trim an array"),
-            &audio.audio_query,
+            audio.pcm_options,
         ))
     }
 
@@ -516,7 +516,7 @@ trait AsInner {
                 )
                 .await?;
             return Ok(wav_from_s16le(
-                &to_s16le_pcm(wave, &audio_query),
+                &to_s16le_pcm(wave, audio_query.pcm_options()),
                 audio_query.output_sampling_rate.get().get(),
                 audio_query.output_stereo,
             ));
@@ -1035,7 +1035,7 @@ trait AsInner {
         };
 
         Ok(wav_from_s16le(
-            &to_s16le_pcm(wave, frame_audio_query),
+            &to_s16le_pcm(wave, frame_audio_query.pcm_options()),
             frame_audio_query.output_sampling_rate.get().get(),
             frame_audio_query.output_stereo,
         ))


### PR DESCRIPTION
## 内容

`Debug`（他言語でも例えばPythonなら`repr`）での表示をすっきりとさせるため。また`AudioFeature`にAudioQueryを丸ごと持たせるためだけに数十行のコードが存在する形になっているので、それの抹消も目的。

## 関連 Issue

cf. #1364
