### PR TITLE
fix(c): PCMが空の場合を考慮する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### Added
 
-- \[Rust,C,Python\] `Synthesizer::create_audio_feature`と`Synthesizer::render`が追加されます ([#851], [#854], [#864], [#867], [#879], [#918], [#972], [#1319], [#1363], [#1371], [#1376], [#1400], [#1401], [#1419], [#1418], [#1420], [#1421], [#1423], [#1422], [#1426], [#1430])。
+- \[Rust,C,Python\] `Synthesizer::create_audio_feature`と`Synthesizer::render`が追加されます ([#851], [#854], [#864], [#867], [#879], [#918], [#972], [#1319], [#1363], [#1371], [#1376], [#1400], [#1401], [#1419], [#1418], [#1420], [#1421], [#1423], [#1422], [#1426], [#1430], [#1431])。
 
 ### Fixed
 
@@ -1559,6 +1559,7 @@ Windows版ダウンローダーのビルドに失敗しています。
 [#1426]: https://github.com/VOICEVOX/voicevox_core/pull/1426
 [#1429]: https://github.com/VOICEVOX/voicevox_core/pull/1429
 [#1430]: https://github.com/VOICEVOX/voicevox_core/pull/1430
+[#1431]: https://github.com/VOICEVOX/voicevox_core/pull/1431
 
 [VOICEVOX/onnxruntime-builder#25]: https://github.com/VOICEVOX/onnxruntime-builder/pull/25
 

--- a/crates/voicevox_core_c_api/include/voicevox_core.h
+++ b/crates/voicevox_core_c_api/include/voicevox_core.h
@@ -525,6 +525,13 @@ extern "C" {
 #endif // __cplusplus
 
 /**
+ * このライブラリにおいて、空の`uint8_t`の配列を表すポインタ。
+ *
+ * このポインタが指す先は未初期化の値であり、読み書きされるべきではない。
+ */
+extern const uint8_t *voicevox_empty_bytes;
+
+/**
  * 必要なONNX Runtime 1.xの最小マイナーバージョンを取得する。
  *
  * @return 必要な最小マイナーバージョン
@@ -1015,8 +1022,10 @@ VoicevoxResultCode voicevox_ensure_compatible(const char *score_json,
 /**
  * signed 16-bit little endianのPCMデータからWAV形式のバイナリを生成する。
  *
+ * `pcm`がヌルならクラッシュする。
+ *
  * @param [in] pcm_length PCMデータのバイト長
- * @param [in] pcm PCMデータ
+ * @param [in] pcm PCMデータ。非ヌル
  * @param [in] sampling_rate サンプリングレート
  * @param [in] is_stereo ステレオかどうか
  * @param [out] output_wav_length 出力のバイト長
@@ -1025,7 +1034,7 @@ VoicevoxResultCode voicevox_ensure_compatible(const char *score_json,
  * @returns 結果コード
  *
  * \safety{
- * - `pcm`は長さ`pcm_length`にわたって<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
+ * - `pcm_length > 0`のとき、`pcm`は長さ`pcm_length`にわたって<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
  * - `output_wav_length`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * - `output_wav`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
  * }
@@ -1629,7 +1638,9 @@ uintptr_t voicevox_audio_feature_frame_length(const struct VoicevoxAudioFeature 
 /**
  * ::VoicevoxAudioFeature の一部区間から、16bit PCMで音声波形を生成する。
  *
- * 生成したPCMデータを解放するには ::voicevox_wav_free を使う。
+ * 生成されたPCMデータが`0`バイトのとき、`output_pcm_length`には`0`が、`output_pcm`には ::voicevox_empty_bytes が書き込まれる。
+ *
+ * 生成した`1`バイト以上のPCMデータを解放するには ::voicevox_wav_free を使う。
  *
  * @param [in] synthesizer 音声シンセサイザ
  * @param [in] audio_feature 音声合成用の中間表現
@@ -1964,16 +1975,19 @@ void voicevox_json_free(char *json);
 /**
  * WAVデータを解放する。
  *
+ * ::voicevox_empty_bytes に対しては警告のログを出す。
+ *
  * @param [in] wav 解放するWAVデータ。nullable
  *
  * \safety{
  * - `wav`がヌルポインタでないならば、以下のAPIで得られたポインタでなくてはいけない。
+ *     - ::voicevox_synthesizer_render
  *     - ::voicevox_synthesizer_synthesis
  *     - ::voicevox_synthesizer_tts
  *     - ::voicevox_synthesizer_tts_from_kana
  *     - ::voicevox_synthesizer_frame_synthesis
- * - `wav`がヌルポインタでないならば、<a href="#voicevox-core-safety">読み込みと書き込みについて有効</a>でなければならない。
- * - `wav`がヌルポインタでないならば、以後<b>ダングリングポインタ</b>(_dangling pointer_)として扱われなくてはならない。
+ * - `wav`がヌルポインタでも ::voicevox_empty_bytes でもないならば、<a href="#voicevox-core-safety">読み込みと書き込みについて有効</a>でなければならない。
+ * - `wav`がヌルポインタでも ::voicevox_empty_bytes でもないならば、以後<b>ダングリングポインタ</b>(_dangling pointer_)として扱われなくてはならない。
  * }
  *
  * \no-orig-impl{voicevox_wav_free}

--- a/crates/voicevox_core_c_api/include/voicevox_core.h
+++ b/crates/voicevox_core_c_api/include/voicevox_core.h
@@ -1986,6 +1986,7 @@ void voicevox_json_free(char *json);
  *     - ::voicevox_synthesizer_tts
  *     - ::voicevox_synthesizer_tts_from_kana
  *     - ::voicevox_synthesizer_frame_synthesis
+ *     - ::voicevox_wav_from_s16le
  * - `wav`がヌルポインタでも ::voicevox_empty_bytes でもないならば、<a href="#voicevox-core-safety">読み込みと書き込みについて有効</a>でなければならない。
  * - `wav`がヌルポインタでも ::voicevox_empty_bytes でもないならば、以後<b>ダングリングポインタ</b>(_dangling pointer_)として扱われなくてはならない。
  * }

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -21,7 +21,7 @@ use self::helpers::{
 };
 use self::object::{CApiObject, CApiObjectPtrExt as _};
 use self::result_code::VoicevoxResultCode;
-use self::slice_owner::U8_SLICE_OWNER;
+use self::slice_owner::{SliceElement, U8_SLICE_OWNER};
 use anstream::{AutoStream, stream::RawStream};
 use c_impls::{
     VoicevoxAudioFeaturePtrExt as _, VoicevoxSynthesizerPtrExt as _,
@@ -98,6 +98,13 @@ fn init_logger_once() {
 //pub const VOICEVOX_ONNXRUNTIME_LIB_RECOMMENDED_NAME: &CStr = ..;
 //#[cfg(feature = "load-onnxruntime")]
 //pub const VOICEVOX_ONNXRUNTIME_LIB_RECOMMENDED_VERSION: &CStr = ..;
+
+// ドキュメントでの説明を円滑にするためだけに存在。この変数自体がユーザーからアクセスしづらいことについては許容する。
+/// このライブラリにおいて、空の`uint8_t`の配列を表すポインタ。
+///
+/// このポインタが指す先は未初期化の値であり、読み書きされるべきではない。
+#[unsafe(no_mangle)]
+pub static voicevox_empty_bytes: &MaybeUninit<u8> = SliceElement::REF_FOR_EMPTY;
 
 // SAFETY: voicevox_core_c_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
 /// 必要なONNX Runtime 1.xの最小マイナーバージョンを取得する。
@@ -808,8 +815,10 @@ pub unsafe extern "C" fn voicevox_ensure_compatible(
 // SAFETY: voicevox_core_c_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
 /// signed 16-bit little endianのPCMデータからWAV形式のバイナリを生成する。
 ///
+/// `pcm`がヌルならクラッシュする。
+///
 /// @param [in] pcm_length PCMデータのバイト長
-/// @param [in] pcm PCMデータ
+/// @param [in] pcm PCMデータ。非ヌル
 /// @param [in] sampling_rate サンプリングレート
 /// @param [in] is_stereo ステレオかどうか
 /// @param [out] output_wav_length 出力のバイト長
@@ -818,7 +827,7 @@ pub unsafe extern "C" fn voicevox_ensure_compatible(
 /// @returns 結果コード
 ///
 /// \safety{
-/// - `pcm`は長さ`pcm_length`にわたって<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
+/// - `pcm_length > 0`のとき、`pcm`は長さ`pcm_length`にわたって<a href="#voicevox-core-safety">読み込みについて有効</a>でなければならない。
 /// - `output_wav_length`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
 /// - `output_wav`は<a href="#voicevox-core-safety">書き込みについて有効</a>でなければならない。
 /// }
@@ -834,8 +843,22 @@ pub unsafe extern "C" fn voicevox_wav_from_s16le(
     output_wav: NonNull<NonNull<u8>>,
 ) {
     init_logger_once();
-    // SAFETY: The safety contract must be upheld by the caller.
-    let pcm = unsafe { std::slice::from_raw_parts(pcm, pcm_length) };
+    if pcm.is_null() {
+        panic!(
+            "`pcm`は非ヌルのポインタでなくてはなりません{}",
+            match pcm_length {
+                0 =>
+                    ": `pcm_length`が`0`のときは`voicevox_empty_bytes`か、\
+                     適当な非ヌルのポインタを渡してください",
+                _ => "",
+            },
+        );
+    }
+    let pcm = match pcm_length {
+        0 => &[],
+        // SAFETY: The safety contract must be upheld by the caller.
+        pcm_length => unsafe { std::slice::from_raw_parts(pcm, pcm_length) },
+    };
     let wav = voicevox_core::wav_from_s16le(pcm, sampling_rate, is_stereo);
     // SAFETY: The safety contract must be upheld by the caller.
     unsafe { U8_SLICE_OWNER.own_and_lend(wav, output_wav, output_wav_length) };
@@ -1711,7 +1734,9 @@ pub extern "C" fn voicevox_audio_feature_frame_length(
 // SAFETY: voicevox_core_c_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
 /// ::VoicevoxAudioFeature の一部区間から、16bit PCMで音声波形を生成する。
 ///
-/// 生成したPCMデータを解放するには ::voicevox_wav_free を使う。
+/// 生成されたPCMデータが`0`バイトのとき、`output_pcm_length`には`0`が、`output_pcm`には ::voicevox_empty_bytes が書き込まれる。
+///
+/// 生成した`1`バイト以上のPCMデータを解放するには ::voicevox_wav_free を使う。
 ///
 /// @param [in] synthesizer 音声シンセサイザ
 /// @param [in] audio_feature 音声合成用の中間表現
@@ -2180,16 +2205,19 @@ pub unsafe extern "C" fn voicevox_json_free(json: *mut c_char) {
 // SAFETY: voicevox_core_c_apiを構成するライブラリの中に、これと同名のシンボルは存在しない
 /// WAVデータを解放する。
 ///
+/// ::voicevox_empty_bytes に対しては警告のログを出す。
+///
 /// @param [in] wav 解放するWAVデータ。nullable
 ///
 /// \safety{
 /// - `wav`がヌルポインタでないならば、以下のAPIで得られたポインタでなくてはいけない。
+///     - ::voicevox_synthesizer_render
 ///     - ::voicevox_synthesizer_synthesis
 ///     - ::voicevox_synthesizer_tts
 ///     - ::voicevox_synthesizer_tts_from_kana
 ///     - ::voicevox_synthesizer_frame_synthesis
-/// - `wav`がヌルポインタでないならば、<a href="#voicevox-core-safety">読み込みと書き込みについて有効</a>でなければならない。
-/// - `wav`がヌルポインタでないならば、以後<b>ダングリングポインタ</b>(_dangling pointer_)として扱われなくてはならない。
+/// - `wav`がヌルポインタでも ::voicevox_empty_bytes でもないならば、<a href="#voicevox-core-safety">読み込みと書き込みについて有効</a>でなければならない。
+/// - `wav`がヌルポインタでも ::voicevox_empty_bytes でもないならば、以後<b>ダングリングポインタ</b>(_dangling pointer_)として扱われなくてはならない。
 /// }
 ///
 /// \no-orig-impl{voicevox_wav_free}

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -854,11 +854,10 @@ pub unsafe extern "C" fn voicevox_wav_from_s16le(
             },
         );
     }
-    let pcm = match pcm_length {
-        0 => &[],
-        // SAFETY: The safety contract must be upheld by the caller.
-        pcm_length => unsafe { std::slice::from_raw_parts(pcm, pcm_length) },
-    };
+    // SAFETY:
+    // - We have denied null.
+    // - The safety contract must be upheld by the caller.
+    let pcm = unsafe { std::slice::from_raw_parts(pcm, pcm_length) };
     let wav = voicevox_core::wav_from_s16le(pcm, sampling_rate, is_stereo);
     // SAFETY: The safety contract must be upheld by the caller.
     unsafe { U8_SLICE_OWNER.own_and_lend(wav, output_wav, output_wav_length) };

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -2215,6 +2215,7 @@ pub unsafe extern "C" fn voicevox_json_free(json: *mut c_char) {
 ///     - ::voicevox_synthesizer_tts
 ///     - ::voicevox_synthesizer_tts_from_kana
 ///     - ::voicevox_synthesizer_frame_synthesis
+///     - ::voicevox_wav_from_s16le
 /// - `wav`がヌルポインタでも ::voicevox_empty_bytes でもないならば、<a href="#voicevox-core-safety">読み込みと書き込みについて有効</a>でなければならない。
 /// - `wav`がヌルポインタでも ::voicevox_empty_bytes でもないならば、以後<b>ダングリングポインタ</b>(_dangling pointer_)として扱われなくてはならない。
 /// }

--- a/crates/voicevox_core_c_api/src/slice_owner.rs
+++ b/crates/voicevox_core_c_api/src/slice_owner.rs
@@ -86,7 +86,7 @@ impl<T: SliceElement> SliceOwner<T> {
         let Some(ptr) = NonNull::new(ptr) else { return };
 
         if ptr == T::PTR_FOR_EMPTY {
-            warn!("`voicevox_empty_bytes`を解放することはできません");
+            warn!("`{}`を解放することはできません", T::EMPTY_SLICE_VAR_NAME);
             return;
         }
 
@@ -102,6 +102,7 @@ impl<T: SliceElement> SliceOwner<T> {
 }
 
 pub(crate) trait SliceElement: Sized + 'static {
+    const EMPTY_SLICE_VAR_NAME: &str;
     const REF_FOR_EMPTY: &'static MaybeUninit<Self>;
 
     const PTR_FOR_EMPTY: NonNull<Self> =
@@ -109,6 +110,7 @@ pub(crate) trait SliceElement: Sized + 'static {
 }
 
 impl SliceElement for u8 {
+    const EMPTY_SLICE_VAR_NAME: &str = "voicevox_empty_bytes";
     const REF_FOR_EMPTY: &'static MaybeUninit<Self> = {
         static DUMMY: MaybeUninit<u8> = MaybeUninit::uninit();
         &DUMMY

--- a/crates/voicevox_core_c_api/src/slice_owner.rs
+++ b/crates/voicevox_core_c_api/src/slice_owner.rs
@@ -1,4 +1,9 @@
-use std::{cell::UnsafeCell, collections::BTreeMap, num::NonZeroUsize, ptr::NonNull, sync::Mutex};
+use std::{
+    cell::UnsafeCell, collections::BTreeMap, mem::MaybeUninit, num::NonZeroUsize, ptr::NonNull,
+    sync::Mutex,
+};
+
+use tracing::warn;
 
 /// Cの世界に貸し出す`[u8]`の所有者(owner)。
 ///
@@ -16,17 +21,19 @@ use std::{cell::UnsafeCell, collections::BTreeMap, num::NonZeroUsize, ptr::NonNu
 pub(crate) static U8_SLICE_OWNER: SliceOwner<u8> = SliceOwner::new();
 
 pub(crate) struct SliceOwner<T> {
-    slices: Mutex<BTreeMap<NonZeroUsize, UnsafeCell<Box<[T]>>>>,
+    non_empty_slices: Mutex<BTreeMap<NonZeroUsize, UnsafeCell<Box<[T]>>>>,
 }
 
-impl<T> SliceOwner<T> {
+impl<T: SliceElement> SliceOwner<T> {
     const fn new() -> Self {
         Self {
-            slices: Mutex::new(BTreeMap::new()),
+            non_empty_slices: Mutex::new(BTreeMap::new()),
         }
     }
 
-    /// `Box<[T]>`を所有し、その先頭ポインタと長さを参照としてC API利用者に与える。
+    /// 与えられた`Box<[T]>`が空ではないならそれを所有し、その先頭ポインタと長さを参照としてC API利用者に与える。
+    ///
+    /// 空のときは[`SliceElement::REF_FOR_EMPTY`]を返す。
     ///
     /// # Safety
     ///
@@ -40,9 +47,17 @@ impl<T> SliceOwner<T> {
         out_ptr: NonNull<NonNull<T>>,
         out_len: NonNull<usize>,
     ) {
-        let mut slices = self.slices.lock().unwrap();
-
         let slice = slice.into();
+
+        if slice.is_empty() {
+            // SAFETY: The safety contract must be upheld by the caller.
+            unsafe { out_ptr.write_unaligned(T::PTR_FOR_EMPTY) };
+            unsafe { out_len.write_unaligned(0) };
+            return;
+        }
+
+        let mut slices = self.non_empty_slices.lock().unwrap();
+
         let ptr = NonNull::new(slice.as_ptr() as *mut T).expect("comes from a slice");
         let len = slice.len();
 
@@ -62,7 +77,7 @@ impl<T> SliceOwner<T> {
 
     /// `own_and_lend`でC API利用者に貸し出したポインタに対応する`Box<[u8]>`をデストラクトする。
     ///
-    /// ヌルポインタに対しては何もしない。
+    /// ヌルポインタに対しては何もしない。[`SliceElement::REF_FOR_EMPTY`]に対しては警告のみ出して何もしない。
     ///
     /// # Panics
     ///
@@ -70,11 +85,34 @@ impl<T> SliceOwner<T> {
     pub(crate) fn drop_for(&self, ptr: *mut T) {
         let Some(ptr) = NonNull::new(ptr) else { return };
 
-        self.slices.lock().unwrap().remove(&ptr.addr()).expect(
-            "解放しようとしたポインタはvoicevox_coreの管理下にありません。\
-             誤ったポインタであるか、二重解放になっていることが考えられます",
-        );
+        if ptr == T::PTR_FOR_EMPTY {
+            warn!("`voicevox_empty_bytes`を解放することはできません");
+            return;
+        }
+
+        self.non_empty_slices
+            .lock()
+            .unwrap()
+            .remove(&ptr.addr())
+            .expect(
+                "解放しようとしたポインタはvoicevox_coreの管理下にありません。\
+                 誤ったポインタであるか、二重解放になっていることが考えられます",
+            );
     }
+}
+
+pub(crate) trait SliceElement: Sized + 'static {
+    const REF_FOR_EMPTY: &'static MaybeUninit<Self>;
+
+    const PTR_FOR_EMPTY: NonNull<Self> =
+        NonNull::new(Self::REF_FOR_EMPTY.as_ptr() as *mut _).unwrap();
+}
+
+impl SliceElement for u8 {
+    const REF_FOR_EMPTY: &'static MaybeUninit<Self> = {
+        static DUMMY: MaybeUninit<u8> = MaybeUninit::uninit();
+        &DUMMY
+    };
 }
 
 #[cfg(test)]
@@ -84,23 +122,15 @@ mod tests {
         ptr::{self, NonNull},
     };
 
-    use super::SliceOwner;
+    use super::{SliceElement, SliceOwner};
 
     #[test]
     fn it_works() {
-        lend_and_delete(vec::<()>(0, &[]));
-        lend_and_delete(vec(0, &[()]));
-        lend_and_delete(vec(2, &[()]));
-
         lend_and_delete(vec::<u8>(0, &[]));
         lend_and_delete(vec(0, &[0u8]));
         lend_and_delete(vec(2, &[0u8]));
 
-        lend_and_delete(vec::<f32>(0, &[]));
-        lend_and_delete(vec(0, &[0f32]));
-        lend_and_delete(vec(2, &[0f32]));
-
-        fn lend_and_delete<T>(vec: Vec<T>) {
+        fn lend_and_delete<T: SliceElement>(vec: Vec<T>) {
             let owner = SliceOwner::<T>::new();
             let expected_len = vec.len();
             let (ptr, len) = unsafe {
@@ -126,8 +156,30 @@ mod tests {
 
     #[test]
     fn it_accepts_null() {
-        let owner = SliceOwner::<i32>::new();
+        let owner = SliceOwner::<u8>::new();
         owner.drop_for(ptr::null_mut());
+    }
+
+    #[test]
+    fn it_accepts_empty() {
+        let owner = SliceOwner::<u8>::new();
+
+        let (ptr, len) = unsafe {
+            let mut ptr = MaybeUninit::uninit();
+            let mut len = MaybeUninit::uninit();
+            owner.own_and_lend(
+                [],
+                NonNull::new(ptr.as_mut_ptr()).unwrap(),
+                NonNull::new(len.as_mut_ptr()).unwrap(),
+            );
+            (ptr.assume_init(), len.assume_init())
+        };
+
+        assert_eq!(0, len);
+
+        for _ in 0..2 {
+            owner.drop_for(ptr.as_ptr());
+        }
     }
 
     #[test]
@@ -135,7 +187,7 @@ mod tests {
         expected = "解放しようとしたポインタはvoicevox_coreの管理下にありません。誤ったポインタであるか、二重解放になっていることが考えられます"
     )]
     fn it_denies_unknown_ptr() {
-        let owner = SliceOwner::<i32>::new();
+        let owner = SliceOwner::<u8>::new();
         let mut x = 42;
         owner.drop_for(&raw mut x);
     }

--- a/crates/voicevox_core_c_api/tests/e2e/snapshots.toml
+++ b/crates/voicevox_core_c_api/tests/e2e/snapshots.toml
@@ -160,6 +160,17 @@ result_messages.33 = "無効なFrameAudioQueryです"
 result_messages.34 = "無効なFramePhonemeです"
 stderr = ''
 
+[render_empty]
+stderr.windows = '''
+{windows-video-cards}
+{timestamp}  INFO voicevox_core::synthesizer: CPUを利用します
+{timestamp}  WARN voicevox_core::slice_owner: `voicevox_empty_bytes`を解放することはできません
+'''
+stderr.unix = '''
+{timestamp}  INFO voicevox_core::synthesizer: CPUを利用します
+{timestamp}  WARN voicevox_core::slice_owner: `voicevox_empty_bytes`を解放することはできません
+'''
+
 [simple_tts]
 output."こんにちは、音声合成の世界へようこそ".wav_length = 176172
 stderr.windows = '''

--- a/crates/voicevox_core_c_api/tests/e2e/testcases.rs
+++ b/crates/voicevox_core_c_api/tests/e2e/testcases.rs
@@ -7,6 +7,7 @@ mod double_delete_voice_model_file;
 mod ensure_compatible;
 mod free_for_null;
 mod global_info;
+mod render_empty;
 mod simple_tts;
 mod song;
 mod streaming_talk;

--- a/crates/voicevox_core_c_api/tests/e2e/testcases/render_empty.rs
+++ b/crates/voicevox_core_c_api/tests/e2e/testcases/render_empty.rs
@@ -1,0 +1,279 @@
+use std::{
+    env,
+    ffi::{CStr, CString},
+    mem::MaybeUninit,
+    sync::LazyLock,
+};
+
+use assert_cmd::assert::AssertResult;
+use const_format::concatcp;
+use libloading::Library;
+use serde::{Deserialize, Serialize};
+use test_util::{
+    OPEN_JTALK_DIC_DIR,
+    c_api::{
+        self, CApi, VoicevoxInitializeOptions, VoicevoxLoadOnnxruntimeOptions, VoicevoxResultCode,
+    },
+};
+
+use crate::{
+    assert_cdylib::{self, Utf8Output, case},
+    snapshots,
+};
+
+case!(TestCase);
+
+#[derive(Serialize, Deserialize)]
+struct TestCase;
+
+#[typetag::serde(name = "render_empty")]
+impl assert_cdylib::TestCase for TestCase {
+    unsafe fn exec(&self, lib: Library) -> anyhow::Result<()> {
+        const TEXT: &CStr = c"こんにちは";
+
+        // SAFETY: The safety contract must be upheld by the caller.
+        let lib = unsafe { CApi::from_library(lib) }?;
+
+        let model = {
+            let mut model = MaybeUninit::uninit();
+            assert_ok(unsafe {
+                // SAFETY:
+                // - `SAMPLE_VOICE_MODEL_FILE_PATH` is a valid string.
+                // - `model` is valid for writes.
+                lib.voicevox_voice_model_file_open(
+                    c_api::SAMPLE_VOICE_MODEL_FILE_PATH.as_ptr(),
+                    model.as_mut_ptr(),
+                )
+            });
+            // SAFETY: `voicevox_voice_model_file_open` initializes `model` if succeeded.
+            unsafe { model.assume_init() }
+        };
+
+        let onnxruntime = {
+            let mut onnxruntime = MaybeUninit::uninit();
+            assert_ok(unsafe {
+                // SAFETY:
+                // - A `CStr` is a valid string.
+                // - `onnxruntime` is valid for writes.
+                lib.voicevox_onnxruntime_load_once(
+                    VoicevoxLoadOnnxruntimeOptions {
+                        filename: CStr::from_bytes_with_nul(
+                            concatcp!(
+                                env::consts::DLL_PREFIX,
+                                "onnxruntime",
+                                env::consts::DLL_SUFFIX,
+                                '\0'
+                            )
+                            .as_ref(),
+                        )
+                        .expect("this ends with nul")
+                        .as_ptr(),
+                    },
+                    onnxruntime.as_mut_ptr(),
+                )
+            });
+            // SAFETY: `voicevox_onnxruntime_load_once` initializes `onnxruntime` if succeeded.
+            unsafe { onnxruntime.assume_init() }
+        };
+
+        let openjtalk = {
+            let mut openjtalk = MaybeUninit::uninit();
+            let open_jtalk_dic_dir = CString::new(OPEN_JTALK_DIC_DIR).unwrap();
+            assert_ok(unsafe {
+                // SAFETY:
+                // - A `CString` is a valid string.
+                // - `openjtalk` is valid for writes.
+                lib.voicevox_open_jtalk_rc_new(open_jtalk_dic_dir.as_ptr(), openjtalk.as_mut_ptr())
+            });
+            // SAFETY: `voicevox_open_jtalk_rc_new` initializes `openjtalk` if succeeded.
+            unsafe { openjtalk.assume_init() }
+        };
+
+        let synthesizer = {
+            let mut synthesizer = MaybeUninit::uninit();
+            assert_ok(unsafe {
+                // SAFETY:
+                // - `onnxruntime` is valid for reads.
+                // - `synthesizer` is valid for writes.
+                lib.voicevox_synthesizer_new(
+                    onnxruntime,
+                    openjtalk,
+                    VoicevoxInitializeOptions {
+                        acceleration_mode:
+                            c_api::VoicevoxAccelerationMode_VOICEVOX_ACCELERATION_MODE_CPU,
+                        ..lib.voicevox_make_default_initialize_options()
+                    },
+                    synthesizer.as_mut_ptr(),
+                )
+            });
+            // SAFETY: `voicevox_synthesizer_new` initializes `synthesizer` if succeeded.
+            unsafe { synthesizer.assume_init() }
+        };
+
+        // SAFETY: `voicevox_synthesizer_load_voice_model` has no safety requirements.
+        assert_ok(unsafe {
+            lib.voicevox_synthesizer_load_voice_model(
+                synthesizer,
+                model,
+                lib.voicevox_make_default_load_voice_model_options(),
+            )
+        });
+
+        let accent_phrases = {
+            let mut accent_phrases = MaybeUninit::uninit();
+            assert_ok(unsafe {
+                // SAFETY:
+                // - `TEXT` is a valid string.
+                // - `accent_phrases` is valid for writes.
+                lib.voicevox_open_jtalk_rc_analyze(
+                    openjtalk,
+                    TEXT.as_ptr(),
+                    accent_phrases.as_mut_ptr(),
+                )
+            });
+            // SAFETY: `voicevox_open_jtalk_rc_analyze` initializes `accent_phrases` if
+            // succeeded.
+            unsafe { accent_phrases.assume_init() }
+        };
+        let accent_phrases = {
+            let mut next_accent_phrases = MaybeUninit::uninit();
+            assert_ok(unsafe {
+                // SAFETY:
+                // - `accent_phrases` is a valid string.
+                // - `next_accent_phrases` is valid for writes.
+                lib.voicevox_synthesizer_replace_phoneme_length(
+                    synthesizer,
+                    accent_phrases,
+                    STYLE_ID,
+                    next_accent_phrases.as_mut_ptr(),
+                )
+            });
+            // SAFETY: `accent_phrases` is valid and is no longer used.
+            unsafe { lib.voicevox_json_free(accent_phrases) };
+            // SAFETY: `voicevox_synthesizer_replace_phoneme_length` initializes
+            // `next_accent_phrases` if succeeded.
+            unsafe { next_accent_phrases.assume_init() }
+        };
+        let accent_phrases = {
+            let mut next_accent_phrases = MaybeUninit::uninit();
+            assert_ok(unsafe {
+                // SAFETY:
+                // - `accent_phrases` is a valid string.
+                // - `next_accent_phrases` is valid for writes.
+                lib.voicevox_synthesizer_replace_mora_pitch(
+                    synthesizer,
+                    accent_phrases,
+                    STYLE_ID,
+                    next_accent_phrases.as_mut_ptr(),
+                )
+            });
+            // SAFETY: `accent_phrases` is valid and is no longer used.
+            unsafe { lib.voicevox_json_free(accent_phrases) };
+            // SAFETY: `voicevox_synthesizer_replace_mora_pitch` initializes
+            // `next_accent_phrases` if succeeded.
+            unsafe { next_accent_phrases.assume_init() }
+        };
+        let audio_query = {
+            let mut audio_query = MaybeUninit::uninit();
+            assert_ok(unsafe {
+                // SAFETY:
+                // - `accent_phrases` is a valid string.
+                // - `next_accent_phrases` is valid for writes.
+                lib.voicevox_audio_query_create_from_accent_phrases(
+                    accent_phrases,
+                    audio_query.as_mut_ptr(),
+                )
+            });
+            // SAFETY: `voicevox_audio_query_create_from_accent_phrases` initializes
+            // `audio_query` if succeeded.
+            unsafe { audio_query.assume_init() }
+        };
+
+        let audio_feature = {
+            let mut audio_feature = MaybeUninit::uninit();
+            assert_ok(unsafe {
+                // SAFETY:
+                // - `audio_query` is a valid string.
+                // - `audio_feature` is valid for writes.
+                lib.voicevox_synthesizer_create_audio_feature(
+                    synthesizer,
+                    audio_query,
+                    STYLE_ID,
+                    lib.voicevox_make_default_synthesis_options(),
+                    audio_feature.as_mut_ptr(),
+                )
+            });
+            // SAFETY: `voicevox_synthesizer_create_audio_feature` initializes `audio_feature`
+            // if succeeded.
+            unsafe { audio_feature.assume_init() }
+        };
+
+        let (pcm_length, pcm) = {
+            // SAFETY: this function has no safety requirements.
+            let len = unsafe { lib.voicevox_audio_feature_frame_length(audio_feature) };
+
+            let mut pcm_length = MaybeUninit::uninit();
+            let mut pcm = MaybeUninit::uninit();
+            assert_ok(unsafe {
+                // SAFETY: `pcm_length` and `pcm` are valid for writes.
+                lib.voicevox_synthesizer_render(
+                    synthesizer,
+                    audio_feature,
+                    len / 2,
+                    len / 2,
+                    pcm_length.as_mut_ptr(),
+                    pcm.as_mut_ptr(),
+                )
+            });
+            // SAFETY: `voicevox_synthesizer_render` initializes `pcm_length` and `pcm` if
+            // succeeded.
+            unsafe { (pcm_length.assume_init(), pcm.assume_init()) }
+        };
+
+        assert_eq!(0, pcm_length);
+
+        // SAFETY: `voicevox_empty_bytes` is a immutable variable.
+        assert_eq!(unsafe { *lib.voicevox_empty_bytes() }, pcm);
+
+        // This should emit a warning.
+        // SAFETY: no longer used.
+        unsafe { lib.voicevox_wav_free(pcm) };
+
+        // SAFETY: they are valid and is no longer used.
+        unsafe { lib.voicevox_json_free(accent_phrases) };
+        unsafe { lib.voicevox_json_free(audio_query) };
+
+        // SAFETY: these functions have no safety requirements.
+        unsafe { lib.voicevox_voice_model_file_delete(model) };
+        unsafe { lib.voicevox_open_jtalk_rc_delete(openjtalk) };
+        unsafe { lib.voicevox_synthesizer_delete(synthesizer) };
+        unsafe { lib.voicevox_audio_feature_delete(audio_feature) };
+
+        return Ok(());
+
+        const STYLE_ID: u32 = 302;
+
+        fn assert_ok(result_code: VoicevoxResultCode) {
+            std::assert_eq!(c_api::VoicevoxResultCode_VOICEVOX_RESULT_OK, result_code);
+        }
+    }
+
+    fn assert_output(&self, output: Utf8Output) -> AssertResult {
+        output
+            .mask_timestamps()
+            .mask_unix_onnxruntime_filename()
+            .mask_windows_video_cards()
+            .assert()
+            .try_success()?
+            .try_stdout("")?
+            .try_stderr(&*SNAPSHOTS.stderr)
+    }
+}
+
+static SNAPSHOTS: LazyLock<Snapshots> = snapshots::section!(render_empty);
+
+#[derive(Deserialize)]
+struct Snapshots {
+    #[serde(deserialize_with = "snapshots::deserialize_platform_specific_snapshot")]
+    stderr: String,
+}


### PR DESCRIPTION
## 内容

`render`が空のPCMを返す場合と、`wav_from_s16le`に空のPCMが渡される場合に対応する。

AudioQueryが拡張されて非ストリーミングの`synthesis`がWAVだけでなくPCMを返しうる、という可能性を考えてAudioQueryの拡張がC APIの破壊的にならないように「空のPCM」の解放は警告止まりとした。

## 関連 Issue

cf. #1364
