### PR TITLE
chore(c): cbindgenの`parse_deps`をやめる

### DIFF
--- a/crates/voicevox_core/src/lib.rs
+++ b/crates/voicevox_core/src/lib.rs
@@ -442,7 +442,6 @@ mod asyncs;
 mod collections;
 mod convert;
 mod core;
-/// cbindgen:ignore
 mod engine;
 mod error;
 mod future;

--- a/crates/voicevox_core_c_api/cbindgen.toml
+++ b/crates/voicevox_core_c_api/cbindgen.toml
@@ -110,12 +110,6 @@ args = "vertical"
 [enum]
 rename_variants = "ScreamingSnakeCase"
 
-# Options for how your Rust library should be parsed
-
-[parse]
-parse_deps = true
-include = ["voicevox_core"]
-
 [defines]
 "feature = load-onnxruntime" = "VOICEVOX_LOAD_ONNXRUNTIME"
 "feature = link-onnxruntime" = "VOICEVOX_LINK_ONNXRUNTIME"


### PR DESCRIPTION
## 内容

とっくの昔に役割を終えているはずなので外す。

今このタイミングでやろうと思ったのは、#1422 をやろうとしたときに牙を剥いてきて勝手にこんな`#define`を生成してきたため。

```c
/**
 * フレームレート。全体の秒数は`frame_length() / FRAME_RATE`で表せる。
 */
#define AudioFeature_FRAME_RATE 93.75
```
