### PR TITLE
fix: 「`render`に空の範囲を渡したときの推論スキップ」を直す

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### Added
 
-- \[Rust,C,Python\] `Synthesizer::create_audio_feature`と`Synthesizer::render`が追加されます ([#851], [#854], [#864], [#867], [#879], [#918], [#972], [#1319], [#1363], [#1371], [#1376], [#1400], [#1401], [#1419], [#1418], [#1420], [#1421], [#1423], [#1422], [#1426], [#1430], [#1431])。
+- \[Rust,C,Python\] `Synthesizer::create_audio_feature`と`Synthesizer::render`が追加されます ([#851], [#854], [#864], [#867], [#879], [#918], [#972], [#1319], [#1363], [#1371], [#1376], [#1400], [#1401], [#1419], [#1418], [#1420], [#1421], [#1423], [#1422], [#1426], [#1430], [#1431], [#1436])。
 
 ### Fixed
 
@@ -1560,6 +1560,7 @@ Windows版ダウンローダーのビルドに失敗しています。
 [#1429]: https://github.com/VOICEVOX/voicevox_core/pull/1429
 [#1430]: https://github.com/VOICEVOX/voicevox_core/pull/1430
 [#1431]: https://github.com/VOICEVOX/voicevox_core/pull/1431
+[#1436]: https://github.com/VOICEVOX/voicevox_core/pull/1436
 
 [VOICEVOX/onnxruntime-builder#25]: https://github.com/VOICEVOX/onnxruntime-builder/pull/25
 

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -480,12 +480,16 @@ trait AsInner {
 
     async fn render(&self, audio: &AudioFeature, range: std::ops::Range<usize>) -> Result<Vec<u8>> {
         // TODO: 44.1kHzなどの対応
-        if range.is_empty() {
-            // FIXME: `start>end`に対してパニックせずに正常に空を返してしまうのでは？
-            // 指定区間が空のときは早期リターン
+        let spec_segment = crop_with_margin(audio, range.clone());
+        if spec_segment.nrows() == 2 * MARGIN {
+            // このまま推論しても問題ないが、実行時間短縮のため推論をスキップする。
+
+            assert!(range.is_empty());
+            // 一貫性の観点から、推論を行わない場合でも`StyleNotFound`エラーが出るようにする。
+            self.status()
+                .ids_for::<StreamingTalkDomain>(audio.style_id)?;
             return Ok(vec![]);
         }
-        let spec_segment = crop_with_margin(audio, range);
         let wave_with_margin = self
             .render_audio_segment(spec_segment.to_owned(), audio.style_id)
             .await?;


### PR DESCRIPTION
## 内容

FIXMEで書いていた`start > end`の場合に加え、以下の２つも弾くようにする。

- `frame_length < start`の場合
- 対象の`style_id`がunloadされていた場合（本来なら`StyleNotFound`として拒否されるべき）

## 関連 Issue

cf. #1364
