### PR TITLE
feat(rust,python): ストリーミングAPIを改名し、Rust APIを復活

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,33 +5,6 @@
 ## [Unreleased]
 
 <!--
-### ストリーミングAPI
-
-- split decoder into spectrogram and vocoder without changing API ([#851])
-- ストリーミングモードのdecodeを実装（precompute_renderとrender） ([#854])
-- fix: Python APIとexample/python/run.pyの型付けを直す ([#864])
-- fix compat breaking: revive workaround padding in decode() ([#867])
-- feat!: `render`の引数の範囲指定部分を各言語の慣習に合わせる ([#879])
-- feat!: decode.onnxを復活させる ([#918])
-- [#1319]
-- [#1363]
-- [#1371]
-- [#1364]
-- [#1376]
-- [#1400]
-- [#1418]
-- [#1420]
-
-[#854]: https://github.com/VOICEVOX/voicevox_core/pull/854
-[#864]: https://github.com/VOICEVOX/voicevox_core/pull/864
-[#867]: https://github.com/VOICEVOX/voicevox_core/pull/867
-[#879]: https://github.com/VOICEVOX/voicevox_core/pull/879
-[#1319]: https://github.com/VOICEVOX/voicevox_core/pull/1319
-[#1364]: https://github.com/VOICEVOX/voicevox_core/pull/1364
-[#1376]: https://github.com/VOICEVOX/voicevox_core/pull/1376
-[#1418]: https://github.com/VOICEVOX/voicevox_core/pull/1418
-[#1420]: https://github.com/VOICEVOX/voicevox_core/pull/1420
-
 ### もし`TextAnalyzer`機能を充実させた場合
 
 - TextAnalyzer traitにstring->AccentPhraseModel[]を移動 ([#740] by [@eyr1n])。
@@ -43,6 +16,10 @@
 
 [@phenylshima]: https://github.com/phenylshima
 -->
+
+### Added
+
+- \[Rust\] `Synthesizer::create_audio_feature`と`Synthesizer::render`が追加されます ([#851], [#854], [#864], [#867], [#879], [#918], [#972], [#1319], [#1363], [#1371], [#1376], [#1400], [#1401], [#1419], [#1418], [#1420], [#1421])。
 
 ## [0.17.0] - 2026-08-14 (+09:00)
 
@@ -1334,13 +1311,17 @@ Windows版ダウンローダーのビルドに失敗しています。
 [#849]: https://github.com/VOICEVOX/voicevox_core/pull/849
 [#850]: https://github.com/VOICEVOX/voicevox_core/pull/850
 [#851]: https://github.com/VOICEVOX/voicevox_core/pull/851
+[#854]: https://github.com/VOICEVOX/voicevox_core/pull/854
 [#856]: https://github.com/VOICEVOX/voicevox_core/pull/856
 [#860]: https://github.com/VOICEVOX/voicevox_core/pull/860
 [#861]: https://github.com/VOICEVOX/voicevox_core/pull/861
 [#862]: https://github.com/VOICEVOX/voicevox_core/pull/862
 [#863]: https://github.com/VOICEVOX/voicevox_core/pull/863
+[#864]: https://github.com/VOICEVOX/voicevox_core/pull/864
+[#867]: https://github.com/VOICEVOX/voicevox_core/pull/867
 [#868]: https://github.com/VOICEVOX/voicevox_core/pull/868
 [#876]: https://github.com/VOICEVOX/voicevox_core/pull/876
+[#879]: https://github.com/VOICEVOX/voicevox_core/pull/879
 [#881]: https://github.com/VOICEVOX/voicevox_core/pull/881
 [#882]: https://github.com/VOICEVOX/voicevox_core/pull/882
 [#884]: https://github.com/VOICEVOX/voicevox_core/pull/884
@@ -1394,6 +1375,7 @@ Windows版ダウンローダーのビルドに失敗しています。
 [#965]: https://github.com/VOICEVOX/voicevox_core/pull/965
 [#967]: https://github.com/VOICEVOX/voicevox_core/pull/967
 [#969]: https://github.com/VOICEVOX/voicevox_core/pull/969
+[#972]: https://github.com/VOICEVOX/voicevox_core/pull/972
 [#973]: https://github.com/VOICEVOX/voicevox_core/pull/973
 [#974]: https://github.com/VOICEVOX/voicevox_core/pull/974
 [#976]: https://github.com/VOICEVOX/voicevox_core/pull/976
@@ -1536,6 +1518,7 @@ Windows版ダウンローダーのビルドに失敗しています。
 [#1304]: https://github.com/VOICEVOX/voicevox_core/pull/1304
 [#1313]: https://github.com/VOICEVOX/voicevox_core/pull/1313
 [#1315]: https://github.com/VOICEVOX/voicevox_core/pull/1315
+[#1319]: https://github.com/VOICEVOX/voicevox_core/pull/1319
 [#1323]: https://github.com/VOICEVOX/voicevox_core/pull/1323
 [#1326]: https://github.com/VOICEVOX/voicevox_core/pull/1326
 [#1331]: https://github.com/VOICEVOX/voicevox_core/pull/1331
@@ -1547,6 +1530,7 @@ Windows版ダウンローダーのビルドに失敗しています。
 [#1362]: https://github.com/VOICEVOX/voicevox_core/pull/1362
 [#1363]: https://github.com/VOICEVOX/voicevox_core/pull/1363
 [#1371]: https://github.com/VOICEVOX/voicevox_core/pull/1371
+[#1376]: https://github.com/VOICEVOX/voicevox_core/pull/1376
 [#1381]: https://github.com/VOICEVOX/voicevox_core/pull/1381
 [#1384]: https://github.com/VOICEVOX/voicevox_core/pull/1384
 [#1385]: https://github.com/VOICEVOX/voicevox_core/pull/1385
@@ -1562,6 +1546,10 @@ Windows版ダウンローダーのビルドに失敗しています。
 [#1409]: https://github.com/VOICEVOX/voicevox_core/pull/1409
 [#1411]: https://github.com/VOICEVOX/voicevox_core/pull/1411
 [#1412]: https://github.com/VOICEVOX/voicevox_core/pull/1412
+[#1418]: https://github.com/VOICEVOX/voicevox_core/pull/1418
+[#1419]: https://github.com/VOICEVOX/voicevox_core/pull/1419
+[#1420]: https://github.com/VOICEVOX/voicevox_core/pull/1420
+[#1421]: https://github.com/VOICEVOX/voicevox_core/pull/1421
 
 [VOICEVOX/onnxruntime-builder#25]: https://github.com/VOICEVOX/onnxruntime-builder/pull/25
 

--- a/crates/voicevox_core/src/blocking.rs
+++ b/crates/voicevox_core/src/blocking.rs
@@ -8,9 +8,7 @@ pub use crate::{
         open_jtalk::blocking::OpenJtalk, text_analyzer::blocking::TextAnalyzer,
         user_dict::dict::blocking::UserDict,
     },
-    synthesizer::blocking::{
-        AudioFeature, Synthesizer,
-    },
+    synthesizer::blocking::{AudioFeature, Synthesizer},
 };
 
 pub mod onnxruntime {

--- a/crates/voicevox_core/src/blocking.rs
+++ b/crates/voicevox_core/src/blocking.rs
@@ -8,13 +8,10 @@ pub use crate::{
         open_jtalk::blocking::OpenJtalk, text_analyzer::blocking::TextAnalyzer,
         user_dict::dict::blocking::UserDict,
     },
-    synthesizer::blocking::Synthesizer,
+    synthesizer::blocking::{
+        AudioFeature, Synthesizer,
+    },
 };
-
-// TODO: 後で復活させる
-// https://github.com/VOICEVOX/voicevox_core/issues/970
-#[doc(hidden)]
-pub use crate::synthesizer::blocking::AudioFeature as __AudioFeature;
 
 pub mod onnxruntime {
     #[cfg(feature = "load-onnxruntime")]
@@ -27,7 +24,5 @@ pub mod synthesizer {
         Builder, FrameSynthesis, LoadVoiceModel, Synthesis, Tts, TtsFromKana,
     };
 
-    // TODO: 後で復活させる
-    // https://github.com/VOICEVOX/voicevox_core/issues/970
-    //pub use crate::synthesizer::blocking::PrecomputeRender;
+    pub use crate::synthesizer::blocking::CreateAudioFeature;
 }

--- a/crates/voicevox_core/src/blocking.rs
+++ b/crates/voicevox_core/src/blocking.rs
@@ -19,8 +19,6 @@ pub mod onnxruntime {
 
 pub mod synthesizer {
     pub use crate::synthesizer::blocking::{
-        Builder, FrameSynthesis, LoadVoiceModel, Synthesis, Tts, TtsFromKana,
+        Builder, CreateAudioFeature, FrameSynthesis, LoadVoiceModel, Synthesis, Tts, TtsFromKana,
     };
-
-    pub use crate::synthesizer::blocking::CreateAudioFeature;
 }

--- a/crates/voicevox_core/src/engine/audio_file.rs
+++ b/crates/voicevox_core/src/engine/audio_file.rs
@@ -72,9 +72,6 @@ impl FrameAudioQuery {
 }
 
 /// 16bit PCMにヘッダを付加しWAVフォーマットのバイナリを生成する。
-// TODO: 後で復活させる
-// https://github.com/VOICEVOX/voicevox_core/issues/970
-#[doc(hidden)]
 pub fn wav_from_s16le(pcm: &[u8], sampling_rate: u32, is_stereo: bool) -> Vec<u8> {
     let num_channels: u16 = if is_stereo { 2 } else { 1 };
     let bit_depth: u16 = 16;

--- a/crates/voicevox_core/src/lib.rs
+++ b/crates/voicevox_core/src/lib.rs
@@ -487,14 +487,10 @@ pub use self::{
                 UserDictWord, UserDictWordBuilder, UserDictWordPriority, UserDictWordType,
             },
         },
+        wav_from_s16le,
     },
     error::{Error, ErrorKind},
     result::Result,
     synthesizer::AccelerationMode,
     version::VERSION,
 };
-
-// TODO: 後で復活させる
-// https://github.com/VOICEVOX/voicevox_core/issues/970
-#[doc(hidden)]
-pub use self::engine::wav_from_s16le as __wav_from_s16le;

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -211,9 +211,6 @@ fn trim_margin_from_wave(wave_with_margin: ndarray::Array1<f32>) -> ndarray::Arr
 }
 
 /// 音声の中間表現。
-// TODO: 後で復活させる
-// https://github.com/VOICEVOX/voicevox_core/issues/970
-#[doc(hidden)]
 #[derive(Clone, PartialEq, derive_more::Debug)]
 pub struct AudioFeature {
     /// (フレーム数, 特徴数)の形を持つ音声特徴量。
@@ -448,7 +445,7 @@ trait AsInner {
         self.status().metas()
     }
 
-    async fn precompute_render(
+    async fn create_audio_feature(
         &self,
         audio_query: &AudioQuery,
         style_id: StyleId,
@@ -522,7 +519,7 @@ trait AsInner {
             ));
         }
         let audio = self
-            .precompute_render(audio_query, style_id, options)
+            .create_audio_feature(audio_query, style_id, options)
             .await?;
         let pcm = self.render(&audio, 0..audio.frame_length()).await?;
         Ok(wav_from_s16le(
@@ -1753,15 +1750,13 @@ pub(crate) mod blocking {
         }
 
         /// AudioQueryから音声合成用の中間表現を生成する。
-        // TODO: 後で復活させる
-        // https://github.com/VOICEVOX/voicevox_core/issues/970
         #[doc(hidden)]
-        pub fn __precompute_render<'a>(
+        pub fn create_audio_feature<'a>(
             &'a self,
             audio_query: &'a AudioQuery,
             style_id: StyleId,
-        ) -> PrecomputeRender<'a> {
-            PrecomputeRender {
+        ) -> CreateAudioFeature<'a> {
+            CreateAudioFeature {
                 synthesizer: self.0.without_text_analyzer(),
                 audio_query,
                 style_id,
@@ -1770,10 +1765,8 @@ pub(crate) mod blocking {
         }
 
         /// 中間表現から16bit PCMで音声波形を生成する。
-        // TODO: 後で復活させる
-        // https://github.com/VOICEVOX/voicevox_core/issues/970
         #[doc(hidden)]
-        pub fn __render(
+        pub fn render(
             &self,
             audio: &AudioFeature,
             range: impl Into<std::ops::Range<usize>>,
@@ -2506,14 +2499,14 @@ pub(crate) mod blocking {
 
     #[must_use = "this is a builder. it does nothing until `perform`ed"]
     #[derive(Debug)]
-    pub struct PrecomputeRender<'a> {
+    pub struct CreateAudioFeature<'a> {
         synthesizer: InnerRefWithoutTextAnalyzer<'a, SingleTasked>,
         audio_query: &'a AudioQuery,
         style_id: StyleId,
         options: SynthesisOptions<SingleTasked>,
     }
 
-    impl PrecomputeRender<'_> {
+    impl CreateAudioFeature<'_> {
         pub fn enable_interrogative_upspeak(mut self, enable_interrogative_upspeak: bool) -> Self {
             self.options.enable_interrogative_upspeak = enable_interrogative_upspeak;
             self
@@ -2522,7 +2515,7 @@ pub(crate) mod blocking {
         /// 実行する。
         pub fn perform(self) -> crate::Result<AudioFeature> {
             self.synthesizer
-                .precompute_render(self.audio_query, self.style_id, &self.options)
+                .create_audio_feature(self.audio_query, self.style_id, &self.options)
                 .block_on()
         }
     }

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -1750,7 +1750,6 @@ pub(crate) mod blocking {
         }
 
         /// AudioQueryから音声合成用の中間表現を生成する。
-        #[doc(hidden)]
         pub fn create_audio_feature<'a>(
             &'a self,
             audio_query: &'a AudioQuery,
@@ -1765,7 +1764,6 @@ pub(crate) mod blocking {
         }
 
         /// 中間表現から16bit PCMで音声波形を生成する。
-        #[doc(hidden)]
         pub fn render(
             &self,
             audio: &AudioFeature,

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
@@ -428,7 +428,7 @@ class Synthesizer:
             スタイルID。
         """
         ...
-    def __precompute_render(
+    def __create_audio_feature(
         self,
         audio_query: AudioQuery,
         style_id: StyleId | int,

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -904,7 +904,7 @@ mod blocking {
             enable_interrogative_upspeak =
                 voicevox_core::__internal::interop::DEFAULT_ENABLE_INTERROGATIVE_UPSPEAK,
         ))]
-        fn _Synthesizer__precompute_render(
+        fn _Synthesizer__create_audio_feature(
             &self,
             #[pyo3(from_py_with = crate::convert::from_audio_query)] audio_query: AudioQuery,
             style_id: u32,
@@ -914,7 +914,7 @@ mod blocking {
             let audio = self
                 .synthesizer
                 .read()?
-                .__precompute_render(&audio_query, StyleId::new(style_id))
+                .__create_audio_feature(&audio_query, StyleId::new(style_id))
                 .enable_interrogative_upspeak(enable_interrogative_upspeak)
                 .perform()
                 .into_py_result(py)?;

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -359,7 +359,7 @@ fn _to_zenkaku(text: &str) -> PyResult<String> {
 
 #[pyfunction]
 fn wav_from_s16le(pcm: &[u8], sampling_rate: u32, is_stereo: bool) -> Vec<u8> {
-    voicevox_core::__wav_from_s16le(pcm, sampling_rate, is_stereo)
+    voicevox_core::wav_from_s16le(pcm, sampling_rate, is_stereo)
 }
 
 #[pyfunction]
@@ -644,7 +644,7 @@ mod blocking {
     #[pyclass(frozen, eq)]
     #[derive(PartialEq)]
     pub(crate) struct AudioFeature {
-        audio: voicevox_core::blocking::__AudioFeature,
+        audio: voicevox_core::blocking::AudioFeature,
     }
 
     #[pymethods]
@@ -914,7 +914,7 @@ mod blocking {
             let audio = self
                 .synthesizer
                 .read()?
-                .__create_audio_feature(&audio_query, StyleId::new(style_id))
+                .create_audio_feature(&audio_query, StyleId::new(style_id))
                 .enable_interrogative_upspeak(enable_interrogative_upspeak)
                 .perform()
                 .into_py_result(py)?;
@@ -944,7 +944,7 @@ mod blocking {
             }
             self.synthesizer
                 .read()?
-                .__render(&audio.audio, start..stop)
+                .render(&audio.audio, start..stop)
                 .into_py_result(py)
         }
 


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
PR #972 (issue #970) で封印したストリーミング処理APIを復活させる。
ひとまずRust版のみを復活

名称は `create_audio_feature` と `render` とする


## 関連 Issue

プロジェクト全体（Rust, Python, Java, C) のAPI提供方針は #1364
