### PR TITLE
chore: typosに２文字の"word"を検出させないようにする

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -5,6 +5,9 @@
 extend-ignore-identifiers-re = [
     "\\bPNGs\\b", # https://github.com/crate-ci/typos/issues/745
 ]
+extend-ignore-words-re = [
+    "^[A-Za-z]{2}$",
+]
 
 [default.extend-identifiers]
 NdArray="NdArray" # onnxruntime::session::NdArray

--- a/_typos.toml
+++ b/_typos.toml
@@ -6,7 +6,7 @@ extend-ignore-identifiers-re = [
     "\\bPNGs\\b", # https://github.com/crate-ci/typos/issues/745
 ]
 extend-ignore-words-re = [
-    "^[A-Za-z]{2}$",
+    "^[A-Za-z]{2}$", # "ba"（crate-ci/typos#848, crate-ci/typos#413）、Python以外での"NDArray"など
 ]
 
 [default.extend-identifiers]


### PR DESCRIPTION
## 内容

偽陽性が激しいため、２文字の"word"を検出させないようにする。今のところ次の２つの偽陽性を確認している。

- "ba"（例: crate-ci/typos#848, crate-ci/typos#413, 正規表現など）
- Python以外での"NDArray"（例: `// PythonのNDArrayでは～`）
  補足: typesは[プログラミング言語ごとにハードコードで除外リストを持っている](https://github.com/crate-ci/typos/blob/v1.50.0/crates/typos-cli/src/file_type_specifics.rs#L9-L118)のでPythonコードだと大丈夫だが、他言語で"NDArray"について言及するとアウト

## 関連 Issue

経緯: https://github.com/VOICEVOX/voicevox_core/pull/1383/changes#r3617136787
