### PR TITLE
feat(python,c): Python/C 向けStreaming APIの実装

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### Added
 
-- \[Rust\] `Synthesizer::create_audio_feature`と`Synthesizer::render`が追加されます ([#851], [#854], [#864], [#867], [#879], [#918], [#972], [#1319], [#1363], [#1371], [#1376], [#1400], [#1401], [#1419], [#1418], [#1420], [#1421], [#1423], [#1422], [#1426])。
+- \[Rust,C,Python\] `Synthesizer::create_audio_feature`と`Synthesizer::render`が追加されます ([#851], [#854], [#864], [#867], [#879], [#918], [#972], [#1319], [#1363], [#1371], [#1376], [#1400], [#1401], [#1419], [#1418], [#1420], [#1421], [#1423], [#1422], [#1426], [#1430])。
 
 ## [0.17.0] - 2026-08-14 (+09:00)
 
@@ -1553,6 +1553,7 @@ Windows版ダウンローダーのビルドに失敗しています。
 [#1422]: https://github.com/VOICEVOX/voicevox_core/pull/1422
 [#1423]: https://github.com/VOICEVOX/voicevox_core/pull/1423
 [#1426]: https://github.com/VOICEVOX/voicevox_core/pull/1426
+[#1430]: https://github.com/VOICEVOX/voicevox_core/pull/1430
 
 [VOICEVOX/onnxruntime-builder#25]: https://github.com/VOICEVOX/onnxruntime-builder/pull/25
 

--- a/crates/voicevox_core/src/engine/audio_file.rs
+++ b/crates/voicevox_core/src/engine/audio_file.rs
@@ -72,6 +72,7 @@ impl FrameAudioQuery {
 }
 
 /// 16bit PCMにヘッダを付加しWAVフォーマットのバイナリを生成する。
+#[cfg_attr(doc, doc(alias = "voicevox_wav_from_s16le"))]
 pub fn wav_from_s16le(pcm: &[u8], sampling_rate: u32, is_stereo: bool) -> Vec<u8> {
     let num_channels: u16 = if is_stereo { 2 } else { 1 };
     let bit_depth: u16 = 16;

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -213,7 +213,7 @@ fn trim_margin_from_wave(wave_with_margin: ndarray::Array1<f32>) -> ndarray::Arr
 }
 
 /// 音声の中間表現。
-#[cfg_attr(doc, doc(alias="VoicevoxAudioFeature"))]
+#[cfg_attr(doc, doc(alias = "VoicevoxAudioFeature"))]
 #[derive(Clone, PartialEq, derive_more::Debug)]
 pub struct AudioFeature {
     /// (フレーム数, 特徴数)の形を持つ音声特徴量。

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -213,6 +213,7 @@ fn trim_margin_from_wave(wave_with_margin: ndarray::Array1<f32>) -> ndarray::Arr
 }
 
 /// 音声の中間表現。
+#[cfg_attr(doc, doc(alias="VoicevoxAudioFeature"))]
 #[derive(Clone, PartialEq, derive_more::Debug)]
 pub struct AudioFeature {
     /// (フレーム数, 特徴数)の形を持つ音声特徴量。
@@ -1752,6 +1753,7 @@ pub(crate) mod blocking {
         }
 
         /// AudioQueryから音声合成用の中間表現を生成する。
+        #[cfg_attr(doc, doc(alias = "voicevox_synthesizer_create_audio_feature"))]
         pub fn create_audio_feature<'a>(
             &'a self,
             audio_query: &'a AudioQuery,
@@ -1766,6 +1768,7 @@ pub(crate) mod blocking {
         }
 
         /// 中間表現から16bit PCMで音声波形を生成する。
+        #[cfg_attr(doc, doc(alias = "voicevox_synthesizer_render"))]
         pub fn render(
             &self,
             audio: &AudioFeature,

--- a/crates/voicevox_core_c_api/include/voicevox_core.h
+++ b/crates/voicevox_core_c_api/include/voicevox_core.h
@@ -1025,7 +1025,7 @@ VoicevoxResultCode voicevox_ensure_compatible(const char *score_json,
  * @returns 結果コード
  *
  * \safety{
- * - `pcm`はRustの`&[u8; pcm_length]`として解釈できなければならない。
+ * - `pcm`は長さ`pcm_length`にわたって<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * - `output_wav_length`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * - `output_wav`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * }
@@ -1035,12 +1035,12 @@ VoicevoxResultCode voicevox_ensure_compatible(const char *score_json,
 #ifdef _WIN32
 __declspec(dllimport)
 #endif
-VoicevoxResultCode voicevox_wav_from_s16le(uintptr_t pcm_length,
-                                           const uint8_t *pcm,
-                                           uint32_t sampling_rate,
-                                           bool is_stereo,
-                                           uintptr_t *output_wav_length,
-                                           uint8_t **output_wav);
+void voicevox_wav_from_s16le(uintptr_t pcm_length,
+                             const uint8_t *pcm,
+                             uint32_t sampling_rate,
+                             bool is_stereo,
+                             uintptr_t *output_wav_length,
+                             uint8_t **output_wav);
 
 /**
  * VVMファイルを開く。
@@ -1633,8 +1633,8 @@ uintptr_t voicevox_audio_feature_frame_length(const struct VoicevoxAudioFeature 
  *
  * @param [in] synthesizer 音声シンセサイザ
  * @param [in] audio_feature 音声合成用の中間表現
- * @param [in] frame_start 開始フレーム番号
- * @param [in] frame_stop 終了フレーム番号（この番号は含まれない）
+ * @param [in] start_inclusive 開始フレーム番号
+ * @param [in] end_exclusive 終了フレーム番号（この番号は含まれない）
  * @param [out] output_pcm_length 出力のバイト長
  * @param [out] output_pcm 出力先
  *
@@ -1652,8 +1652,8 @@ __declspec(dllimport)
 #endif
 VoicevoxResultCode voicevox_synthesizer_render(const struct VoicevoxSynthesizer *synthesizer,
                                                const struct VoicevoxAudioFeature *audio_feature,
-                                               uintptr_t frame_start,
-                                               uintptr_t frame_stop,
+                                               uintptr_t start_inclusive,
+                                               uintptr_t end_exclusive,
                                                uintptr_t *output_pcm_length,
                                                uint8_t **output_pcm);
 

--- a/crates/voicevox_core_c_api/include/voicevox_core.h
+++ b/crates/voicevox_core_c_api/include/voicevox_core.h
@@ -1545,6 +1545,105 @@ VoicevoxResultCode voicevox_synthesizer_synthesis(const struct VoicevoxSynthesiz
                                                   uint8_t **output_wav);
 
 /**
+ * AudioQueryから音声合成用の中間表現を<b>構築</b>(_construct_)する。
+ *
+ * 生成した中間表現を解放するには ::voicevox_audio_feature_delete を使う。
+ *
+ * @param [in] synthesizer 音声シンセサイザ
+ * @param [in] audio_query_json AudioQueryのJSON文字列
+ * @param [in] style_id スタイルID
+ * @param [in] options オプション
+ * @param [out] out_audio_feature 構築先
+ *
+ * @returns 結果コード
+ *
+ * \safety{
+ * - `audio_query_json`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
+ * - `out_audio_feature`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
+ * }
+ *
+ * \orig-impl{voicevox_synthesizer_create_audio_feature}
+ */
+#ifdef _WIN32
+__declspec(dllimport)
+#endif
+VoicevoxResultCode voicevox_synthesizer_create_audio_feature(const struct VoicevoxSynthesizer *synthesizer,
+                                                             const char *audio_query_json,
+                                                             VoicevoxStyleId style_id,
+                                                             struct VoicevoxSynthesisOptions options,
+                                                             struct VoicevoxAudioFeature **out_audio_feature);
+
+/**
+ * 音声合成用の中間表現。
+ *
+ * <b>構築</b>(_construction_)は ::voicevox_synthesizer_create_audio_feature で行い、<b>破棄</b>(_destruction_)は ::voicevox_audio_feature_delete で行う。
+ *
+ * \orig-impl{VoicevoxAudioFeature}
+ */
+typedef struct VoicevoxAudioFeature VoicevoxAudioFeature;
+
+/**
+ * ::VoicevoxAudioFeature のフレーム数を取得する。
+ *
+ * @param [in] audio_feature 音声合成用の中間表現
+ *
+ * @returns フレーム数
+ *
+ * \no-orig-impl{voicevox_audio_feature_frame_length}
+ */
+#ifdef _WIN32
+__declspec(dllimport)
+#endif
+uintptr_t voicevox_audio_feature_frame_length(const struct VoicevoxAudioFeature *audio_feature);
+
+/**
+ * ::VoicevoxAudioFeature の一部区間から、16bit PCMで音声波形を生成する。
+ *
+ * 生成したPCMデータを解放するには ::voicevox_wav_free を使う。
+ *
+ * @param [in] synthesizer 音声シンセサイザ
+ * @param [in] audio_feature 音声合成用の中間表現
+ * @param [in] frame_start 開始フレーム番号
+ * @param [in] frame_stop 終了フレーム番号（この番号は含まれない）
+ * @param [out] output_pcm_length 出力のバイト長
+ * @param [out] output_pcm 出力先
+ *
+ * @returns 結果コード
+ *
+ * \safety{
+ * - `output_pcm_length`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
+ * - `output_pcm`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
+ * }
+ *
+ * \orig-impl{voicevox_synthesizer_render}
+ */
+#ifdef _WIN32
+__declspec(dllimport)
+#endif
+VoicevoxResultCode voicevox_synthesizer_render(const struct VoicevoxSynthesizer* synthesizer,
+                                               const struct VoicevoxAudioFeature* audio_feature,
+                                               uintptr_t frame_start,
+                                               uintptr_t frame_stop,
+                                               uintptr_t *output_pcm_length,
+                                               uint8_t **output_pcm);
+
+/**
+ * ::VoicevoxAudioFeature を<b>破棄</b>(_destruct_)する。
+ *
+ * 破棄対象への他スレッドでのアクセスが存在する場合、それらがすべて終わるのを待ってから破棄する。
+ *
+ * この関数の呼び出し後に破棄し終えた対象にアクセスすると、プロセスを異常終了する。
+ *
+ * @param [in] audio_feature 破棄対象。nullable
+ *
+ * \no-orig-impl{voicevox_audio_feature_delete}
+ */
+#ifdef _WIN32
+__declspec(dllimport)
+#endif
+void voicevox_audio_feature_delete(struct VoicevoxAudioFeature *audio_feature);
+
+/**
  * デフォルトのテキスト音声合成オプションを生成する
  * @return テキスト音声合成オプション
  *

--- a/crates/voicevox_core_c_api/include/voicevox_core.h
+++ b/crates/voicevox_core_c_api/include/voicevox_core.h
@@ -340,6 +340,15 @@ typedef int32_t VoicevoxUserDictWordType;
 typedef struct OpenJtalkRc OpenJtalkRc;
 
 /**
+ * 音声合成用の中間表現。
+ *
+ * <b>構築</b>(_construction_)は ::voicevox_synthesizer_create_audio_feature で行い、<b>破棄</b>(_destruction_)は ::voicevox_audio_feature_delete で行う。
+ *
+ * \orig-impl{VoicevoxAudioFeature}
+ */
+typedef struct VoicevoxAudioFeature VoicevoxAudioFeature;
+
+/**
  * ONNX Runtime。
  *
  * シングルトンであり、インスタンスは高々一つ。
@@ -1574,15 +1583,6 @@ VoicevoxResultCode voicevox_synthesizer_create_audio_feature(const struct Voicev
                                                              struct VoicevoxAudioFeature **out_audio_feature);
 
 /**
- * 音声合成用の中間表現。
- *
- * <b>構築</b>(_construction_)は ::voicevox_synthesizer_create_audio_feature で行い、<b>破棄</b>(_destruction_)は ::voicevox_audio_feature_delete で行う。
- *
- * \orig-impl{VoicevoxAudioFeature}
- */
-typedef struct VoicevoxAudioFeature VoicevoxAudioFeature;
-
-/**
  * ::VoicevoxAudioFeature のフレーム数を取得する。
  *
  * @param [in] audio_feature 音声合成用の中間表現
@@ -1620,8 +1620,8 @@ uintptr_t voicevox_audio_feature_frame_length(const struct VoicevoxAudioFeature 
 #ifdef _WIN32
 __declspec(dllimport)
 #endif
-VoicevoxResultCode voicevox_synthesizer_render(const struct VoicevoxSynthesizer* synthesizer,
-                                               const struct VoicevoxAudioFeature* audio_feature,
+VoicevoxResultCode voicevox_synthesizer_render(const struct VoicevoxSynthesizer *synthesizer,
+                                               const struct VoicevoxAudioFeature *audio_feature,
                                                uintptr_t frame_start,
                                                uintptr_t frame_stop,
                                                uintptr_t *output_pcm_length,

--- a/crates/voicevox_core_c_api/include/voicevox_core.h
+++ b/crates/voicevox_core_c_api/include/voicevox_core.h
@@ -1013,6 +1013,36 @@ VoicevoxResultCode voicevox_ensure_compatible(const char *score_json,
                                               const char *frame_audio_query_json);
 
 /**
+ * signed 16-bit little endianのPCMデータからWAV形式のバイナリを生成する。
+ *
+ * @param [in] pcm_length PCMデータのバイト長
+ * @param [in] pcm PCMデータ
+ * @param [in] sampling_rate サンプリングレート
+ * @param [in] is_stereo ステレオかどうか
+ * @param [out] output_wav_length 出力のバイト長
+ * @param [out] output_wav 出力先
+ *
+ * @returns 結果コード
+ *
+ * \safety{
+ * - `pcm`はRustの`&[u8; pcm_length]`として解釈できなければならない。
+ * - `output_wav_length`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
+ * - `output_wav`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
+ * }
+ *
+ * \orig-impl{voicevox_wav_from_s16le}
+ */
+#ifdef _WIN32
+__declspec(dllimport)
+#endif
+VoicevoxResultCode voicevox_wav_from_s16le(uintptr_t pcm_length,
+                                           const uint8_t *pcm,
+                                           uint32_t sampling_rate,
+                                           bool is_stereo,
+                                           uintptr_t *output_wav_length,
+                                           uint8_t **output_wav);
+
+/**
  * VVMファイルを開く。
  *
  * @param [in] path vvmファイルへのUTF-8のファイルパス

--- a/crates/voicevox_core_c_api/src/c_impls.rs
+++ b/crates/voicevox_core_c_api/src/c_impls.rs
@@ -14,8 +14,8 @@ use ref_cast::ref_cast_custom;
 use voicevox_core::{CharacterMeta, Result, VoiceModelId};
 
 use crate::{
-    OpenJtalkRc, VoicevoxInitializeOptions, VoicevoxOnnxruntime, VoicevoxSynthesizer,
-    VoicevoxUserDict, VoicevoxVoiceModelFile,
+    OpenJtalkRc, VoicevoxAudioFeature, VoicevoxInitializeOptions, VoicevoxOnnxruntime,
+    VoicevoxSynthesizer, VoicevoxUserDict, VoicevoxVoiceModelFile,
     helpers::CApiResult,
     object::{CApiObject, CApiObjectPtrExt as _, MaybeDeleted},
 };
@@ -142,6 +142,13 @@ impl *const VoicevoxVoiceModelFile {
     }
 }
 
+#[ext(VoicevoxAudioFeaturePtrExt)]
+impl *const VoicevoxAudioFeature {
+    pub(crate) fn frame_length(self) -> usize {
+        self.body().frame_length()
+    }
+}
+
 fn metas_to_json(metas: &[CharacterMeta]) -> CString {
     let metas = serde_json::to_string(metas).expect("should not fail");
     CString::new(metas).expect("should not contain NUL")
@@ -153,6 +160,7 @@ fn metas_to_json(metas: &[CharacterMeta]) -> CString {
     [ VoicevoxUserDict ]       [ voicevox_core::blocking::UserDict ];
     [ VoicevoxSynthesizer ]    [ voicevox_core::blocking::Synthesizer<voicevox_core::blocking::OpenJtalk> ];
     [ VoicevoxVoiceModelFile ] [ voicevox_core::blocking::VoiceModelFile ];
+    [ VoicevoxAudioFeature ]   [ voicevox_core::AudioFeature ];
 )]
 impl CApiObject for H {
     type RustApiObject = B;

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -23,7 +23,10 @@ use self::object::{CApiObject as _, CApiObjectPtrExt as _};
 use self::result_code::VoicevoxResultCode;
 use self::slice_owner::U8_SLICE_OWNER;
 use anstream::{AutoStream, stream::RawStream};
-use c_impls::{VoicevoxSynthesizerPtrExt as _, VoicevoxVoiceModelFilePtrExt as _};
+use c_impls::{
+    VoicevoxAudioFeaturePtrExt as _, VoicevoxSynthesizerPtrExt as _,
+    VoicevoxVoiceModelFilePtrExt as _,
+};
 use chrono::SecondsFormat;
 use colorchoice::ColorChoice;
 use educe::Educe;
@@ -1592,6 +1595,136 @@ pub unsafe extern "C" fn voicevox_synthesizer_synthesis(
         unsafe { U8_SLICE_OWNER.own_and_lend(wav, output_wav, output_wav_length) };
         Ok(())
     })())
+}
+
+// SAFETY: voicevox_core_c_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
+/// AudioQueryから音声合成用の中間表現を<b>構築</b>(_construct_)する。
+///
+/// 生成した中間表現を解放するには ::voicevox_audio_feature_delete を使う。
+///
+/// @param [in] synthesizer 音声シンセサイザ
+/// @param [in] audio_query_json AudioQueryのJSON文字列
+/// @param [in] style_id スタイルID
+/// @param [in] options オプション
+/// @param [out] out_audio_feature 構築先
+///
+/// @returns 結果コード
+///
+/// \safety{
+/// - `audio_query_json`はヌル終端文字列を指し、かつ<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
+/// - `out_audio_feature`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
+/// }
+///
+/// \orig-impl{voicevox_synthesizer_create_audio_feature}
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn voicevox_synthesizer_create_audio_feature(
+    synthesizer: *const VoicevoxSynthesizer,
+    audio_query_json: *const c_char,
+    style_id: VoicevoxStyleId,
+    options: VoicevoxSynthesisOptions,
+    out_audio_feature: NonNull<NonNull<VoicevoxAudioFeature>>,
+) -> VoicevoxResultCode {
+    init_logger_once();
+    into_result_code_with_error((|| {
+        // SAFETY: The safety contract must be upheld by the caller.
+        let audio_query_json = unsafe { CStr::from_ptr(audio_query_json) };
+        let audio_query = ValidateJson::validate_json(audio_query_json)?;
+        let VoicevoxSynthesisOptions {
+            enable_interrogative_upspeak,
+        } = options;
+        let audio_feature = synthesizer
+            .body()
+            .create_audio_feature(&audio_query, StyleId::new(style_id))
+            .enable_interrogative_upspeak(enable_interrogative_upspeak)
+            .perform()?;
+        let audio_feature = <VoicevoxAudioFeature as object::CApiObject>::new(audio_feature);
+        // SAFETY: The safety contract must be upheld by the caller.
+        unsafe { out_audio_feature.write_unaligned(audio_feature) };
+        Ok(())
+    })())
+}
+
+/// 音声合成用の中間表現。
+///
+/// <b>構築</b>(_construction_)は ::voicevox_synthesizer_create_audio_feature で行い、<b>破棄</b>(_destruction_)は ::voicevox_audio_feature_delete で行う。
+///
+/// \no-orig-impl{VoicevoxAudioFeature}
+#[derive(Debug, Educe)]
+#[educe(Default(expression = "Self { _padding: MaybeUninit::uninit() }"))]
+pub struct VoicevoxAudioFeature {
+    _padding: MaybeUninit<[u8; 1]>,
+}
+
+// SAFETY: voicevox_core_c_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
+/// ::VoicevoxAudioFeature のフレーム数を取得する。
+///
+/// @param [in] audio_feature 音声合成用の中間表現
+///
+/// @returns フレーム数
+///
+/// \no-orig-impl{voicevox_audio_feature_frame_length}
+#[unsafe(no_mangle)]
+pub extern "C" fn voicevox_audio_feature_frame_length(
+    audio_feature: *const VoicevoxAudioFeature,
+) -> usize {
+    init_logger_once();
+    audio_feature.frame_length()
+}
+
+// SAFETY: voicevox_core_c_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
+/// ::VoicevoxAudioFeature の一部区間から、16bit PCMで音声波形を生成する。
+///
+/// 生成したPCMデータを解放するには ::voicevox_wav_free を使う。
+///
+/// @param [in] synthesizer 音声シンセサイザ
+/// @param [in] audio_feature 音声合成用の中間表現
+/// @param [in] frame_start 開始フレーム番号
+/// @param [in] frame_stop 終了フレーム番号（この番号は含まれない）
+/// @param [out] output_pcm_length 出力のバイト長
+/// @param [out] output_pcm 出力先
+///
+/// @returns 結果コード
+///
+/// \safety{
+/// - `output_pcm_length`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
+/// - `output_pcm`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
+/// }
+///
+/// \no-orig-impl{voicevox_synthesizer_render_audio_feature}
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn voicevox_synthesizer_render_audio_feature(
+    synthesizer: *const VoicevoxSynthesizer,
+    audio_feature: *const VoicevoxAudioFeature,
+    frame_start: usize,
+    frame_stop: usize,
+    output_pcm_length: NonNull<usize>,
+    output_pcm: NonNull<NonNull<u8>>,
+) -> VoicevoxResultCode {
+    init_logger_once();
+    into_result_code_with_error((|| {
+        let pcm = synthesizer
+            .body()
+            .render(&audio_feature.body(), frame_start..frame_stop)?;
+        // SAFETY: The safety contract must be upheld by the caller.
+        unsafe { U8_SLICE_OWNER.own_and_lend(pcm, output_pcm, output_pcm_length) };
+        Ok(())
+    })())
+}
+
+// SAFETY: voicevox_core_c_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
+/// ::VoicevoxAudioFeature を<b>破棄</b>(_destruct_)する。
+///
+/// 破棄対象への他スレッドでのアクセスが存在する場合、それらがすべて終わるのを待ってから破棄する。
+///
+/// この関数の呼び出し後に破棄し終えた対象にアクセスすると、プロセスを異常終了する。
+///
+/// @param [in] audio_feature 破棄対象。nullable
+///
+/// \no-orig-impl{voicevox_audio_feature_delete}
+#[unsafe(no_mangle)]
+pub extern "C" fn voicevox_audio_feature_delete(audio_feature: *mut VoicevoxAudioFeature) {
+    init_logger_once();
+    audio_feature.drop_body();
 }
 
 /// ::voicevox_synthesizer_tts のオプション。

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -818,7 +818,7 @@ pub unsafe extern "C" fn voicevox_ensure_compatible(
 /// @returns 結果コード
 ///
 /// \safety{
-/// - `pcm`はRustの`&[u8; pcm_length]`として解釈できなければならない。
+/// - `pcm`は長さ`pcm_length`にわたって<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
 /// - `output_wav_length`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
 /// - `output_wav`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
 /// }
@@ -832,16 +832,13 @@ pub unsafe extern "C" fn voicevox_wav_from_s16le(
     is_stereo: bool,
     output_wav_length: NonNull<usize>,
     output_wav: NonNull<NonNull<u8>>,
-) -> VoicevoxResultCode {
+) {
     init_logger_once();
-    into_result_code_with_error((|| {
-        // SAFETY: The safety contract must be upheld by the caller.
-        let pcm = unsafe { std::slice::from_raw_parts(pcm, pcm_length) };
-        let wav = voicevox_core::wav_from_s16le(pcm, sampling_rate, is_stereo);
-        // SAFETY: The safety contract must be upheld by the caller.
-        unsafe { U8_SLICE_OWNER.own_and_lend(wav, output_wav, output_wav_length) };
-        Ok(())
-    })())
+    // SAFETY: The safety contract must be upheld by the caller.
+    let pcm = unsafe { std::slice::from_raw_parts(pcm, pcm_length) };
+    let wav = voicevox_core::wav_from_s16le(pcm, sampling_rate, is_stereo);
+    // SAFETY: The safety contract must be upheld by the caller.
+    unsafe { U8_SLICE_OWNER.own_and_lend(wav, output_wav, output_wav_length) };
 }
 
 /// 音声モデルファイル。

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -19,7 +19,7 @@ use self::helpers::{
     CApiError, ToCJson as _, UuidBytesExt as _, ValidateJson, accent_phrases_to_json,
     audio_query_model_to_json, ensure_utf8, into_result_code_with_error,
 };
-use self::object::{CApiObject as _, CApiObjectPtrExt as _};
+use self::object::{CApiObject, CApiObjectPtrExt as _};
 use self::result_code::VoicevoxResultCode;
 use self::slice_owner::U8_SLICE_OWNER;
 use anstream::{AutoStream, stream::RawStream};
@@ -1676,7 +1676,7 @@ pub unsafe extern "C" fn voicevox_synthesizer_create_audio_feature(
             .create_audio_feature(&audio_query, StyleId::new(style_id))
             .enable_interrogative_upspeak(enable_interrogative_upspeak)
             .perform()?;
-        let audio_feature = <VoicevoxAudioFeature as object::CApiObject>::new(audio_feature);
+        let audio_feature = <VoicevoxAudioFeature as CApiObject>::new(audio_feature);
         // SAFETY: The safety contract must be upheld by the caller.
         unsafe { out_audio_feature.write_unaligned(audio_feature) };
         Ok(())
@@ -1710,6 +1710,7 @@ pub extern "C" fn voicevox_audio_feature_frame_length(
     audio_feature.frame_length()
 }
 
+// FIXME: voicevox_wav_freeをvoicevox_bytes_freeに改名
 // SAFETY: voicevox_core_c_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
 /// ::VoicevoxAudioFeature の一部区間から、16bit PCMで音声波形を生成する。
 ///
@@ -1717,8 +1718,8 @@ pub extern "C" fn voicevox_audio_feature_frame_length(
 ///
 /// @param [in] synthesizer 音声シンセサイザ
 /// @param [in] audio_feature 音声合成用の中間表現
-/// @param [in] frame_start 開始フレーム番号
-/// @param [in] frame_stop 終了フレーム番号（この番号は含まれない）
+/// @param [in] start_inclusive 開始フレーム番号
+/// @param [in] end_exclusive 終了フレーム番号（この番号は含まれない）
 /// @param [out] output_pcm_length 出力のバイト長
 /// @param [out] output_pcm 出力先
 ///
@@ -1734,8 +1735,8 @@ pub extern "C" fn voicevox_audio_feature_frame_length(
 pub unsafe extern "C" fn voicevox_synthesizer_render(
     synthesizer: *const VoicevoxSynthesizer,
     audio_feature: *const VoicevoxAudioFeature,
-    frame_start: usize,
-    frame_stop: usize,
+    start_inclusive: usize,
+    end_exclusive: usize,
     output_pcm_length: NonNull<usize>,
     output_pcm: NonNull<NonNull<u8>>,
 ) -> VoicevoxResultCode {
@@ -1743,7 +1744,7 @@ pub unsafe extern "C" fn voicevox_synthesizer_render(
     into_result_code_with_error((|| {
         let pcm = synthesizer
             .body()
-            .render(&audio_feature.body(), frame_start..frame_stop)?;
+            .render(&audio_feature.body(), start_inclusive..end_exclusive)?;
         // SAFETY: The safety contract must be upheld by the caller.
         unsafe { U8_SLICE_OWNER.own_and_lend(pcm, output_pcm, output_pcm_length) };
         Ok(())
@@ -2178,6 +2179,7 @@ pub unsafe extern "C" fn voicevox_json_free(json: *mut c_char) {
     }
 }
 
+// FIXME: voicevox_synthesizer_renderで確保するPCMデータの管理にも使うため、voicevox_wav_freeをvoicevox_bytes_freeに改名
 // SAFETY: voicevox_core_c_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
 /// WAVデータを解放する。
 ///

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -805,6 +805,45 @@ pub unsafe extern "C" fn voicevox_ensure_compatible(
     })())
 }
 
+// SAFETY: voicevox_core_c_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
+/// signed 16-bit little endianのPCMデータからWAV形式のバイナリを生成する。
+///
+/// @param [in] pcm_length PCMデータのバイト長
+/// @param [in] pcm PCMデータ
+/// @param [in] sampling_rate サンプリングレート
+/// @param [in] is_stereo ステレオかどうか
+/// @param [out] output_wav_length 出力のバイト長
+/// @param [out] output_wav 出力先
+///
+/// @returns 結果コード
+///
+/// \safety{
+/// - `pcm`はRustの`&[u8; pcm_length]`として解釈できなければならない。
+/// - `output_wav_length`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
+/// - `output_wav`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
+/// }
+///
+/// \orig-impl{voicevox_wav_from_s16le}
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn voicevox_wav_from_s16le(
+    pcm_length: usize,
+    pcm: *const u8,
+    sampling_rate: u32,
+    is_stereo: bool,
+    output_wav_length: NonNull<usize>,
+    output_wav: NonNull<NonNull<u8>>,
+) -> VoicevoxResultCode {
+    init_logger_once();
+    into_result_code_with_error((|| {
+        // SAFETY: The safety contract must be upheld by the caller.
+        let pcm = unsafe { std::slice::from_raw_parts(pcm, pcm_length) };
+        let wav = voicevox_core::wav_from_s16le(pcm, sampling_rate, is_stereo);
+        // SAFETY: The safety contract must be upheld by the caller.
+        unsafe { U8_SLICE_OWNER.own_and_lend(wav, output_wav, output_wav_length) };
+        Ok(())
+    })())
+}
+
 /// 音声モデルファイル。
 ///
 /// VVMファイルと対応する。

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -1648,7 +1648,7 @@ pub unsafe extern "C" fn voicevox_synthesizer_create_audio_feature(
 ///
 /// <b>構築</b>(_construction_)は ::voicevox_synthesizer_create_audio_feature で行い、<b>破棄</b>(_destruction_)は ::voicevox_audio_feature_delete で行う。
 ///
-/// \no-orig-impl{VoicevoxAudioFeature}
+/// \orig-impl{VoicevoxAudioFeature}
 #[derive(Debug, Educe)]
 #[educe(Default(expression = "Self { _padding: MaybeUninit::uninit() }"))]
 pub struct VoicevoxAudioFeature {
@@ -1690,9 +1690,9 @@ pub extern "C" fn voicevox_audio_feature_frame_length(
 /// - `output_pcm`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
 /// }
 ///
-/// \no-orig-impl{voicevox_synthesizer_render_audio_feature}
+/// \orig-impl{voicevox_synthesizer_render}
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn voicevox_synthesizer_render_audio_feature(
+pub unsafe extern "C" fn voicevox_synthesizer_render(
     synthesizer: *const VoicevoxSynthesizer,
     audio_feature: *const VoicevoxAudioFeature,
     frame_start: usize,

--- a/crates/voicevox_core_python_api/python/test/test_blocking_stream_tts.py
+++ b/crates/voicevox_core_python_api/python/test/test_blocking_stream_tts.py
@@ -16,10 +16,11 @@ def test(synthesizer: Synthesizer) -> None:
     wav1 = synthesizer.tts(TEXT, STYLE_ID)
 
     query = synthesizer.create_audio_query(TEXT, STYLE_ID)
-    feat2 = synthesizer.create_audio_feature(query, STYLE_ID)
-    pcm2 = synthesizer.render(feat2, 0, feat2.frame_length)
+    feat = synthesizer.create_audio_feature(query, STYLE_ID)
+    pcm = synthesizer.render(feat, 0, feat.frame_length)
+    wav2 = wav_from_s16le(pcm, query.output_sampling_rate, query.output_stereo)
 
-    assert wav1 == wav_from_s16le(pcm2, query.output_sampling_rate, query.output_stereo)
+    assert wav1 == wav2
 
 
 @pytest.fixture

--- a/crates/voicevox_core_python_api/python/test/test_blocking_stream_tts.py
+++ b/crates/voicevox_core_python_api/python/test/test_blocking_stream_tts.py
@@ -1,0 +1,31 @@
+"""
+ストリーミング音声合成を行う。
+"""
+
+import conftest
+import pytest
+from voicevox_core import AudioQuery
+from voicevox_core.blocking import Onnxruntime, OpenJtalk, Synthesizer, VoiceModelFile
+
+
+def test(synthesizer: Synthesizer) -> None:
+    TEXT = "こんにちは？"
+    STYLE_ID = 0
+
+    wav1 = synthesizer.tts(TEXT, STYLE_ID)
+
+    query = synthesizer.create_audio_query(TEXT, STYLE_ID)
+    feat2 = synthesizer.create_audio_feature(query, STYLE_ID)
+    wav2 = synthesizer.render(feat2, 0, feat2.audio.frame_length())
+
+    assert wav1 == wav2
+
+
+@pytest.fixture
+def synthesizer() -> Synthesizer:
+    onnxruntime = Onnxruntime.load_once(filename=conftest.onnxruntime_filename)
+    open_jtalk = OpenJtalk(conftest.open_jtalk_dic_dir)
+    synthesizer = Synthesizer(onnxruntime, open_jtalk, acceleration_mode="CPU")
+    with VoiceModelFile.open(conftest.model_dir) as model:
+        synthesizer.load_voice_model(model)
+    return synthesizer

--- a/crates/voicevox_core_python_api/python/test/test_blocking_stream_tts.py
+++ b/crates/voicevox_core_python_api/python/test/test_blocking_stream_tts.py
@@ -4,7 +4,7 @@
 
 import conftest
 import pytest
-from voicevox_core import AudioQuery
+from voicevox_core import wav_from_s16le
 from voicevox_core.blocking import Onnxruntime, OpenJtalk, Synthesizer, VoiceModelFile
 
 
@@ -17,9 +17,9 @@ def test(synthesizer: Synthesizer) -> None:
 
     query = synthesizer.create_audio_query(TEXT, STYLE_ID)
     feat2 = synthesizer.create_audio_feature(query, STYLE_ID)
-    wav2 = synthesizer.render(feat2, 0, feat2.frame_length)
+    pcm2 = synthesizer.render(feat2, 0, feat2.frame_length)
 
-    assert wav1 == wav2
+    assert wav1 == wav_from_s16le(pcm2)
 
 
 @pytest.fixture

--- a/crates/voicevox_core_python_api/python/test/test_blocking_stream_tts.py
+++ b/crates/voicevox_core_python_api/python/test/test_blocking_stream_tts.py
@@ -19,7 +19,7 @@ def test(synthesizer: Synthesizer) -> None:
     feat2 = synthesizer.create_audio_feature(query, STYLE_ID)
     pcm2 = synthesizer.render(feat2, 0, feat2.frame_length)
 
-    assert wav1 == wav_from_s16le(pcm2)
+    assert wav1 == wav_from_s16le(pcm2, query.output_sampling_rate, query.output_stereo)
 
 
 @pytest.fixture

--- a/crates/voicevox_core_python_api/python/test/test_blocking_stream_tts.py
+++ b/crates/voicevox_core_python_api/python/test/test_blocking_stream_tts.py
@@ -10,7 +10,7 @@ from voicevox_core.blocking import Onnxruntime, OpenJtalk, Synthesizer, VoiceMod
 
 def test(synthesizer: Synthesizer) -> None:
     TEXT = "こんにちは？"
-    STYLE_ID = 0
+    STYLE_ID = 302  # `streaming_talk`に対応したスタイル。voicevox_core/model/sample.vvm/metas.jsonを参照。
 
     wav1 = synthesizer.tts(TEXT, STYLE_ID)
 

--- a/crates/voicevox_core_python_api/python/test/test_blocking_stream_tts.py
+++ b/crates/voicevox_core_python_api/python/test/test_blocking_stream_tts.py
@@ -10,13 +10,14 @@ from voicevox_core.blocking import Onnxruntime, OpenJtalk, Synthesizer, VoiceMod
 
 def test(synthesizer: Synthesizer) -> None:
     TEXT = "こんにちは？"
-    STYLE_ID = 302  # `streaming_talk`に対応したスタイル。voicevox_core/model/sample.vvm/metas.jsonを参照。
+    # `streaming_talk`に対応したスタイルを使用。voicevox_core/model/sample.vvm/metas.jsonを参照。
+    STYLE_ID = 302
 
     wav1 = synthesizer.tts(TEXT, STYLE_ID)
 
     query = synthesizer.create_audio_query(TEXT, STYLE_ID)
     feat2 = synthesizer.create_audio_feature(query, STYLE_ID)
-    wav2 = synthesizer.render(feat2, 0, feat2.audio.frame_length())
+    wav2 = synthesizer.render(feat2, 0, feat2.frame_length)
 
     assert wav1 == wav2
 

--- a/crates/voicevox_core_python_api/python/voicevox_core/__init__.py
+++ b/crates/voicevox_core_python_api/python/voicevox_core/__init__.py
@@ -1,8 +1,5 @@
 """無料で使える中品質なテキスト読み上げソフトウェア、VOICEVOXのコア。"""
 
-# TODO: `AudioFeature`と`wav_from_s16le`を復活させる
-# https://github.com/VOICEVOX/voicevox_core/issues/970
-
 from ._python import (  # noqa: F401
     AccelerationMode,
     AccentPhrase,
@@ -26,6 +23,7 @@ from ._python import (  # noqa: F401
 )
 from ._rust import (  # noqa: F401
     AnalyzeTextError,
+    AudioFeature,
     GetSupportedDevicesError,
     GpuSupportError,
     IncompatibleQueriesError,
@@ -48,6 +46,7 @@ from ._rust import (  # noqa: F401
     WordNotFoundError,
     __version__,
     ensure_compatible,
+    wav_from_s16le,
 )
 
 from . import asyncio, blocking  # noqa: F401 isort: skip
@@ -57,6 +56,7 @@ __all__ = [
     "AccelerationMode",
     "AccentPhrase",
     "AnalyzeTextError",
+    "AudioFeature",
     "AudioQuery",
     "asyncio",
     "blocking",
@@ -97,4 +97,5 @@ __all__ = [
     "VoiceModelId",
     "WordNotFoundError",
     "ensure_compatible",
+    "wav_from_s16le",
 ]

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
@@ -427,13 +427,47 @@ class Synthesizer:
         style_id: StyleId | int,
         *,
         enable_interrogative_upspeak: bool = True,
-    ) -> AudioFeature: ...
+    ) -> AudioFeature:
+        """
+        :class:`AudioQuery` から中間表現である :class:`AudioFeature` を生成する。
+
+        Parameters
+        ----------
+        audio_query
+            :class:`AudioQuery` 。
+        style_id
+            スタイルID。
+        enable_interrogative_upspeak
+            疑問文の調整を有効にするかどうか。
+
+        Returns
+        -------
+        :class:`AudioFeature` 。
+        """
+        ...
     def render(
         self,
         audio: AudioFeature,
         start: int,
         stop: int,
-    ) -> bytes: ...
+    ) -> bytes:
+        """
+        :class:`AudioFeature` から音声合成する。
+
+        Parameters
+        ----------
+        audio_feature
+            :class:`AudioFeature` 。
+        start
+            開始フレーム。
+        stop
+            終了フレーム。
+
+        Returns
+        -------
+        WAVデータ。
+        """
+        ...
     def synthesis(
         self,
         audio_query: AudioQuery,

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
@@ -421,14 +421,14 @@ class Synthesizer:
             スタイルID。
         """
         ...
-    def __create_audio_feature(
+    def create_audio_feature(
         self,
         audio_query: AudioQuery,
         style_id: StyleId | int,
         *,
         enable_interrogative_upspeak: bool = True,
     ) -> AudioFeature: ...
-    def __render(
+    def render(
         self,
         audio: AudioFeature,
         start: int,

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust/blocking.pyi
@@ -452,20 +452,20 @@ class Synthesizer:
         stop: int,
     ) -> bytes:
         """
-        :class:`AudioFeature` から音声合成する。
+        :class:`AudioFeature` からPCM形式の音声バイナリを生成する。
 
         Parameters
         ----------
         audio_feature
             :class:`AudioFeature` 。
         start
-            開始フレーム。
+            生成範囲の始端（このフレームを含む）。
         stop
-            終了フレーム。
+            生成範囲の終端（このフレームは含まれない）。
 
         Returns
         -------
-        WAVデータ。
+        signed 16-bit little endianのPCMデータ。
         """
         ...
     def synthesis(

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -892,9 +892,6 @@ mod blocking {
                 .into_py_result(py)
         }
 
-        // TODO: 後で復活させる
-        // https://github.com/VOICEVOX/voicevox_core/issues/970
-        #[allow(non_snake_case)]
         #[pyo3(signature=(
             audio_query,
             style_id,
@@ -902,7 +899,7 @@ mod blocking {
             enable_interrogative_upspeak =
                 voicevox_core::__internal::interop::DEFAULT_ENABLE_INTERROGATIVE_UPSPEAK,
         ))]
-        fn _Synthesizer__create_audio_feature(
+        fn create_audio_feature(
             &self,
             #[pyo3(from_py_with = crate::convert::from_audio_query)] audio_query: AudioQuery,
             style_id: u32,
@@ -919,10 +916,7 @@ mod blocking {
             Ok(AudioFeature { audio })
         }
 
-        // TODO: 後で復活させる
-        // https://github.com/VOICEVOX/voicevox_core/issues/970
-        #[allow(non_snake_case)]
-        fn _Synthesizer__render(
+        fn render(
             &self,
             audio: &AudioFeature,
             #[pyo3(from_py_with = crate::convert::from_audio_feature_range_start)] start: usize,


### PR DESCRIPTION
## 内容
`create_audio_feature` と `render` をPython/C 向けに実装


## 関連 Issue

#1364

## その他

(edited by @qryxip)

残課題は以下。

- https://github.com/VOICEVOX/voicevox_core/pull/1430#discussion_r3933276448
    - ドキュメンテーションコメントをなんとかする
- https://github.com/VOICEVOX/voicevox_core/pull/1430#discussion_r3932588339
    - C: `voicevox_wav_free`は`voicevox_bytes_free`に改名すべき
- https://github.com/VOICEVOX/voicevox_core/pull/1430#issuecomment-5554468999
    - C: PCMが空の場合のケアをしないといけない
    - C: このままだとRustのパニックを引き起すので、`INVALID_AUDIO_FEATURE_RANGE`的なものが要る