### PR TITLE
fix: `MACOSX_DEPLOYMENT_TARGET`を設定する

### DIFF
--- a/.github/workflows/build-downloader.yml
+++ b/.github/workflows/build-downloader.yml
@@ -100,6 +100,10 @@ jobs:
       - name: Set version
         run: cargo set-version ${{ needs.config.outputs.version }} --exclude voicevox_core_python_api --exclude xtask
 
+      - name: set MACOSX_DEPLOYMENT_TARGET
+        if: endsWith(matrix.target, '-apple-darwin')
+        run: rustc --target=${{ matrix.target }} --print=deployment-target >> "$GITHUB_ENV"
+
       - name: Build downloader
         run: cargo build -v --release -p downloader --target ${{ matrix.target }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -291,6 +291,9 @@ jobs:
           fi
       - name: cache target
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: set MACOSX_DEPLOYMENT_TARGET
+        if: endsWith(matrix.target, '-apple-darwin')
+        run: rustc --target=${{ matrix.target }} --print=deployment-target >> "$GITHUB_ENV"
       - name: build voicevox_core_c_api
         shell: bash
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Fixed
 
+- \[macOS\] ダウンローダーを含め、リリースされるバイナリがビルドされるときに`MACOSX_DEPLOYMENT_TARGET`が適切に設定されるようになります。従来は一部の依存ライブラリだけ`xcrun --show-sdk-version`の値でビルドされてしまっていたため、古いmacOSでダウンローダーや`OpenJtalk`が動かない可能性がありました ([#1438])。
 - \[Python\] `VoiceModelFile.open`が送出する`InvalidModelFormatError`が、`voicevox_core`モジュールにて適切に公開されます ([#1429])。
 
 ## [0.17.0] - 2026-08-14 (+09:00)
@@ -1562,6 +1563,7 @@ Windows版ダウンローダーのビルドに失敗しています。
 [#1431]: https://github.com/VOICEVOX/voicevox_core/pull/1431
 [#1432]: https://github.com/VOICEVOX/voicevox_core/pull/1432
 [#1437]: https://github.com/VOICEVOX/voicevox_core/pull/1437
+[#1438]: https://github.com/VOICEVOX/voicevox_core/pull/1438
 
 [VOICEVOX/onnxruntime-builder#25]: https://github.com/VOICEVOX/onnxruntime-builder/pull/25
 


### PR DESCRIPTION
## 内容

Rustはデフォルトではrustcに埋め込まれたバージョンをターゲットにビルドします。
https://doc.rust-lang.org/rustc/platform-support/apple-darwin.html#os-version
しかし、依存するC/C++ライブラリのビルドはrustcとは無関係に行われます。
そのため`MACOSX_DEPLOYMENT_TARGET`が未設定の場合、依存ライブラリのターゲットがビルド時に使用したSDKのバージョンになってしまい古いmacOSでは動作しない可能性があります。

少なくともopen_jtalk-rsがこの影響を受けています。

このPRでは`MACOSX_DEPLOYMENT_TARGET`を明示的に設定することで依存ライブラリが古いmacOSでも動作するようにビルドされるようにします。

## 関連 Issue

ref VOICEVOX/voicevox_project#90

## その他

`MACOSX_DEPLOYMENT_TARGET`の値はとりあえずrustcのデフォルトに設定しています。
ただ、voicevox-onnxruntimeのターゲットが`13.3`なのでそこまで上げてしまってもいいかも?

念のためダウンローダーのビルドの方にも設定をしておきました。