### PR TITLE
fix: `render`の「空の範囲に対する推論スキップ」をやめる

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### Added
 
-- \[Rust,C,Python\] `Synthesizer::create_audio_feature`と`Synthesizer::render`が追加されます ([#851], [#854], [#864], [#867], [#879], [#918], [#972], [#1319], [#1363], [#1371], [#1376], [#1400], [#1401], [#1419], [#1418], [#1420], [#1421], [#1423], [#1422], [#1426], [#1430], [#1431])。
+- \[Rust,C,Python\] `Synthesizer::create_audio_feature`と`Synthesizer::render`が追加されます ([#851], [#854], [#864], [#867], [#879], [#918], [#972], [#1319], [#1363], [#1371], [#1376], [#1400], [#1401], [#1419], [#1418], [#1420], [#1421], [#1423], [#1422], [#1426], [#1430], [#1431], [#1437])。
 
 ### Fixed
 
@@ -1560,6 +1560,7 @@ Windows版ダウンローダーのビルドに失敗しています。
 [#1429]: https://github.com/VOICEVOX/voicevox_core/pull/1429
 [#1430]: https://github.com/VOICEVOX/voicevox_core/pull/1430
 [#1431]: https://github.com/VOICEVOX/voicevox_core/pull/1431
+[#1437]: https://github.com/VOICEVOX/voicevox_core/pull/1437
 
 [VOICEVOX/onnxruntime-builder#25]: https://github.com/VOICEVOX/onnxruntime-builder/pull/25
 

--- a/crates/voicevox_core/src/synthesizer.rs
+++ b/crates/voicevox_core/src/synthesizer.rs
@@ -480,11 +480,6 @@ trait AsInner {
 
     async fn render(&self, audio: &AudioFeature, range: std::ops::Range<usize>) -> Result<Vec<u8>> {
         // TODO: 44.1kHzなどの対応
-        if range.is_empty() {
-            // FIXME: `start>end`に対してパニックせずに正常に空を返してしまうのでは？
-            // 指定区間が空のときは早期リターン
-            return Ok(vec![]);
-        }
         let spec_segment = crop_with_margin(audio, range);
         let wave_with_margin = self
             .render_audio_segment(spec_segment.to_owned(), audio.style_id)


### PR DESCRIPTION
## 内容

`render`には引数の`range`に対し`range.is_empty()`なら推論をスキップして`[]`を返すという機構があった。しかしこの機構は不十分であり、以下の場合に対する考慮がされていなかった。

- `start > end`の場合（パニックするべき）
- `frame_length < start`の場合（〃）
- 対象の`style_id`がunloadされていた場合（`StyleNotFound`として拒否するべき）

直すという選択肢もあるが、ソングのときと異なりわざわざ手間をかけて推論をスキップする理由もないはずなのでこの機構を消してしまう。
(経緯: https://github.com/VOICEVOX/voicevox_core/pull/1436#discussion_r3971342262)

Closes: #1436
