### PR TITLE
feat(rust,python): `render`に対する不正な範囲指定のエラーを改善

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### Added
 
-- \[Rust\] `Synthesizer::create_audio_feature`と`Synthesizer::render`が追加されます ([#851], [#854], [#864], [#867], [#879], [#918], [#972], [#1319], [#1363], [#1371], [#1376], [#1400], [#1401], [#1419], [#1418], [#1420], [#1421], [#1423], [#1422])。
+- \[Rust\] `Synthesizer::create_audio_feature`と`Synthesizer::render`が追加されます ([#851], [#854], [#864], [#867], [#879], [#918], [#972], [#1319], [#1363], [#1371], [#1376], [#1400], [#1401], [#1419], [#1418], [#1420], [#1421], [#1423], [#1422], [#1426])。
 
 ## [0.17.0] - 2026-08-14 (+09:00)
 
@@ -1552,6 +1552,7 @@ Windows版ダウンローダーのビルドに失敗しています。
 [#1421]: https://github.com/VOICEVOX/voicevox_core/pull/1421
 [#1422]: https://github.com/VOICEVOX/voicevox_core/pull/1422
 [#1423]: https://github.com/VOICEVOX/voicevox_core/pull/1423
+[#1426]: https://github.com/VOICEVOX/voicevox_core/pull/1426
 
 [VOICEVOX/onnxruntime-builder#25]: https://github.com/VOICEVOX/onnxruntime-builder/pull/25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5171,6 +5171,7 @@ dependencies = [
  "heck 0.5.0",
  "log",
  "num-bigint",
+ "num-traits",
  "pyo3",
  "pyo3-log",
  "ref-cast",

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -192,16 +192,18 @@ fn crop_with_margin(
     audio: &AudioFeature,
     range: std::ops::Range<usize>,
 ) -> ndarray::ArrayView2<'_, f32> {
-    if range.start > audio.frame_length() || range.end > audio.frame_length() {
-        panic!(
-            "{range:?} is out of range for audio feature of length {frame_length}",
-            frame_length = audio.frame_length(),
-        );
+    let frame_length = audio.frame_length();
+    let std::ops::Range { start, end } = range;
+    if start > frame_length {
+        panic!("range start index {start} out of range for audio feature of length {frame_length}");
     }
-    if range.start > range.end {
-        panic!("{range:?} is invalid because start > end",);
+    if end > frame_length {
+        panic!("range end index {end} out of range for audio feature of length {frame_length}");
     }
-    let range = range.start..range.end + 2 * MARGIN;
+    if start > end {
+        panic!("range starts at {start} but ends at {end}");
+    }
+    let range = start..end + 2 * MARGIN;
     audio.internal_state.slice(ndarray::s![range, ..])
 }
 /// 追加した安全マージンを生成音声から取り除く

--- a/crates/voicevox_core_python_api/Cargo.toml
+++ b/crates/voicevox_core_python_api/Cargo.toml
@@ -19,6 +19,7 @@ futures-lite.workspace = true
 heck.workspace = true
 log.workspace = true
 num-bigint.workspace = true
+num-traits.workspace = true
 pyo3 = { workspace = true, features = ["experimental-async", "abi3-py310", "extension-module", "num-bigint", "uuid"] }
 pyo3-log.workspace = true
 ref-cast.workspace = true

--- a/crates/voicevox_core_python_api/src/convert.rs
+++ b/crates/voicevox_core_python_api/src/convert.rs
@@ -84,14 +84,18 @@ fn from_audio_feature_range_index(
 ///
 /// # Motivation
 ///
-/// Pythonの`list`や`NDArray`であれば、どんな値であろうとスライスを拒否することはない。
+/// Rust APIの`render`に不適当な範囲を渡すとパニックするため、渡す前に対処する必要がある。その方法は
 ///
-/// ```text
-/// >>> list(range(10))[1 << 99999:1 << 999]  # OK!
-/// []
-/// ```
+/// 1. 範囲を補正してしまうか、
+/// 2. `ValueError`として拒否するか
 ///
-/// しかしVOICEVOXの`AudioFeature`では誤った範囲指定を拒否したいため、Rustと同じ基準で入力を弾きたい。
+/// の２つ。
+///
+/// `list`や`NDArray`にならうならば1.だが、例えば同じPythonでもPillowではデフォルト値で埋められるし、OpenCVはエラーになる。
+///
+/// そのためVOICEVOX COREとしても言語間で挙動を統一するメリットの方を取ることとする。
+///
+/// <https://github.com/VOICEVOX/voicevox_core/pull/867#discussion_r1831401779>
 pub(crate) fn error_for_audio_feature_range(
     frame_length: usize,
     start: usize,

--- a/crates/voicevox_core_python_api/src/convert.rs
+++ b/crates/voicevox_core_python_api/src/convert.rs
@@ -5,6 +5,7 @@ use derive_more::From;
 use easy_ext::ext;
 use heck::{ToLowerCamelCase as _, ToSnakeCase as _};
 use num_bigint::BigInt;
+use num_traits::Signed as _;
 use pyo3::{
     Bound, FromPyObject, IntoPyObject, PyAny, PyErr, PyResult, Python,
     exceptions::{PyException, PyValueError},
@@ -30,6 +31,69 @@ use crate::{
     ParseKanaError, ReadZipEntryError, RunModelError, SaveUserDictError, StyleAlreadyLoadedError,
     StyleNotFoundError, UseUserDictError, WordNotFoundError,
 };
+
+pub(crate) fn from_audio_feature_range_start(ob: &Bound<'_, PyAny>) -> PyResult<usize> {
+    from_audio_feature_range_index(ob, "start")
+}
+
+pub(crate) fn from_audio_feature_range_stop(ob: &Bound<'_, PyAny>) -> PyResult<usize> {
+    from_audio_feature_range_index(ob, "stop")
+}
+
+fn from_audio_feature_range_index(ob: &Bound<'_, PyAny>, name: &'static str) -> PyResult<usize> {
+    let index = &BigInt::extract(ob.as_borrowed())?;
+    if index.is_negative() {
+        return Err(PyValueError::new_err(format!(
+            "argument '{name}': must not be negative: {index} \
+             (note: instead, consider subtracting an offset from the 'AudioFeature.frame_length')",
+        )));
+    }
+    index.try_into().map_err(|_| {
+        PyValueError::new_err(format!(
+            "argument '{name}': cannot fit '{index}' into an index-sized integer \
+             (note: if you meant the end of the audio feature, consider using the \
+             'AudioFeature.frame_length')",
+        ))
+    })
+}
+
+/// Rustの`[_; frame_length]`に対して`start..stop`が不適当であるなら[`PyValueError`]を返す。
+///
+/// # Motivation
+///
+/// Pythonの`list`や`NDArray`であれば、どんな値であろうとスライスを拒否することはない。
+///
+/// ```text
+/// >>> list(range(10))[1 << 99999:1 << 999]  # OK!
+/// []
+/// ```
+///
+/// しかしVOICEVOXの`AudioFeature`では誤った範囲指定を拒否したいため、Rustと同じ基準で入力を弾きたい。
+pub(crate) fn error_for_audio_feature_range(
+    frame_length: usize,
+    start: usize,
+    stop: usize,
+) -> PyResult<()> {
+    if vec![(); frame_length].get(start..stop).is_none() {
+        return Err(PyValueError::new_err(format!(
+            "Audio feature of length {frame_length} cannot accept '{start}:{stop}' as a valid \
+             range: {reason}",
+            reason = if start > frame_length {
+                "'start' out of range for the audio feature \
+                 (note: if you meant the end of the audio feature, consider using the \
+                 'AudioFeature.frame_length')"
+            } else if stop > frame_length {
+                "'stop' out of range for the audio feature \
+                 (note: if you meant the end of the audio feature, consider using the \
+                 'AudioFeature.frame_length')"
+            } else {
+                assert!(start > stop);
+                "'start' exceeds 'stop'"
+            }
+        )));
+    }
+    Ok(())
+}
 
 pub(crate) fn from_acceleration_mode(ob: &Bound<'_, PyAny>) -> PyResult<AccelerationMode> {
     match ob.extract::<&str>()? {

--- a/crates/voicevox_core_python_api/src/convert.rs
+++ b/crates/voicevox_core_python_api/src/convert.rs
@@ -32,6 +32,75 @@ use crate::{
     StyleNotFoundError, UseUserDictError, WordNotFoundError,
 };
 
+pub(crate) fn from_acceleration_mode(ob: &Bound<'_, PyAny>) -> PyResult<AccelerationMode> {
+    match ob.extract::<&str>()? {
+        "AUTO" => Ok(AccelerationMode::Auto),
+        "CPU" => Ok(AccelerationMode::Cpu),
+        "GPU" => Ok(AccelerationMode::Gpu),
+        mode => Err(PyValueError::new_err(format!(
+            "`AccelerationMode` should be one of {{AUTO, CPU, GPU}}: {mode}",
+            mode = PyString::new(ob.py(), mode).repr()?,
+        ))),
+    }
+}
+
+pub(crate) fn from_on_existing_voice_model_id(
+    ob: &Bound<'_, PyAny>,
+) -> PyResult<OnExistingVoiceModelId> {
+    match ob.extract::<&str>()? {
+        "ERROR" => Ok(OnExistingVoiceModelId::Error),
+        "RELOAD" => Ok(OnExistingVoiceModelId::Reload),
+        "SKIP" => Ok(OnExistingVoiceModelId::Skip),
+        on_existing => Err(PyValueError::new_err(format!(
+            "`OnExistingVoiceModelId` should be one of {{ERROR, RELOAD, SKIP}}: {on_existing}",
+            on_existing = PyString::new(ob.py(), on_existing).repr()?,
+        ))),
+    }
+}
+
+pub(crate) fn from_audio_query<T: HasCamelCaseFields>(ob: &Bound<'_, PyAny>) -> PyResult<T> {
+    let py = ob.py();
+
+    let fields = dataclasses_asdict(ob)?
+        .iter()
+        .map(|(key, value)| {
+            let key = key.cast::<PyString>()?.to_str()?;
+            let key = if T::SNAKE_CASE_FIELDS.contains(&key) {
+                key.to_owned()
+            } else {
+                key.to_lower_camel_case()
+            };
+            Ok((key, value))
+        })
+        .collect::<PyResult<Vec<_>>>()?
+        .into_py_dict(py)?;
+
+    serde_pyobject::from_pyobject(fields).map_err(|serde_pyobject::Error(cause)| {
+        let err = InvalidQueryError::new_err(T::validation_error_description());
+        err.set_cause(py, Some(cause));
+        err
+    })
+}
+
+pub(crate) trait HasCamelCaseFields: Validate {
+    const SNAKE_CASE_FIELDS: &[&str];
+}
+
+impl HasCamelCaseFields for AudioQuery {
+    const SNAKE_CASE_FIELDS: &[&str] = &["accent_phrases"];
+}
+
+impl HasCamelCaseFields for FrameAudioQuery {
+    const SNAKE_CASE_FIELDS: &[&str] = &[];
+}
+
+pub(crate) fn from_accent_phrases(ob: &Bound<'_, PyAny>) -> PyResult<Vec<AccentPhrase>> {
+    ob.cast::<PyList>()?
+        .iter()
+        .map(|p| from_query_like_via_serde(&p))
+        .collect()
+}
+
 pub(crate) fn from_audio_feature_range_start(ob: &Bound<'_, PyAny>) -> PyResult<usize> {
     from_audio_feature_range_index(
         ob,
@@ -118,75 +187,6 @@ pub(crate) fn error_for_audio_feature_range(
         )));
     }
     Ok(())
-}
-
-pub(crate) fn from_acceleration_mode(ob: &Bound<'_, PyAny>) -> PyResult<AccelerationMode> {
-    match ob.extract::<&str>()? {
-        "AUTO" => Ok(AccelerationMode::Auto),
-        "CPU" => Ok(AccelerationMode::Cpu),
-        "GPU" => Ok(AccelerationMode::Gpu),
-        mode => Err(PyValueError::new_err(format!(
-            "`AccelerationMode` should be one of {{AUTO, CPU, GPU}}: {mode}",
-            mode = PyString::new(ob.py(), mode).repr()?,
-        ))),
-    }
-}
-
-pub(crate) fn from_on_existing_voice_model_id(
-    ob: &Bound<'_, PyAny>,
-) -> PyResult<OnExistingVoiceModelId> {
-    match ob.extract::<&str>()? {
-        "ERROR" => Ok(OnExistingVoiceModelId::Error),
-        "RELOAD" => Ok(OnExistingVoiceModelId::Reload),
-        "SKIP" => Ok(OnExistingVoiceModelId::Skip),
-        on_existing => Err(PyValueError::new_err(format!(
-            "`OnExistingVoiceModelId` should be one of {{ERROR, RELOAD, SKIP}}: {on_existing}",
-            on_existing = PyString::new(ob.py(), on_existing).repr()?,
-        ))),
-    }
-}
-
-pub(crate) fn from_audio_query<T: HasCamelCaseFields>(ob: &Bound<'_, PyAny>) -> PyResult<T> {
-    let py = ob.py();
-
-    let fields = dataclasses_asdict(ob)?
-        .iter()
-        .map(|(key, value)| {
-            let key = key.cast::<PyString>()?.to_str()?;
-            let key = if T::SNAKE_CASE_FIELDS.contains(&key) {
-                key.to_owned()
-            } else {
-                key.to_lower_camel_case()
-            };
-            Ok((key, value))
-        })
-        .collect::<PyResult<Vec<_>>>()?
-        .into_py_dict(py)?;
-
-    serde_pyobject::from_pyobject(fields).map_err(|serde_pyobject::Error(cause)| {
-        let err = InvalidQueryError::new_err(T::validation_error_description());
-        err.set_cause(py, Some(cause));
-        err
-    })
-}
-
-pub(crate) trait HasCamelCaseFields: Validate {
-    const SNAKE_CASE_FIELDS: &[&str];
-}
-
-impl HasCamelCaseFields for AudioQuery {
-    const SNAKE_CASE_FIELDS: &[&str] = &["accent_phrases"];
-}
-
-impl HasCamelCaseFields for FrameAudioQuery {
-    const SNAKE_CASE_FIELDS: &[&str] = &[];
-}
-
-pub(crate) fn from_accent_phrases(ob: &Bound<'_, PyAny>) -> PyResult<Vec<AccentPhrase>> {
-    ob.cast::<PyList>()?
-        .iter()
-        .map(|p| from_query_like_via_serde(&p))
-        .collect()
 }
 
 pub(crate) fn from_utf8_path(ob: &Bound<'_, PyAny>) -> PyResult<Utf8PathBuf> {

--- a/crates/voicevox_core_python_api/src/convert.rs
+++ b/crates/voicevox_core_python_api/src/convert.rs
@@ -33,28 +33,51 @@ use crate::{
 };
 
 pub(crate) fn from_audio_feature_range_start(ob: &Bound<'_, PyAny>) -> PyResult<usize> {
-    from_audio_feature_range_index(ob, "start")
+    from_audio_feature_range_index(
+        ob,
+        |index| {
+            format!(
+                "argument 'start': must not be negative: {index} \
+                 (note: instead, consider subtracting an offset from the \
+                 'AudioFeature.frame_length')",
+            )
+        },
+        |index| format!("argument 'start': cannot fit '{index}' into an index-sized integer"),
+    )
 }
 
 pub(crate) fn from_audio_feature_range_stop(ob: &Bound<'_, PyAny>) -> PyResult<usize> {
-    from_audio_feature_range_index(ob, "stop")
+    from_audio_feature_range_index(
+        ob,
+        |index| {
+            format!(
+                "argument 'stop': must not be negative: {index} \
+                 (note: instead, consider subtracting an offset from the \
+                 'AudioFeature.frame_length')",
+            )
+        },
+        |index| {
+            format!(
+                "argument 'stop': cannot fit '{index}' into an index-sized integer \
+                 (note: if you meant the end of the audio feature, consider using the \
+                 'AudioFeature.frame_length')",
+            )
+        },
+    )
 }
 
-fn from_audio_feature_range_index(ob: &Bound<'_, PyAny>, name: &'static str) -> PyResult<usize> {
+fn from_audio_feature_range_index(
+    ob: &Bound<'_, PyAny>,
+    error_for_negative: fn(&BigInt) -> String,
+    error_for_too_large: fn(&BigInt) -> String,
+) -> PyResult<usize> {
     let index = &BigInt::extract(ob.as_borrowed())?;
     if index.is_negative() {
-        return Err(PyValueError::new_err(format!(
-            "argument '{name}': must not be negative: {index} \
-             (note: instead, consider subtracting an offset from the 'AudioFeature.frame_length')",
-        )));
+        return Err(PyValueError::new_err(error_for_negative(index)));
     }
-    index.try_into().map_err(|_| {
-        PyValueError::new_err(format!(
-            "argument '{name}': cannot fit '{index}' into an index-sized integer \
-             (note: if you meant the end of the audio feature, consider using the \
-             'AudioFeature.frame_length')",
-        ))
-    })
+    index
+        .try_into()
+        .map_err(|_| PyValueError::new_err(error_for_too_large(index)))
 }
 
 /// Rustの`[_; frame_length]`に対して`start..stop`が不適当であるなら[`PyValueError`]を返す。
@@ -79,9 +102,7 @@ pub(crate) fn error_for_audio_feature_range(
             "Audio feature of length {frame_length} cannot accept '{start}:{stop}' as a valid \
              range: {reason}",
             reason = if start > frame_length {
-                "'start' out of range for the audio feature \
-                 (note: if you meant the end of the audio feature, consider using the \
-                 'AudioFeature.frame_length')"
+                "'start' out of range for the audio feature"
             } else if stop > frame_length {
                 "'stop' out of range for the audio feature \
                  (note: if you meant the end of the audio feature, consider using the \

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -403,7 +403,7 @@ mod blocking {
     use camino::Utf8PathBuf;
     use pyo3::{
         Bound, IntoPyObject as _, Py, PyAny, PyRef, PyResult, PyTypeInfo as _, Python,
-        exceptions::{PyIndexError, PyTypeError, PyValueError},
+        exceptions::PyTypeError,
         pyclass, pymethods,
         sync::PyOnceLock,
         types::{IntoPyDict as _, PyAnyMethods as _, PyDict, PyList, PyString, PyTuple, PyType},
@@ -925,21 +925,11 @@ mod blocking {
         fn _Synthesizer__render(
             &self,
             audio: &AudioFeature,
-            start: usize,
-            stop: usize,
+            #[pyo3(from_py_with = crate::convert::from_audio_feature_range_start)] start: usize,
+            #[pyo3(from_py_with = crate::convert::from_audio_feature_range_stop)] stop: usize,
             py: Python<'_>,
         ) -> PyResult<Vec<u8>> {
-            if start > audio.audio.frame_length() || stop > audio.audio.frame_length() {
-                return Err(PyIndexError::new_err(format!(
-                    "({start}, {stop}) is out of range for audio feature of length {len}",
-                    len = audio.audio.frame_length(),
-                )));
-            }
-            if start > stop {
-                return Err(PyValueError::new_err(format!(
-                    "({start}, {stop}) is invalid range because start > end",
-                )));
-            }
+            crate::convert::error_for_audio_feature_range(audio.audio.frame_length(), start, stop)?;
             self.synthesizer
                 .read()?
                 .render(&audio.audio, start..stop)

--- a/docs/guide/dev/api-design.md
+++ b/docs/guide/dev/api-design.md
@@ -20,3 +20,4 @@ VOICEVOX CORE の主要機能は Rust で実装されることを前提として
 * `Synthesizer::render`は`range: std::ops::Range<usize>`を引数に取っています。`Range<usize>`にあたる型が標準で存在し、かつそれが配列の範囲指定として用いられるようなものであれば、それを使うべきです。
     * ただし例えばPythonでは、`slice`を引数に取るのは慣習にそぐわないため`start: int, stop: int`のようにすべきです。
     * もし`Range<usize>`にあたる型が標準で無く、かつRustの"start"/"end"やPythonの"start"/"stop"にあたる明確な言葉が無いのであれば、誤解が生じないよう"end_exclusive"のように命名するべきです。
+    * Rustの`SliceIndex`基準で不正な範囲については、Python APIであっても拒否するべきです。Pythonの`list`や`NDArray`を基準にするなら拒否するべきではありませんが、例えばOpenCVのスライス操作は不正な範囲を拒否したりするため、VOICEVOX COREとしても言語間で挙動を統一するメリットを取ることとします。


### PR DESCRIPTION
## 内容

Rust APIでは`<[_] as Index<impl SliceIndex<[_]>>>`の挙動により近づけるようにし、Python APIでもエラーの文面を可能な限り充実させる。

２年前の #867 で私が考慮し忘れていたことを今やる形。

## 関連 Issue

cf. #1364
