### PR TITLE
feat(rust,python): `AudioFeature`を`blocking`モジュールの外に

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### Added
 
-- \[Rust\] `Synthesizer::create_audio_feature`と`Synthesizer::render`が追加されます ([#851], [#854], [#864], [#867], [#879], [#918], [#972], [#1319], [#1363], [#1371], [#1376], [#1400], [#1401], [#1419], [#1418], [#1420], [#1421])。
+- \[Rust\] `Synthesizer::create_audio_feature`と`Synthesizer::render`が追加されます ([#851], [#854], [#864], [#867], [#879], [#918], [#972], [#1319], [#1363], [#1371], [#1376], [#1400], [#1401], [#1419], [#1418], [#1420], [#1421], [#1423])。
 
 ## [0.17.0] - 2026-08-14 (+09:00)
 
@@ -1550,6 +1550,7 @@ Windows版ダウンローダーのビルドに失敗しています。
 [#1419]: https://github.com/VOICEVOX/voicevox_core/pull/1419
 [#1420]: https://github.com/VOICEVOX/voicevox_core/pull/1420
 [#1421]: https://github.com/VOICEVOX/voicevox_core/pull/1421
+[#1423]: https://github.com/VOICEVOX/voicevox_core/pull/1423
 
 [VOICEVOX/onnxruntime-builder#25]: https://github.com/VOICEVOX/onnxruntime-builder/pull/25
 

--- a/crates/voicevox_core/src/blocking.rs
+++ b/crates/voicevox_core/src/blocking.rs
@@ -8,7 +8,7 @@ pub use crate::{
         open_jtalk::blocking::OpenJtalk, text_analyzer::blocking::TextAnalyzer,
         user_dict::dict::blocking::UserDict,
     },
-    synthesizer::blocking::{AudioFeature, Synthesizer},
+    synthesizer::blocking::Synthesizer,
 };
 
 pub mod onnxruntime {

--- a/crates/voicevox_core/src/lib.rs
+++ b/crates/voicevox_core/src/lib.rs
@@ -491,6 +491,6 @@ pub use self::{
     },
     error::{Error, ErrorKind},
     result::Result,
-    synthesizer::AccelerationMode,
+    synthesizer::{AccelerationMode, AudioFeature},
     version::VERSION,
 };

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -1645,11 +1645,9 @@ pub(crate) mod blocking {
     };
 
     use super::{
-        AccelerationMode, AsInner as _, AssumeSingleTasked, InitializeOptions, Inner,
+        AccelerationMode, AsInner as _, AssumeSingleTasked, AudioFeature, InitializeOptions, Inner,
         InnerRefWithoutTextAnalyzer, LoadVoiceModelOptions, SynthesisOptions, TtsOptions,
     };
-
-    pub use super::AudioFeature;
 
     /// 音声シンセサイザ。
     #[cfg_attr(doc, doc(alias = "VoicevoxSynthesizer"))]

--- a/crates/voicevox_core_python_api/python/voicevox_core/__init__.py
+++ b/crates/voicevox_core_python_api/python/voicevox_core/__init__.py
@@ -1,6 +1,6 @@
 """無料で使える中品質なテキスト読み上げソフトウェア、VOICEVOXのコア。"""
 
-# TODO: `wav_from_s16le`を復活させる
+# TODO: `AudioFeature`と`wav_from_s16le`を復活させる
 # https://github.com/VOICEVOX/voicevox_core/issues/970
 
 from ._python import (  # noqa: F401

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/__init__.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/__init__.pyi
@@ -14,6 +14,14 @@ if TYPE_CHECKING:
 
 __version__: str
 
+class AudioFeature:
+    @property
+    def frame_length(self) -> int: ...
+    @property
+    def frame_rate(self) -> float: ...
+    def __repr__(self) -> str: ...
+    def __eq__(self, other: object) -> bool: ...
+
 class NotLoadedOpenjtalkDictError(Exception):
     """open_jtalk辞書ファイルが読み込まれていない。"""
 

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
         UserDictWord,
         VoiceModelId,
     )
+    from voicevox_core._rust import AudioFeature
 
 class VoiceModelFile:
     """
@@ -180,14 +181,6 @@ class OpenJtalk:
             日本語のテキスト。
         """
         ...
-
-class AudioFeature:
-    @property
-    def frame_length(self) -> int: ...
-    @property
-    def frame_rate(self) -> float: ...
-    def __repr__(self) -> str: ...
-    def __eq__(self, other: object) -> bool: ...
 
 class Synthesizer:
     """

--- a/crates/voicevox_core_python_api/python/voicevox_core/blocking.py
+++ b/crates/voicevox_core_python_api/python/voicevox_core/blocking.py
@@ -1,8 +1,5 @@
 """ブロッキング版API。"""
 
-# TODO: `AudioFeature`を復活させる
-# https://github.com/VOICEVOX/voicevox_core/issues/970
-
 # pyright: reportMissingModuleSource=false
 from ._rust.blocking import (
     Onnxruntime,

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -14,7 +14,7 @@ use macros::pyproject_project_version;
 use pyo3::{
     Bound, Py, PyAny, PyResult, PyTypeInfo, Python, create_exception,
     exceptions::{PyException, PyKeyError, PyValueError},
-    pyclass, pyfunction, pymodule,
+    pyclass, pyfunction, pymethods, pymodule,
     types::{PyAnyMethods as _, PyList, PyModule, PyModuleMethods as _, PyString},
     wrap_pyfunction,
 };
@@ -30,6 +30,7 @@ fn rust(py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResult<()> {
 
     module.add("__version__", pyproject_project_version!())?;
     module.add_class::<_ReservedFields>()?;
+    module.add_class::<AudioFeature>()?;
     module.add_wrapped(wrap_pyfunction!(_audio_query_from_accent_phrases))?;
     module.add_wrapped(wrap_pyfunction!(_audio_query_from_json))?;
     module.add_wrapped(wrap_pyfunction!(_audio_query_to_json))?;
@@ -53,7 +54,6 @@ fn rust(py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResult<()> {
     blocking_module.add_class::<self::blocking::OpenJtalk>()?;
     blocking_module.add_class::<self::blocking::VoiceModelFile>()?;
     blocking_module.add_class::<self::blocking::UserDict>()?;
-    blocking_module.add_class::<self::blocking::AudioFeature>()?;
     module.add_and_register_submodule(blocking_module)?;
 
     let asyncio_module = PyModule::new(py, "voicevox_core._rust.asyncio")?;
@@ -371,6 +371,34 @@ fn ensure_compatible(
     voicevox_core::ensure_compatible(&score, &frame_audio_query).into_py_result(py)
 }
 
+#[pyclass(frozen, eq)]
+#[derive(PartialEq)]
+struct AudioFeature {
+    audio: voicevox_core::AudioFeature,
+}
+
+#[pymethods]
+impl AudioFeature {
+    #[getter]
+    fn frame_length(&self) -> usize {
+        self.audio.frame_length()
+    }
+
+    #[getter]
+    fn frame_rate(&self) -> f64 {
+        self.audio.frame_rate
+    }
+
+    fn __repr__(&self, py: Python<'_>) -> String {
+        let Self { audio: rust_api } = self;
+        let rust_api = PyString::new(py, &format!("{rust_api:?}"));
+        format!(
+            "<voicevox_core.{NAME} rust_api=<{rust_api:?}>>",
+            NAME = Self::NAME,
+        )
+    }
+}
+
 mod blocking {
     use std::{ffi::OsString, path::PathBuf, sync::Arc};
 
@@ -391,7 +419,7 @@ mod blocking {
     };
 
     use crate::{
-        Closable, SingleTasked, VoiceModelFilePyFields,
+        AudioFeature, Closable, SingleTasked, VoiceModelFilePyFields,
         convert::{ToDataclass, VoicevoxCoreResultExt as _},
     };
 
@@ -638,34 +666,6 @@ mod blocking {
     impl voicevox_core::blocking::TextAnalyzer for OwnedOpenJtalk {
         fn analyze(&self, text: &str) -> anyhow::Result<Vec<AccentPhrase>> {
             self.0.get().open_jtalk.analyze(text)
-        }
-    }
-
-    #[pyclass(frozen, eq)]
-    #[derive(PartialEq)]
-    pub(crate) struct AudioFeature {
-        audio: voicevox_core::blocking::AudioFeature,
-    }
-
-    #[pymethods]
-    impl AudioFeature {
-        #[getter]
-        fn frame_length(&self) -> usize {
-            self.audio.frame_length()
-        }
-
-        #[getter]
-        fn frame_rate(&self) -> f64 {
-            self.audio.frame_rate
-        }
-
-        fn __repr__(&self, py: Python<'_>) -> String {
-            let Self { audio: rust_api } = self;
-            let rust_api = PyString::new(py, &format!("{rust_api:?}"));
-            format!(
-                "<voicevox_core.blocking.{NAME} rust_api=<{rust_api:?}>>",
-                NAME = Self::NAME,
-            )
         }
     }
 


### PR DESCRIPTION
## 内容

`AudioFeature`は同期版と非同期版とで分ける必要はないため。

## 関連 Issue

cf. #1364
