### PR TITLE
refactor(c): `Option<T>` → `enum MaybeDeleted<T>`

### DIFF
--- a/crates/voicevox_core_c_api/src/c_impls.rs
+++ b/crates/voicevox_core_c_api/src/c_impls.rs
@@ -17,7 +17,7 @@ use crate::{
     OpenJtalkRc, VoicevoxInitializeOptions, VoicevoxOnnxruntime, VoicevoxSynthesizer,
     VoicevoxUserDict, VoicevoxVoiceModelFile,
     helpers::CApiResult,
-    object::{CApiObject, CApiObjectPtrExt as _},
+    object::{CApiObject, CApiObjectPtrExt as _, MaybeDeleted},
 };
 
 // FIXME: 中身(Rust API)を直接操作するかラッパーメソッド越しにするのかが混在していて、一貫性を
@@ -169,11 +169,11 @@ impl CApiObject for H {
     }
 
     fn bodies() -> &'static std::sync::Mutex<
-        HashMap<NonZero<usize>, Arc<parking_lot::RwLock<Option<Self::RustApiObject>>>>,
+        HashMap<NonZero<usize>, Arc<parking_lot::RwLock<MaybeDeleted<Self::RustApiObject>>>>,
     > {
         #[expect(clippy::type_complexity, reason = "`CApiObject::bodies`と同様")]
         static BODIES: LazyLock<
-            std::sync::Mutex<HashMap<NonZero<usize>, Arc<parking_lot::RwLock<Option<B>>>>>,
+            std::sync::Mutex<HashMap<NonZero<usize>, Arc<parking_lot::RwLock<MaybeDeleted<B>>>>>,
         > = LazyLock::new(Default::default);
 
         &BODIES

--- a/crates/voicevox_core_c_api/src/object.rs
+++ b/crates/voicevox_core_c_api/src/object.rs
@@ -51,7 +51,7 @@ pub(crate) trait CApiObject: Default + Debug + 'static {
             NonZero<usize>, // `heads`の要素へのポインタのアドレス
             Arc<
                 parking_lot::RwLock<
-                    Option<Self::RustApiObject>, // `RwLock`をdropする直前まで`Some`
+                    MaybeDeleted<Self::RustApiObject>, // `RwLock`をdropする直前まで`Some`
                 >,
             >,
         >,
@@ -65,7 +65,7 @@ pub(crate) trait CApiObject: Default + Debug + 'static {
             NonNull::from(&Self::heads()[i])
         };
         Self::lock_known_addrs().insert(this.addr());
-        let body = parking_lot::RwLock::new(body.into()).into();
+        let body = parking_lot::RwLock::new(MaybeDeleted::Alive(body)).into();
         Self::lock_bodies().insert(this.addr(), body);
         this
     }
@@ -158,8 +158,33 @@ impl<T: CApiObject> T {
     }
 
     fn lock_bodies() -> impl DerefMut<
-        Target = HashMap<NonZero<usize>, Arc<parking_lot::RwLock<Option<Self::RustApiObject>>>>,
+        Target = HashMap<
+            NonZero<usize>,
+            Arc<parking_lot::RwLock<MaybeDeleted<Self::RustApiObject>>>,
+        >,
     > {
         Self::bodies().lock().unwrap_or_else(|e| panic!("{e}"))
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum MaybeDeleted<T> {
+    Alive(T),
+    Deleted,
+}
+
+impl<T> MaybeDeleted<T> {
+    fn take(&mut self) -> Option<T> {
+        match mem::replace(self, Self::Deleted) {
+            MaybeDeleted::Alive(x) => Some(x),
+            MaybeDeleted::Deleted => None,
+        }
+    }
+
+    fn as_ref(&self) -> Option<&T> {
+        match self {
+            MaybeDeleted::Alive(x) => Some(x),
+            MaybeDeleted::Deleted => None,
+        }
     }
 }

--- a/crates/voicevox_core_c_api/src/object.rs
+++ b/crates/voicevox_core_c_api/src/object.rs
@@ -51,7 +51,7 @@ pub(crate) trait CApiObject: Default + Debug + 'static {
             NonZero<usize>, // `heads`の要素へのポインタのアドレス
             Arc<
                 parking_lot::RwLock<
-                    MaybeDeleted<Self::RustApiObject>, // `RwLock`をdropする直前まで`Some`
+                    MaybeDeleted<Self::RustApiObject>, // `RwLock`をdropする直前まで`Alive`
                 >,
             >,
         >,


### PR DESCRIPTION
## 内容

Python APIとJava APIの実装では既に`enum MaybeClosed<T>`という形にしてるので、C APIでも同じようにする。

#1364 により`Arc<parking_lot::RwLock<_>>`を丸ごと取り回すことになるような気がしているため、先んじてコードを明確にするのが目的。
